### PR TITLE
Organize dataclasses into dedicated types package

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,1 @@
+"""Atropos server package."""

--- a/server/helpers/audio.py
+++ b/server/helpers/audio.py
@@ -1,8 +1,8 @@
 import os
 from typing import Optional
 
-from helpers.formatting import Fore, Style
-from steps.download import download_audio, extract_audio_from_video
+from .formatting import Fore, Style
+from server.steps.download import download_audio, extract_audio_from_video
 
 
 def ensure_audio(yt_url: str, audio_out: str, video_out: Optional[str] = None) -> bool:

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -1,12 +1,12 @@
-from steps.transcribe import transcribe_audio
-from steps.download import download_transcript, download_video, get_video_info
+from server.steps.transcribe import transcribe_audio
+from server.steps.download import download_transcript, download_video, get_video_info
 
 import os
 import sys
 
-from helpers.audio import ensure_audio
-from helpers.transcript import write_transcript_txt
-from helpers.formatting import Fore, Style, sanitize_filename
+from server.helpers.audio import ensure_audio
+from server.helpers.transcript import write_transcript_txt
+from server.helpers.formatting import Fore, Style, sanitize_filename
 
 
 if __name__ == "__main__":

--- a/server/steps/candidates.py
+++ b/server/steps/candidates.py
@@ -14,29 +14,13 @@ def _to_float(val):
         return float(val)
     except Exception:
         return None
-from dataclasses import dataclass
 from typing import List, Optional, Tuple
 import json
 import re
 from pathlib import Path
 
-from helpers.ai import ollama_call_json, retry
-
-# -----------------------------
-# Data structures
-# -----------------------------
-
-
-@dataclass
-class ClipCandidate:
-    start: float
-    end: float
-    rating: float
-    reason: str
-    quote: str
-
-    def duration(self) -> float:
-        return max(0.0, self.end - self.start)
+from server.helpers.ai import ollama_call_json, retry
+from server.types.clip_candidate import ClipCandidate
 
 # -----------------------------
 # Manifest utils (export/import candidates)

--- a/server/steps/cut.py
+++ b/server/steps/cut.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from .candidates import ClipCandidate
+from server.types.clip_candidate import ClipCandidate
 
 
 def save_clip(

--- a/server/steps/render.py
+++ b/server/steps/render.py
@@ -6,7 +6,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from .candidates import ClipCandidate
+from server.types.clip_candidate import ClipCandidate
 from .subtitle import (
     _escape_for_drawtext,
     _escape_for_subtitles_filter,

--- a/server/steps/transcribe.py
+++ b/server/steps/transcribe.py
@@ -1,6 +1,6 @@
 from faster_whisper import WhisperModel
 
-from helpers.timing import Timer
+from server.types.timer import Timer
 
 
 def transcribe_audio(file_path, model_size="medium"):

--- a/server/types/__init__.py
+++ b/server/types/__init__.py
@@ -1,0 +1,6 @@
+"""Type definitions for the Atropos server."""
+
+from .clip_candidate import ClipCandidate
+from .timer import Timer
+
+__all__ = ["ClipCandidate", "Timer"]

--- a/server/types/clip_candidate.py
+++ b/server/types/clip_candidate.py
@@ -1,0 +1,15 @@
+"""Dataclass representing a clip candidate segment."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ClipCandidate:
+    start: float
+    end: float
+    rating: float
+    reason: str
+    quote: str
+
+    def duration(self) -> float:
+        return max(0.0, self.end - self.start)

--- a/server/types/timer.py
+++ b/server/types/timer.py
@@ -1,3 +1,5 @@
+"""Simple timing context manager dataclass."""
+
 import time
 from dataclasses import dataclass
 
@@ -17,5 +19,3 @@ class Timer:
     @property
     def elapsed(self) -> float:
         return self.stop_time - self.start_time
-
-__all__ = ["Timer"]


### PR DESCRIPTION
## Summary
- Introduce `server.types` package with standalone `ClipCandidate` and `Timer` dataclasses.
- Update pipeline, helpers, and steps modules to import types and other modules via fully-qualified package paths.
- Remove obsolete `helpers.timing` module.

## Testing
- `python -m py_compile server/types/clip_candidate.py server/types/timer.py server/steps/transcribe.py server/steps/candidates.py server/steps/cut.py server/steps/render.py server/helpers/audio.py server/pipeline.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc6a10a6c8323a63a2cde0c42f714