### PR TITLE
feat: highlight step timing and total runtime

### DIFF
--- a/server/helpers/logging.py
+++ b/server/helpers/logging.py
@@ -31,12 +31,14 @@ def run_step(name: str, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     except Exception as exc:
         elapsed = time.perf_counter() - start
         print(
-            f"{Fore.RED}{name} failed after {elapsed:.2f}s: {exc}{Style.RESET_ALL}"
+            f"{Fore.RED}  ↳ failed after {Fore.MAGENTA}{elapsed:.2f}s{Fore.RED}: {exc}{Style.RESET_ALL}"
         )
         raise
     else:
         elapsed = time.perf_counter() - start
-        print(f"{Fore.GREEN}{name} completed in {elapsed:.2f}s{Style.RESET_ALL}")
+        print(
+            f"{Fore.GREEN}  ↳ completed in {Fore.MAGENTA}{elapsed:.2f}s{Style.RESET_ALL}"
+        )
         return result
 
 
@@ -50,9 +52,11 @@ def log_timing(name: str) -> Generator[None, None, None]:
     except Exception as exc:
         elapsed = time.perf_counter() - start
         print(
-            f"{Fore.RED}{name} failed after {elapsed:.2f}s: {exc}{Style.RESET_ALL}"
+            f"{Fore.RED}  ↳ failed after {Fore.MAGENTA}{elapsed:.2f}s{Fore.RED}: {exc}{Style.RESET_ALL}"
         )
         raise
     else:
         elapsed = time.perf_counter() - start
-        print(f"{Fore.GREEN}{name} completed in {elapsed:.2f}s{Style.RESET_ALL}")
+        print(
+            f"{Fore.GREEN}  ↳ completed in {Fore.MAGENTA}{elapsed:.2f}s{Style.RESET_ALL}"
+        )

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -12,6 +12,7 @@ from steps.subtitle import build_srt_for_range
 from steps.render import render_vertical_with_captions_moviepy
 
 import sys
+import time
 from pathlib import Path
 
 from helpers.audio import ensure_audio
@@ -22,6 +23,8 @@ from interfaces.clip_candidate import ClipCandidate
 
 
 if __name__ == "__main__":
+    overall_start = time.perf_counter()
+
     yt_url = 'https://www.youtube.com/watch?v=GDbDRWzFfds'
     # yt_url = input("Enter YouTube video URL: ")
     video_info = get_video_info(yt_url)
@@ -196,4 +199,9 @@ if __name__ == "__main__":
 
     run_step(
         f"STEP 7: Rendering vertical video -> {vertical_output}", step_render
+    )
+
+    total_elapsed = time.perf_counter() - overall_start
+    print(
+        f"{Fore.MAGENTA}Full pipeline completed in {total_elapsed:.2f}s{Style.RESET_ALL}"
     )


### PR DESCRIPTION
## Summary
- show step durations on their own line in pipeline logs
- report full runtime after all steps complete

## Testing
- `pytest`
- `python - <<'PY' from server.helpers.logging import run_step; run_step('Test step', lambda: None)`

------
https://chatgpt.com/codex/tasks/task_e_68ad19297ed88323b1f41f51c70cadbe