### PR TITLE
Compute clip duration internally for ffmpeg cuts

### DIFF
--- a/server/steps/cut.py
+++ b/server/steps/cut.py
@@ -45,6 +45,8 @@ def save_clip(
         print("FFMPEG: invalid range (end <= start)")
         return False
 
+    duration = end - start
+
     # Build ffmpeg command
     # Use -ss before -i for fast seek; for reencode we also put -ss after -i for accuracy.
     base = [
@@ -56,7 +58,7 @@ def save_clip(
 
     if reencode:
         base += [
-            "-to", f"{end:.3f}",
+            "-t", f"{duration:.3f}",
             "-c:v", "libx264",
             "-preset", "veryfast",
             "-crf", "18",
@@ -64,9 +66,9 @@ def save_clip(
             "-movflags", "+faststart",
         ]
     else:
-        # stream copy; some containers ignore -to unless after -i, but this works for mp4 typically
+        # stream copy; some containers ignore -t unless after -i, but this works for mp4 typically
         base += [
-            "-to", f"{end:.3f}",
+            "-t", f"{duration:.3f}",
             "-c", "copy",
             "-movflags", "+faststart",
         ]

--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+from server.steps.cut import save_clip
+
+
+def test_cut_duration_respects_start(tmp_path: Path) -> None:
+    """Clips starting mid-video should have the expected length."""
+
+    source = tmp_path / "src.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=16x16",
+            "-t",
+            "5",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(source),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    clip = tmp_path / "clip.mp4"
+    assert save_clip(source, clip, start=1.0, end=3.0, reencode=True)
+
+    probe = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(clip),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    duration = float(probe.stdout.decode().strip())
+    assert 1.9 <= duration <= 2.1
+


### PR DESCRIPTION
## Summary
- derive clip duration from end-start before building ffmpeg command
- use ffmpeg `-t` with derived duration for accurate clip length
- add unit test confirming clip starting mid-video matches expected duration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae3335447c8323a2be6ad712f14b66