### PR TITLE
Add word timings and silence detection for refined clips

### DIFF
--- a/server/steps/silence.py
+++ b/server/steps/silence.py
@@ -1,0 +1,37 @@
+import subprocess
+from pathlib import Path
+from typing import List, Tuple
+
+from .candidates.helpers import parse_ffmpeg_silences
+
+
+def detect_silences(audio_path: str | Path,
+                    *,
+                    noise_level: str = "-30dB",
+                    min_silence: float = 0.3) -> List[Tuple[float, float]]:
+    """Run ffmpeg's silencedetect filter and return silence ranges.
+
+    Parameters
+    ----------
+    audio_path: str | Path
+        Path to the input audio file.
+    noise_level: str
+        Threshold passed to ffmpeg's silencedetect noise parameter.
+    min_silence: float
+        Minimum duration in seconds to qualify as silence.
+    """
+    cmd = [
+        "ffmpeg",
+        "-i",
+        str(audio_path),
+        "-af",
+        f"silencedetect=noise={noise_level}:d={min_silence}",
+        "-f",
+        "null",
+        "-",
+    ]
+    proc = subprocess.run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, text=True
+    )
+    log = proc.stderr
+    return parse_ffmpeg_silences(log)

--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -8,7 +8,8 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "server"))
 
-from server.steps.cut import save_clip
+from server.steps.cut import save_clip, save_clip_from_candidate
+from server.interfaces.clip_candidate import ClipCandidate
 
 
 def test_cut_duration_respects_start(tmp_path: Path) -> None:
@@ -56,4 +57,70 @@ def test_cut_duration_respects_start(tmp_path: Path) -> None:
     )
     duration = float(probe.stdout.decode().strip())
     assert 1.9 <= duration <= 2.1
+
+
+def test_clip_snaps_to_word_boundaries(tmp_path: Path) -> None:
+    """save_clip_from_candidate should honour provided word timings."""
+
+    source = tmp_path / "src.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=16x16",
+            "-t",
+            "5",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(source),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    transcript = tmp_path / "tx.txt"
+    transcript.write_text("[0.00 -> 5.00] hello world\n", encoding="utf-8")
+
+    cand = ClipCandidate(start=1.2, end=2.3, rating=9.0, reason="", quote="")
+    words = [
+        {"start": 1.0, "end": 1.5, "text": "hello"},
+        {"start": 2.0, "end": 2.5, "text": "world"},
+    ]
+    silences = [(0.0, 0.75), (2.95, 5.0)]
+
+    out = save_clip_from_candidate(
+        source,
+        tmp_path,
+        cand,
+        transcript_path=transcript,
+        words=words,
+        silences=silences,
+        reencode=True,
+    )
+    assert out is not None
+    assert "1.00-2.50" in out.name
+
+    probe = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(out),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    duration = float(probe.stdout.decode().strip())
+    assert 1.45 <= duration <= 1.55
 


### PR DESCRIPTION
## Summary
- Capture word-level timing in transcription results
- Detect silences via ffmpeg and feed both words and silences through the pipeline
- Refine clip cutting using word and silence boundaries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae63695ce08323a9aeb9b86572a688