### PR TITLE
filter music-only transcript segments

### DIFF
--- a/server/steps/candidates/__init__.py
+++ b/server/steps/candidates/__init__.py
@@ -10,6 +10,7 @@ from .helpers import (
     _get_field,
     _to_float,
     parse_transcript,
+    has_spoken_words,
     _merge_adjacent_candidates,
     _enforce_non_overlap,
 )
@@ -121,6 +122,8 @@ def find_clip_timestamps_batched(
             if not (min_ts <= start < end <= max_ts):
                 continue
             if rating < min_rating:
+                continue
+            if not has_spoken_words(start, end, items):
                 continue
             all_candidates.append(
                 ClipCandidate(

--- a/server/steps/candidates/helpers.py
+++ b/server/steps/candidates/helpers.py
@@ -96,6 +96,27 @@ def parse_transcript(transcript_path: str | Path) -> List[Tuple[float, float, st
     return items
 
 
+def has_spoken_words(
+    start: float, end: float, items: List[Tuple[float, float, str]]
+) -> bool:
+    """Return True if any overlapping transcript line contains alphabetic characters.
+
+    Lines that consist solely of bracketed markers like ``[music]`` are ignored.
+    """
+    for s, e, text in items:
+        if e <= start or s >= end:
+            continue
+        t = text.strip()
+        if not t:
+            continue
+        # Exclude bracketed markers such as "[music]".
+        if re.fullmatch(r"\[[^\]]+\]", t.lower()):
+            continue
+        if re.search(r"[a-zA-Z]", t):
+            return True
+    return False
+
+
 # -----------------------------
 # Silence/VAD utilities (FFmpeg silencedetect logs)
 # -----------------------------
@@ -357,6 +378,7 @@ __all__ = [
     "export_candidates_json",
     "load_candidates_json",
     "parse_transcript",
+    "has_spoken_words",
     "parse_ffmpeg_silences",
     "snap_to_silence",
     "snap_to_word_boundaries",

--- a/server/steps/candidates/prompts.py
+++ b/server/steps/candidates/prompts.py
@@ -33,6 +33,7 @@ def _build_system_instructions(prompt_desc: str, min_rating: float) -> str:
         "NEGATIVE FILTERS (exclude these):\n"
         "- Filler, bland agreement, mere exposition, or housekeeping.\n"
         "- Partial thoughts that cut off before the key beat/payoff.\n"
+        "- Segments with no spoken words (e.g., intros/outros, music-only).\n"
         "SCORING GUIDE:\n"
         "9–10: extremely aligned, highly engaging, shareable.\n"
         "8: clearly strong, likely to resonate with most viewers.\n"

--- a/tests/test_spoken_words.py
+++ b/tests/test_spoken_words.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+from server.steps.candidates import find_clip_timestamps_batched
+from server.steps.candidates.helpers import has_spoken_words, parse_transcript
+
+
+def test_has_spoken_words_filters_music_line(tmp_path: Path) -> None:
+    transcript = """
+[0.00 -> 5.00] [music]
+[5.00 -> 10.00] hello there
+""".strip()
+    p = tmp_path / "tx.txt"
+    p.write_text(transcript, encoding="utf-8")
+    items = parse_transcript(p)
+    assert not has_spoken_words(0.0, 4.0, items)
+    assert has_spoken_words(5.0, 6.0, items)
+
+
+def test_batched_skip_music_only(tmp_path: Path, monkeypatch) -> None:
+    transcript = """
+[0.00 -> 5.00] [music]
+[5.00 -> 10.00] hello there
+""".strip()
+    p = tmp_path / "tx.txt"
+    p.write_text(transcript, encoding="utf-8")
+
+    def fake_call_json(**kwargs):
+        return [
+            {"start": 0.0, "end": 4.0, "rating": 8.0, "reason": "", "quote": ""},
+            {"start": 5.0, "end": 6.0, "rating": 8.0, "reason": "", "quote": "hi"},
+        ]
+
+    monkeypatch.setattr(
+        "server.steps.candidates.ollama_call_json", fake_call_json
+    )
+
+    cands = find_clip_timestamps_batched(p)
+    assert len(cands) == 1
+    assert cands[0].quote == "hi"


### PR DESCRIPTION
## Summary
- add `has_spoken_words` helper to detect real speech and ignore markers like `[music]`
- skip LLM candidates lacking spoken words and update system instructions
- cover music-only transcripts with regression tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae64f4ae248323a798ef14f7ded022