### PR TITLE
Add tone verification and configurable word counts

### DIFF
--- a/server/steps/candidates/educational.py
+++ b/server/steps/candidates/educational.py
@@ -10,22 +10,30 @@ from .prompts import EDUCATIONAL_PROMPT_DESC
 def find_educational_timestamps_batched(
     transcript_path: str | Path,
     *,
+    min_word_count: int = 8,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find educational clip candidates using batched processing."""
     return find_clip_timestamps_batched(
-        transcript_path, prompt_desc=EDUCATIONAL_PROMPT_DESC, **kwargs
+        transcript_path,
+        prompt_desc=EDUCATIONAL_PROMPT_DESC,
+        min_word_count=min_word_count,
+        **kwargs,
     )
 
 
 def find_educational_timestamps(
     transcript_path: str | Path,
     *,
+    min_word_count: int = 8,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find educational clip candidates."""
     return find_clip_timestamps(
-        transcript_path, prompt_desc=EDUCATIONAL_PROMPT_DESC, **kwargs
+        transcript_path,
+        prompt_desc=EDUCATIONAL_PROMPT_DESC,
+        min_word_count=min_word_count,
+        **kwargs,
     )
 
 

--- a/server/steps/candidates/funny.py
+++ b/server/steps/candidates/funny.py
@@ -11,11 +11,16 @@ def find_funny_timestamps_batched(
     transcript_path: str | Path,
     *,
     min_rating: float = 8.0,
+    min_word_count: int = 5,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find humorous clip candidates using batched processing."""
     return find_clip_timestamps_batched(
-        transcript_path, prompt_desc=FUNNY_PROMPT_DESC, min_rating=min_rating, **kwargs
+        transcript_path,
+        prompt_desc=FUNNY_PROMPT_DESC,
+        min_rating=min_rating,
+        min_word_count=min_word_count,
+        **kwargs,
     )
 
 
@@ -23,11 +28,16 @@ def find_funny_timestamps(
     transcript_path: str | Path,
     *,
     min_rating: float = 8.0,
+    min_word_count: int = 5,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find humorous clip candidates."""
     return find_clip_timestamps(
-        transcript_path, prompt_desc=FUNNY_PROMPT_DESC, min_rating=min_rating, **kwargs
+        transcript_path,
+        prompt_desc=FUNNY_PROMPT_DESC,
+        min_rating=min_rating,
+        min_word_count=min_word_count,
+        **kwargs,
     )
 
 

--- a/server/steps/candidates/helpers.py
+++ b/server/steps/candidates/helpers.py
@@ -117,6 +117,16 @@ def has_spoken_words(
     return False
 
 
+def count_words(start: float, end: float, items: List[Tuple[float, float, str]]) -> int:
+    """Return the number of word tokens overlapping the [start, end] window."""
+    total = 0
+    for s, e, text in items:
+        if e <= start or s >= end:
+            continue
+        total += len(re.findall(r"\b\w+\b", text))
+    return total
+
+
 # -----------------------------
 # Silence/VAD utilities (FFmpeg silencedetect logs)
 # -----------------------------

--- a/server/steps/candidates/inspiring.py
+++ b/server/steps/candidates/inspiring.py
@@ -10,22 +10,30 @@ from .prompts import INSPIRING_PROMPT_DESC
 def find_inspiring_timestamps_batched(
     transcript_path: str | Path,
     *,
+    min_word_count: int = 8,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find inspiring clip candidates using batched processing."""
     return find_clip_timestamps_batched(
-        transcript_path, prompt_desc=INSPIRING_PROMPT_DESC, **kwargs
+        transcript_path,
+        prompt_desc=INSPIRING_PROMPT_DESC,
+        min_word_count=min_word_count,
+        **kwargs,
     )
 
 
 def find_inspiring_timestamps(
     transcript_path: str | Path,
     *,
+    min_word_count: int = 8,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find inspiring clip candidates."""
     return find_clip_timestamps(
-        transcript_path, prompt_desc=INSPIRING_PROMPT_DESC, **kwargs
+        transcript_path,
+        prompt_desc=INSPIRING_PROMPT_DESC,
+        min_word_count=min_word_count,
+        **kwargs,
     )
 
 

--- a/server/steps/candidates/prompts.py
+++ b/server/steps/candidates/prompts.py
@@ -3,18 +3,21 @@ from __future__ import annotations
 FUNNY_PROMPT_DESC = (
     "genuinely funny, laugh-inducing moments. Focus on bits that have a clear setup and a punchline, "
     "or a sharp twist/surprise. Prioritize incongruity, exaggeration, taboo/embarrassment (PG–R), "
-    "playful insults/roasts, callbacks, misdirection, and deadpan contradictions. Avoid bland banter, "
-    "filler agreement, or mere information."
+    "playful insults/roasts, callbacks, misdirection, and deadpan contradictions. Do NOT include "
+    "dry narration, polite small talk, generic compliments, or clips where someone merely says "
+    "'that's funny' without delivering a joke."
 )
 
 INSPIRING_PROMPT_DESC = (
     "uplifting or motivational moments that stir positive emotion, showcase overcoming "
-    "challenges, or deliver heartfelt advice."
+    "challenges, or deliver heartfelt advice. Avoid hollow platitudes, self-promotion, "
+    "sarcasm, or bleak/nihilistic comments."
 )
 
 EDUCATIONAL_PROMPT_DESC = (
     "informative, insightful, or instructional moments that clearly teach a concept or "
-    "share useful facts."
+    "share useful facts. Exclude vague speculation, unsupported opinions, "
+    "advertisements, or trivial asides that provide no real learning."
 )
 
 
@@ -25,7 +28,7 @@ def _build_system_instructions(prompt_desc: str, min_rating: float) -> str:
         '{"start": number, "end": number, "rating": 1-10 number, '
         '"reason": string, "quote": string, "tags": string[]}\n'
         f"Include ONLY items with rating >= {min_rating}.\n"
-        "RUBRIC (all must be true for inclusion):\n"
+        "RUBRIC (all must be clearly satisfied; borderline clips must be excluded):\n"
         "- Relevance: The moment strongly reflects the target described above.\n"
         "- Coherence: It forms a self-contained beat; the audience will understand without extra context.\n"
         "- Clipability: It is engaging and quotable; likely to grab attention in a short clip.\n"
@@ -34,6 +37,7 @@ def _build_system_instructions(prompt_desc: str, min_rating: float) -> str:
         "- Filler, bland agreement, mere exposition, or housekeeping.\n"
         "- Partial thoughts that cut off before the key beat/payoff.\n"
         "- Segments with no spoken words (e.g., intros/outros, music-only).\n"
+        "- Moments that do not unmistakably match the requested tone.\n"
         "SCORING GUIDE:\n"
         "9–10: extremely aligned, highly engaging, shareable.\n"
         "8: clearly strong, likely to resonate with most viewers.\n"

--- a/tests/test_funny_filter.py
+++ b/tests/test_funny_filter.py
@@ -1,0 +1,21 @@
+from server.steps.candidates.funny import find_funny_timestamps
+
+
+def test_funny_rejects_nonfunny(monkeypatch, tmp_path):
+    transcript = tmp_path / "t.txt"
+    transcript.write_text(
+        "[0.00 -> 3.00] This is a serious statement about finances.\n",
+        encoding="utf-8",
+    )
+
+    def fake_ollama_call_json(*, model, prompt, options=None, timeout=120):
+        if "TRANSCRIPT" in prompt:
+            return [{"start": 0.0, "end": 3.0, "rating": 9, "reason": "", "quote": ""}]
+        return [{"match": False}]
+
+    monkeypatch.setattr(
+        "server.steps.candidates.ollama_call_json", fake_ollama_call_json
+    )
+
+    results = find_funny_timestamps(transcript, min_rating=8.0, min_word_count=1)
+    assert results == []

--- a/tests/test_spoken_words.py
+++ b/tests/test_spoken_words.py
@@ -32,10 +32,13 @@ def test_batched_skip_music_only(tmp_path: Path, monkeypatch) -> None:
     p.write_text(transcript, encoding="utf-8")
 
     def fake_call_json(**kwargs):
-        return [
-            {"start": 0.0, "end": 4.0, "rating": 8.0, "reason": "", "quote": ""},
-            {"start": 5.0, "end": 6.0, "rating": 8.0, "reason": "", "quote": "hi"},
-        ]
+        prompt = kwargs.get("prompt", "")
+        if "TRANSCRIPT" in prompt:
+            return [
+                {"start": 0.0, "end": 4.0, "rating": 8.0, "reason": "", "quote": ""},
+                {"start": 5.0, "end": 6.0, "rating": 8.0, "reason": "", "quote": "hi"},
+            ]
+        return [{"match": True}]
 
     monkeypatch.setattr(
         "server.steps.candidates.ollama_call_json", fake_call_json


### PR DESCRIPTION
## Summary
- tighten funny/inspiring/educational rubrics with explicit negative examples and stricter acceptance criteria
- add secondary LLM tone check and minimum word-count filtering for candidate clips
- expose per-tone word count configuration and add tests rejecting non-funny clips

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae6648fd208323b7cf21968b6a9322