### PR TITLE
Add tone verification for clip candidates

### DIFF
--- a/server/steps/candidates/educational.py
+++ b/server/steps/candidates/educational.py
@@ -9,23 +9,35 @@ from .prompts import EDUCATIONAL_PROMPT_DESC
 
 def find_educational_timestamps_batched(
     transcript_path: str | Path,
-    *args,
+    *,
+    min_rating: float = 7.0,
+    min_words: int = 8,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find educational clip candidates using batched processing."""
     return find_clip_timestamps_batched(
-        transcript_path, prompt_desc=EDUCATIONAL_PROMPT_DESC, **kwargs
+        transcript_path,
+        prompt_desc=EDUCATIONAL_PROMPT_DESC,
+        min_rating=min_rating,
+        min_words=min_words,
+        **kwargs,
     )
 
 
 def find_educational_timestamps(
     transcript_path: str | Path,
-    *args,
+    *,
+    min_rating: float = 7.0,
+    min_words: int = 8,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find educational clip candidates."""
     return find_clip_timestamps(
-        transcript_path, prompt_desc=EDUCATIONAL_PROMPT_DESC, **kwargs
+        transcript_path,
+        prompt_desc=EDUCATIONAL_PROMPT_DESC,
+        min_rating=min_rating,
+        min_words=min_words,
+        **kwargs,
     )
 
 

--- a/server/steps/candidates/funny.py
+++ b/server/steps/candidates/funny.py
@@ -11,11 +11,16 @@ def find_funny_timestamps_batched(
     transcript_path: str | Path,
     *,
     min_rating: float = 8.0,
+    min_words: int = 5,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find humorous clip candidates using batched processing."""
     return find_clip_timestamps_batched(
-        transcript_path, prompt_desc=FUNNY_PROMPT_DESC, min_rating=min_rating, **kwargs
+        transcript_path,
+        prompt_desc=FUNNY_PROMPT_DESC,
+        min_rating=min_rating,
+        min_words=min_words,
+        **kwargs,
     )
 
 
@@ -23,11 +28,16 @@ def find_funny_timestamps(
     transcript_path: str | Path,
     *,
     min_rating: float = 8.0,
+    min_words: int = 5,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find humorous clip candidates."""
     return find_clip_timestamps(
-        transcript_path, prompt_desc=FUNNY_PROMPT_DESC, min_rating=min_rating, **kwargs
+        transcript_path,
+        prompt_desc=FUNNY_PROMPT_DESC,
+        min_rating=min_rating,
+        min_words=min_words,
+        **kwargs,
     )
 
 

--- a/server/steps/candidates/inspiring.py
+++ b/server/steps/candidates/inspiring.py
@@ -9,23 +9,35 @@ from .prompts import INSPIRING_PROMPT_DESC
 
 def find_inspiring_timestamps_batched(
     transcript_path: str | Path,
-    *args,
+    *,
+    min_rating: float = 7.0,
+    min_words: int = 8,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find inspiring clip candidates using batched processing."""
     return find_clip_timestamps_batched(
-        transcript_path, prompt_desc=INSPIRING_PROMPT_DESC, **kwargs
+        transcript_path,
+        prompt_desc=INSPIRING_PROMPT_DESC,
+        min_rating=min_rating,
+        min_words=min_words,
+        **kwargs,
     )
 
 
 def find_inspiring_timestamps(
     transcript_path: str | Path,
-    *args,
+    *,
+    min_rating: float = 7.0,
+    min_words: int = 8,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find inspiring clip candidates."""
     return find_clip_timestamps(
-        transcript_path, prompt_desc=INSPIRING_PROMPT_DESC, **kwargs
+        transcript_path,
+        prompt_desc=INSPIRING_PROMPT_DESC,
+        min_rating=min_rating,
+        min_words=min_words,
+        **kwargs,
     )
 
 

--- a/server/steps/candidates/prompts.py
+++ b/server/steps/candidates/prompts.py
@@ -4,17 +4,19 @@ FUNNY_PROMPT_DESC = (
     "genuinely funny, laugh-inducing moments. Focus on bits that have a clear setup and a punchline, "
     "or a sharp twist/surprise. Prioritize incongruity, exaggeration, taboo/embarrassment (PG–R), "
     "playful insults/roasts, callbacks, misdirection, and deadpan contradictions. Avoid bland banter, "
-    "filler agreement, or mere information."
+    "filler agreement, or mere information. Reject polite chuckles, self-referential commentary without a joke, "
+    "sarcasm lacking a payoff, or anything that only works with unseen visual context."
 )
 
 INSPIRING_PROMPT_DESC = (
     "uplifting or motivational moments that stir positive emotion, showcase overcoming "
-    "challenges, or deliver heartfelt advice."
+    "challenges, or deliver heartfelt advice. Exclude generic compliments, shallow positivity, or "
+    "promotional sound bites that lack an emotional arc."
 )
 
 EDUCATIONAL_PROMPT_DESC = (
     "informative, insightful, or instructional moments that clearly teach a concept or "
-    "share useful facts."
+    "share useful facts. Reject vague opinions, hearsay, or marketing pitches that do not explain how or why."
 )
 
 
@@ -30,9 +32,11 @@ def _build_system_instructions(prompt_desc: str, min_rating: float) -> str:
         "- Coherence: It forms a self-contained beat; the audience will understand without extra context.\n"
         "- Clipability: It is engaging and quotable; likely to grab attention in a short clip.\n"
         "- Completeness: Start at the natural setup/lead-in (not mid-word) and end right after the payoff/beat lands.\n"
+        "- Strictness: If tone alignment is questionable or borderline, exclude the moment.\n"
         "NEGATIVE FILTERS (exclude these):\n"
         "- Filler, bland agreement, mere exposition, or housekeeping.\n"
         "- Partial thoughts that cut off before the key beat/payoff.\n"
+        "- Any segment that conflicts with the tone-specific negative examples.\n"
         "SCORING GUIDE:\n"
         "9–10: extremely aligned, highly engaging, shareable.\n"
         "8: clearly strong, likely to resonate with most viewers.\n"

--- a/tests/test_funny_filter.py
+++ b/tests/test_funny_filter.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+import server.steps.candidates as cand_pkg
+from server.steps.candidates.funny import find_funny_timestamps
+
+
+def test_non_funny_segments_rejected(tmp_path: Path, monkeypatch) -> None:
+    transcript = tmp_path / "t.txt"
+    transcript.write_text("[0.00 -> 3.00] This is a very serious discussion about science.\n", encoding="utf-8")
+
+    def fake_ollama_call_json(model, prompt, options=None, timeout=None):
+        if not hasattr(fake_ollama_call_json, "calls"):
+            fake_ollama_call_json.calls = 0
+        fake_ollama_call_json.calls += 1
+        if fake_ollama_call_json.calls == 1:
+            return [
+                {
+                    "start": 0.0,
+                    "end": 3.0,
+                    "rating": 9,
+                    "reason": "pretend",
+                    "quote": "serious discussion",
+                }
+            ]
+        return {"match": False}
+
+    monkeypatch.setattr(cand_pkg, "ollama_call_json", fake_ollama_call_json)
+
+    result = find_funny_timestamps(str(transcript), min_words=1)
+    assert result == []
+


### PR DESCRIPTION
## Summary
- tighten clip description rubric with tone-specific negatives and stricter rules
- add secondary LLM check with configurable min word thresholds
- expose word-count tuning in tone finders and test funny filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af0641738c8323a2c9cf6f221d10f3