### PR TITLE
Save intermediate candidate lists

### DIFF
--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -149,6 +149,8 @@ if __name__ == "__main__":
     # STEP 5: Find Clip Candidates
     # ----------------------
     candidates_path = project_dir / "candidates.json"
+    candidates_all_path = project_dir / "candidates_all.json"
+    candidates_top_path = project_dir / "candidates_top.json"
 
     CLIP_FINDERS = {
         "funny": find_funny_timestamps_batched,
@@ -156,20 +158,26 @@ if __name__ == "__main__":
         "educational": find_educational_timestamps_batched,
     }
 
-    def step_candidates() -> list[ClipCandidate]:
+    def step_candidates() -> tuple[list[ClipCandidate], list[ClipCandidate], list[ClipCandidate]]:
         finder = CLIP_FINDERS.get(CLIP_TYPE)
         if finder is None:
             raise ValueError(f"Unsupported clip type: {CLIP_TYPE}")
-        return finder(str(transcript_output_path), min_rating=MIN_RATING)
+        return finder(
+            str(transcript_output_path),
+            min_rating=MIN_RATING,
+            return_all_stages=True,
+        )
 
-    candidates = run_step(
+    candidates, top_candidates, all_candidates = run_step(
         "STEP 5: Finding clip candidates from transcript", step_candidates
     )
+
+    export_candidates_json(all_candidates, candidates_all_path)
+    export_candidates_json(top_candidates, candidates_top_path)
+    export_candidates_json(candidates, candidates_path)
     if not candidates:
         print(f"{Fore.RED}STEP 5: No clip candidates found.{Style.RESET_ALL}")
         sys.exit()
-
-    export_candidates_json(candidates, candidates_path)
     # candidates = load_candidates_json('../out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/candidates.json')
 
     # Parse transcript once for snapping boundaries

--- a/server/steps/candidates/educational.py
+++ b/server/steps/candidates/educational.py
@@ -12,6 +12,7 @@ def find_educational_timestamps_batched(
     *,
     min_rating: float = 7.0,
     min_words: int = 8,
+    return_all_stages: bool = False,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find educational clip candidates using batched processing."""
@@ -20,6 +21,7 @@ def find_educational_timestamps_batched(
         prompt_desc=EDUCATIONAL_PROMPT_DESC,
         min_rating=min_rating,
         min_words=min_words,
+        return_all_stages=return_all_stages,
         **kwargs,
     )
 
@@ -29,6 +31,7 @@ def find_educational_timestamps(
     *,
     min_rating: float = 7.0,
     min_words: int = 8,
+    return_all_stages: bool = False,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find educational clip candidates."""
@@ -37,6 +40,7 @@ def find_educational_timestamps(
         prompt_desc=EDUCATIONAL_PROMPT_DESC,
         min_rating=min_rating,
         min_words=min_words,
+        return_all_stages=return_all_stages,
         **kwargs,
     )
 

--- a/server/steps/candidates/funny.py
+++ b/server/steps/candidates/funny.py
@@ -12,6 +12,7 @@ def find_funny_timestamps_batched(
     *,
     min_rating: float = 8.0,
     min_words: int = 5,
+    return_all_stages: bool = False,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find humorous clip candidates using batched processing."""
@@ -20,6 +21,7 @@ def find_funny_timestamps_batched(
         prompt_desc=FUNNY_PROMPT_DESC,
         min_rating=min_rating,
         min_words=min_words,
+        return_all_stages=return_all_stages,
         **kwargs,
     )
 
@@ -29,6 +31,7 @@ def find_funny_timestamps(
     *,
     min_rating: float = 8.0,
     min_words: int = 5,
+    return_all_stages: bool = False,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find humorous clip candidates."""
@@ -37,6 +40,7 @@ def find_funny_timestamps(
         prompt_desc=FUNNY_PROMPT_DESC,
         min_rating=min_rating,
         min_words=min_words,
+        return_all_stages=return_all_stages,
         **kwargs,
     )
 

--- a/server/steps/candidates/inspiring.py
+++ b/server/steps/candidates/inspiring.py
@@ -12,6 +12,7 @@ def find_inspiring_timestamps_batched(
     *,
     min_rating: float = 7.0,
     min_words: int = 8,
+    return_all_stages: bool = False,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find inspiring clip candidates using batched processing."""
@@ -20,6 +21,7 @@ def find_inspiring_timestamps_batched(
         prompt_desc=INSPIRING_PROMPT_DESC,
         min_rating=min_rating,
         min_words=min_words,
+        return_all_stages=return_all_stages,
         **kwargs,
     )
 
@@ -29,6 +31,7 @@ def find_inspiring_timestamps(
     *,
     min_rating: float = 7.0,
     min_words: int = 8,
+    return_all_stages: bool = False,
     **kwargs,
 ) -> List[ClipCandidate]:
     """Find inspiring clip candidates."""
@@ -37,6 +40,7 @@ def find_inspiring_timestamps(
         prompt_desc=INSPIRING_PROMPT_DESC,
         min_rating=min_rating,
         min_words=min_words,
+        return_all_stages=return_all_stages,
         **kwargs,
     )
 


### PR DESCRIPTION
## Summary
- allow candidate search helpers to optionally return raw, top, and verified candidate sets
- persist all, top-rated, and tone-verified candidates as JSON during pipeline step

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af17f34e2c8323b5e393162e1ecf16