### PR TITLE
Adjust snap to include surrounding silences

### DIFF
--- a/tests/test_silence.py
+++ b/tests/test_silence.py
@@ -56,5 +56,9 @@ def test_detect_silences(tmp_path: Path) -> None:
 
 def test_snap_helpers() -> None:
     silences = [(0.0, 1.0), (5.0, 6.0)]
-    assert snap_start_to_silence(2.5, silences) == 1.0
-    assert snap_end_to_silence(4.0, silences) == 5.0
+    # ``snap_start_to_silence`` should extend to the beginning of the previous
+    # silent segment so the leading silence is preserved.
+    assert snap_start_to_silence(2.5, silences) == 0.0
+    # ``snap_end_to_silence`` should extend through the following silent segment
+    # ensuring trailing silence remains.
+    assert snap_end_to_silence(4.0, silences) == 6.0


### PR DESCRIPTION
## Summary
- include leading silence by snapping clip start to the beginning of the previous silence
- include trailing silence by snapping clip end to the end of the next silence
- update tests for new snapping behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af674ca0a083239775fb1ec5481977