### PR TITLE
Extend segment merging for incomplete sentences

### DIFF
--- a/server/steps/candidates/helpers.py
+++ b/server/steps/candidates/helpers.py
@@ -215,16 +215,25 @@ def _snap_end_to_segment_end(
 
     This helps clips end on a natural pause or sentence boundary rather than
     cutting off mid-thought."""
-    for idx, (s, e, _) in enumerate(items):
+    for idx, (s, e, cur_txt) in enumerate(items):
         if s <= end_time <= e:
             end = e
+            txt = cur_txt
             for nxt_s, nxt_e, nxt_txt in items[idx + 1 :]:
                 gap = nxt_s - end
                 if gap > 0.6:
                     break
+                # If the current segment doesn't end with terminal punctuation,
+                # assume the sentence continues regardless of the next segment's
+                # casing.
+                if txt and not txt.rstrip().endswith((".", "?", "!")):
+                    end = nxt_e
+                    txt = nxt_txt
+                    continue
                 first = nxt_txt.lstrip()[:1]
                 if first and first.islower():
                     end = nxt_e
+                    txt = nxt_txt
                     continue
                 break
             return end


### PR DESCRIPTION
## Summary
- ensure `_snap_end_to_segment_end` continues through segments when current text lacks end punctuation

## Testing
- `pytest -q`
- Ran `_merge_adjacent_candidates`/`_enforce_non_overlap` on a sample transcript showing segments merge until sentence completion


------
https://chatgpt.com/codex/tasks/task_e_68af699397148323aad2055e5e197d5d