### PR TITLE
Normalize candidate scoring by tone-aware z-score

### DIFF
--- a/tests/test_candidate_ranking.py
+++ b/tests/test_candidate_ranking.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+from server.steps.candidates.helpers import _enforce_non_overlap
+from server.interfaces.clip_candidate import ClipCandidate
+
+
+def test_tone_aligned_prioritized() -> None:
+    items = [(0.0, 2.0, "a"), (2.0, 4.0, "b")]
+    good = ClipCandidate(start=0.0, end=1.0, rating=5.0, reason="", quote="")
+    bad = ClipCandidate(start=0.0, end=1.0, rating=9.0, reason="", quote="")
+    good.tone_match = True
+    bad.tone_match = False
+
+    result = _enforce_non_overlap([bad, good], items)
+    assert len(result) == 1
+    chosen = result[0]
+    assert chosen.rating == good.rating
+    assert chosen.start == 0.0 and chosen.end == 4.0


### PR DESCRIPTION
## Summary
- Normalize candidate ratings using z-score and integrate tone verification as a priority weight
- Preserve tone verification flag when refining candidates
- Add unit test ensuring tone-aligned clips are prioritized

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af6bd328b88323aab3d8f415a29b28