### PR TITLE
Prefer shorter clip candidates

### DIFF
--- a/server/steps/candidates/helpers.py
+++ b/server/steps/candidates/helpers.py
@@ -342,7 +342,9 @@ def _enforce_non_overlap(
         z = (x.rating - mean) / std
         tone_ok = bool(getattr(x, "tone_match", True))
         tone_penalty = 0 if tone_ok else 1
-        return (tone_penalty, -(z * prior), x.start, x.end)
+        length_bonus = 0.1 / max(d, 1.0)
+        score = z * prior + length_bonus
+        return (tone_penalty, -score, d, x.start, x.end)
 
     adjusted.sort(key=score_key)
     selected: List[ClipCandidate] = []

--- a/tests/test_candidate_ranking.py
+++ b/tests/test_candidate_ranking.py
@@ -23,3 +23,18 @@ def test_tone_aligned_prioritized() -> None:
     chosen = result[0]
     assert chosen.rating == good.rating
     assert chosen.start == 0.0 and chosen.end == 4.0
+
+
+def test_shorter_clip_preferred() -> None:
+    items = [
+        (0.0, 5.0, "A"),
+        (5.0, 10.0, "B"),
+        (10.0, 15.0, "C"),
+        (15.0, 20.0, "D"),
+    ]
+    long = ClipCandidate(start=0.0, end=14.0, rating=7.0, reason="", quote="")
+    short = ClipCandidate(start=0.0, end=8.0, rating=7.0, reason="", quote="")
+    result = _enforce_non_overlap([long, short], items)
+    assert len(result) == 1
+    chosen = result[0]
+    assert chosen.start == 0.0 and chosen.end == 10.0


### PR DESCRIPTION
## Summary
- reward shorter clip candidates by adding length bonus to ranking
- add regression test ensuring shorter clip wins when scores tie

## Testing
- `pytest tests/test_candidate_ranking.py::test_shorter_clip_preferred -q`
- `pytest -q` *(fails: No such file or directory: 'ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68af72399db48323b51009b4dca4872b