### PR TITLE
Add transcript segmentation and sentence snapping

### DIFF
--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -7,9 +7,10 @@ from steps.candidates.helpers import (
     export_candidates_json,
     load_candidates_json,
     parse_transcript,
-    _snap_start_to_segment_start,
-    _snap_end_to_segment_end,
+    _snap_start_to_sentence_start,
+    _snap_end_to_sentence_end,
 )
+from steps.segment import segment_transcript_items, write_segments_json
 from steps.cut import save_clip_from_candidate
 from steps.subtitle import build_srt_for_range
 from steps.render import render_vertical_with_captions
@@ -183,6 +184,8 @@ if __name__ == "__main__":
 
     # Parse transcript once for snapping boundaries
     items = parse_transcript(transcript_output_path)
+    segments = segment_transcript_items(items)
+    write_segments_json(segments, project_dir / "segments.json")
 
     clips_dir = project_dir / "clips"
     subtitles_dir = project_dir / "subtitles"
@@ -193,8 +196,8 @@ if __name__ == "__main__":
     shorts_dir.mkdir(parents=True, exist_ok=True)
 
     for idx, cand in enumerate(candidates, start=1):
-        snapped_start = _snap_start_to_segment_start(cand.start, items)
-        snapped_end = _snap_end_to_segment_end(cand.end, items)
+        snapped_start = _snap_start_to_sentence_start(cand.start, segments)
+        snapped_end = _snap_end_to_sentence_end(cand.end, segments)
         adj_start = snap_start_to_silence(snapped_start, silences)
         adj_end = snap_end_to_silence(snapped_end, silences)
         candidate = ClipCandidate(

--- a/server/steps/candidates/helpers.py
+++ b/server/steps/candidates/helpers.py
@@ -242,6 +242,26 @@ def _snap_start_to_segment_start(
     return start_time
 
 
+def _snap_end_to_sentence_end(
+    time: float, segments: List[Tuple[float, float, str]]
+) -> float:
+    """Snap ``time`` to the end of the sentence/beat containing it."""
+    for s, e, _ in segments:
+        if s <= time <= e:
+            return e
+    return time
+
+
+def _snap_start_to_sentence_start(
+    time: float, segments: List[Tuple[float, float, str]]
+) -> float:
+    """Snap ``time`` to the beginning of the sentence/beat containing it."""
+    for s, e, _ in segments:
+        if s <= time <= e:
+            return s
+    return time
+
+
 def _merge_adjacent_candidates(
     candidates: List[ClipCandidate],
     items: List[Tuple[float, float, str]],

--- a/server/steps/segment.py
+++ b/server/steps/segment.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+
+def segment_transcript_items(
+    items: List[Tuple[float, float, str]]
+) -> List[Tuple[float, float, str]]:
+    """Split transcript items into sentence-level segments with proportional timestamps.
+
+    Parameters
+    ----------
+    items:
+        List of ``(start, end, text)`` triples from :func:`parse_transcript`.
+    Returns
+    -------
+    List[Tuple[float, float, str]]
+        New list where each entry corresponds to a single sentence/beat.
+    """
+    segments: List[Tuple[float, float, str]] = []
+    for start, end, text in items:
+        sentences = [s.strip() for s in _SENTENCE_SPLIT.split(text) if s.strip()]
+        if not sentences:
+            continue
+        total_len = sum(len(s) for s in sentences)
+        cur = start
+        duration = end - start
+        for sent in sentences:
+            ratio = len(sent) / total_len if total_len else 0.0
+            seg_end = cur + duration * ratio
+            segments.append((cur, seg_end, sent))
+            cur = seg_end
+    return segments
+
+
+def write_segments_json(
+    segments: List[Tuple[float, float, str]], output_path: str | Path
+) -> None:
+    """Write segments to ``output_path`` as JSON."""
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    payload = [
+        {"start": s, "end": e, "text": t}
+        for s, e, t in segments
+    ]
+    out.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/tests/test_segment_boundaries.py
+++ b/tests/test_segment_boundaries.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+from server.steps.segment import segment_transcript_items, write_segments_json
+
+
+def test_segment_transcript_items_and_json(tmp_path: Path) -> None:
+    items = [(0.0, 10.0, "Hello world. This is test.")]
+    segments = segment_transcript_items(items)
+    assert len(segments) == 2
+    first_len = len("Hello world.")
+    second_len = len("This is test.")
+    expected_first_end = 10.0 * first_len / (first_len + second_len)
+    assert segments[0][2] == "Hello world."
+    assert segments[1][2] == "This is test."
+    assert segments[0][0] == 0.0
+    assert segments[0][1] == pytest.approx(expected_first_end)
+    assert segments[1][0] == pytest.approx(expected_first_end)
+    assert segments[1][1] == pytest.approx(10.0)
+
+    out = tmp_path / "segments.json"
+    write_segments_json(segments, out)
+    assert out.exists()
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data[0]["text"] == "Hello world."
+    assert data[1]["text"] == "This is test."


### PR DESCRIPTION
## Summary
- Implement transcript segmentation and JSON export utilities.
- Snap candidate windows to sentence boundaries with new helpers.
- Integrate segmentation into pipeline and add tests for boundary splitting.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af743b8ff08323b7c47ed67087fe1b