### PR TITLE
Refactor caption handling and rendering

### DIFF
--- a/server/steps/captions.py
+++ b/server/steps/captions.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import List, Tuple, Optional, Union
+
+_SRT_TIME = re.compile(
+    r"^(\d{2}):(\d{2}):(\d{2}),(\d{3})\s+-->\s+(\d{2}):(\d{2}):(\d{2}),(\d{3})$"
+)
+
+
+def _hmsms_to_sec(h: str, m: str, s: str, ms: str) -> float:
+    return int(h) * 3600 + int(m) * 60 + int(s) + int(ms) / 1000.0
+
+
+def _parse_srt_text(s: str) -> List[Tuple[float, float, str]]:
+    """Parse an SRT subtitle string into a list of timed text entries."""
+    chunks = re.split(r"\r?\n\r?\n+", s.strip())
+    out: List[Tuple[float, float, str]] = []
+    for ch in chunks:
+        lines = [ln for ln in ch.splitlines() if ln.strip() != ""]
+        if not lines:
+            continue
+        idx = 0
+        if lines and lines[0].strip().isdigit():
+            idx = 1
+        if idx >= len(lines):
+            continue
+        m = _SRT_TIME.match(lines[idx].strip())
+        if not m:
+            continue
+        sh, sm, ss, sms, eh, em, es, ems = m.groups()
+        start = _hmsms_to_sec(sh, sm, ss, sms)
+        end = _hmsms_to_sec(eh, em, es, ems)
+        text = " ".join(ln.strip() for ln in lines[idx + 1 :]).strip()
+        if end > start and text:
+            out.append((start, end, text))
+    return out
+
+
+def _load_captions_from_path(p: Path) -> List[Tuple[float, float, str]]:
+    """Load captions from a file path supporting SRT or JSON formats."""
+    if not p.exists():
+        return []
+    suf = p.suffix.lower()
+    try:
+        data = p.read_text(encoding="utf-8")
+    except Exception:
+        data = p.read_text(errors="ignore")
+    if suf == ".srt":
+        return _parse_srt_text(data)
+    if suf == ".json":
+        try:
+            obj = json.loads(data)
+            if isinstance(obj, list):
+                tmp: List[Tuple[float, float, str]] = []
+                for it in obj:
+                    if isinstance(it, dict):
+                        s = float(it.get("start", 0.0))
+                        e = float(it.get("end", it.get("stop", s)))
+                        txt = str(it.get("text", it.get("content", "")))
+                        if e > s and txt:
+                            tmp.append((s, e, txt))
+                    elif isinstance(it, (list, tuple)) and len(it) >= 3:
+                        s, e, txt = it[0], it[1], str(it[2])
+                        if float(e) > float(s) and txt:
+                            tmp.append((float(s), float(e), txt))
+                return tmp
+        except Exception:
+            return []
+    return []
+
+
+def _normalize_caps(
+    caps: Optional[Union[List[Tuple[float, float, str]], List[dict], str, Path]]
+) -> List[Tuple[float, float, str]]:
+    """Normalize various caption representations into a sorted list."""
+    if caps is None:
+        return []
+    if isinstance(caps, (str, Path)):
+        return _load_captions_from_path(Path(caps))
+    norm: List[Tuple[float, float, str]] = []
+    for it in caps:
+        if isinstance(it, dict):
+            s = float(it.get("start", 0.0))
+            e = float(it.get("end", it.get("stop", s)))
+            txt = str(it.get("text", it.get("content", "")))
+        else:
+            s, e, txt = it  # type: ignore[misc]
+        if e > s and txt:
+            norm.append((s, e, txt))
+    norm.sort(key=lambda x: x[0])
+    return norm
+

--- a/server/steps/render.py
+++ b/server/steps/render.py
@@ -5,10 +5,130 @@ from typing import List, Tuple, Optional, Union
 
 import cv2
 import numpy as np
-import re
-import json
 import subprocess
 import os
+
+from .captions import _normalize_caps
+
+
+def _prepare_background(frame: np.ndarray, frame_width: int, frame_height: int, blur_ksize: int) -> np.ndarray:
+    h, w = frame.shape[:2]
+    scale_bg = max(frame_width / w, frame_height / h)
+    bg = cv2.resize(frame, (int(w * scale_bg), int(h * scale_bg)))
+    y0 = max(0, (bg.shape[0] - frame_height) // 2)
+    x0 = max(0, (bg.shape[1] - frame_width) // 2)
+    bg = bg[y0:y0 + frame_height, x0:x0 + frame_width]
+    k = blur_ksize if blur_ksize % 2 == 1 else blur_ksize + 1
+    bg = cv2.GaussianBlur(bg, (k, k), 0)
+    bg = cv2.addWeighted(bg, 0.55, np.zeros_like(bg), 0.45, 0)
+    return bg
+
+
+def _place_foreground(
+    bg: np.ndarray,
+    frame: np.ndarray,
+    frame_width: int,
+    frame_height: int,
+    fg_height_ratio: float,
+    fg_vertical_bias: float,
+) -> Tuple[np.ndarray, int, int]:
+    h, w = frame.shape[:2]
+    fg_target_h = max(100, int(frame_height * fg_height_ratio))
+    scale_fg = fg_target_h / h
+    fg_w, fg_h = int(w * scale_fg), int(h * scale_fg)
+    fg = cv2.resize(frame, (fg_w, fg_h))
+    x_fg = (frame_width - fg_w) // 2
+    center_y = int(frame_height * (0.5 - fg_vertical_bias))
+    y_fg = max(0, center_y - fg_h // 2)
+
+    canvas = bg.copy()
+    x1 = max(0, x_fg)
+    y1 = max(0, y_fg)
+    x2 = min(frame_width, x_fg + fg_w)
+    y2 = min(frame_height, y_fg + fg_h)
+    if x2 > x1 and y2 > y1:
+        src_x1 = max(0, -x_fg)
+        src_y1 = max(0, -y_fg)
+        src_x2 = src_x1 + (x2 - x1)
+        src_y2 = src_y1 + (y2 - y1)
+        canvas[y1:y2, x1:x2] = fg[src_y1:src_y2, src_x1:src_x2]
+
+    return canvas, y_fg, fg_h
+
+
+def _draw_captions(
+    canvas: np.ndarray,
+    text: str,
+    frame_width: int,
+    frame_height: int,
+    y_fg: int,
+    fg_h: int,
+    *,
+    gap_below_fg: int,
+    bottom_safe_ratio: float,
+    line_spacing: int,
+    wrap_width_px_ratio: float,
+    font,
+    line_type,
+    font_scale: float,
+    thickness: int,
+    outline: int,
+    fill_bgr: Tuple[int, int, int],
+    outline_bgr: Tuple[int, int, int],
+) -> np.ndarray:
+    if not text:
+        return canvas
+    max_text_w = int(frame_width * wrap_width_px_ratio)
+    words = text.replace("\n", " ").split()
+    lines: List[str] = []
+    cur = ""
+    for wtok in words:
+        test = (cur + " " + wtok).strip()
+        (tw, _), _ = cv2.getTextSize(test, font, font_scale, thickness + outline)
+        if tw <= max_text_w or not cur:
+            cur = test
+        else:
+            lines.append(cur)
+            cur = wtok
+    if cur:
+        lines.append(cur)
+
+    bottom_safe = int(frame_height * bottom_safe_ratio)
+    sizes = [cv2.getTextSize(ln, font, font_scale, thickness + outline)[0] for ln in lines]
+    total_h = sum(sz[1] for sz in sizes) + line_spacing * max(0, len(lines) - 1)
+    under_fg_y = y_fg + fg_h + gap_below_fg
+    max_y = frame_height - bottom_safe - total_h
+    y_text = max(0, min(under_fg_y, max_y))
+
+    for ln in lines:
+        (tw, th), _ = cv2.getTextSize(ln, font, font_scale, thickness + outline)
+        x_text = (frame_width - tw) // 2
+        for dx in (-outline, 0, outline):
+            for dy in (-outline, 0, outline):
+                if dx == 0 and dy == 0:
+                    continue
+                cv2.putText(
+                    canvas,
+                    ln,
+                    (x_text + dx, y_text + th + dy),
+                    font,
+                    font_scale,
+                    outline_bgr,
+                    thickness + outline,
+                    line_type,
+                )
+        cv2.putText(
+            canvas,
+            ln,
+            (x_text, y_text + th),
+            font,
+            font_scale,
+            fill_bgr,
+            thickness,
+            line_type,
+        )
+        y_text += th + line_spacing
+    return canvas
 
 
 def render_vertical_with_captions(
@@ -18,7 +138,7 @@ def render_vertical_with_captions(
     *,
     frame_width: int = 1080,
     frame_height: int = 1920,
-    fg_height_ratio: float = 0.42,      # slightly less zoom on FG
+    fg_height_ratio: float = 0.42,
     fg_vertical_bias: float = 0.04,
     bottom_safe_ratio: float = 0.14,
     gap_below_fg: int = 28,
@@ -26,102 +146,22 @@ def render_vertical_with_captions(
     thickness: int = 2,
     outline: int = 4,
     line_spacing: int = 10,
-    wrap_width_px_ratio: float = 0.86,  # caption max width as ratio of frame_width
-    blur_ksize: int = 31,               # must be odd; background blur amount
-    fill_bgr: Tuple[int, int, int] = (255, 187, 28),   # hex 1cbbff -> RGB(28,187,255) -> BGR(255,187,28)
-    outline_bgr: Tuple[int, int, int] = (236, 236, 236),  # hex ececec
+    wrap_width_px_ratio: float = 0.86,
+    blur_ksize: int = 31,
+    fill_bgr: Tuple[int, int, int] = (255, 187, 28),
+    outline_bgr: Tuple[int, int, int] = (236, 236, 236),
 ) -> Path:
-    """Render a vertical video with burned-in captions without using ffmpeg.
+    """Render a vertical video with burned-in captions without using ffmpeg."""
 
-    The original clip is resized and placed with blurred background and captions.
-    """
     clip_path = Path(clip_path)
-    output = Path(output_path) if output_path is not None else Path(clip_path).with_name(Path(clip_path).stem + "_vertical.mp4")
+    output = (
+        Path(output_path)
+        if output_path is not None
+        else Path(clip_path).with_name(Path(clip_path).stem + "_vertical.mp4")
+    )
     output.parent.mkdir(parents=True, exist_ok=True)
 
-    temp_video = output.with_suffix('.video.mp4')
-
-    _SRT_TIME = re.compile(r"^(\d{2}):(\d{2}):(\d{2}),(\d{3})\s+-->\s+(\d{2}):(\d{2}):(\d{2}),(\d{3})$")
-
-    def _hmsms_to_sec(h: str, m: str, s: str, ms: str) -> float:
-        return int(h) * 3600 + int(m) * 60 + int(s) + int(ms) / 1000.0
-
-    def _parse_srt_text(s: str) -> List[Tuple[float, float, str]]:
-        chunks = re.split(r"\r?\n\r?\n+", s.strip())
-        out: List[Tuple[float, float, str]] = []
-        for ch in chunks:
-            lines = [ln for ln in ch.splitlines() if ln.strip() != ""]
-            if not lines:
-                continue
-            # allow optional numeric index on first line
-            idx = 0
-            if lines and lines[0].strip().isdigit():
-                idx = 1
-            if idx >= len(lines):
-                continue
-            m = _SRT_TIME.match(lines[idx].strip())
-            if not m:
-                # not a timed block
-                continue
-            sh, sm, ss, sms, eh, em, es, ems = m.groups()
-            start = _hmsms_to_sec(sh, sm, ss, sms)
-            end = _hmsms_to_sec(eh, em, es, ems)
-            text = " ".join(ln.strip() for ln in lines[idx+1:]).strip()
-            if end > start and text:
-                out.append((start, end, text))
-        return out
-
-    def _load_captions_from_path(p: Path) -> List[Tuple[float, float, str]]:
-        if not p.exists():
-            return []
-        suf = p.suffix.lower()
-        try:
-            data = p.read_text(encoding="utf-8")
-        except Exception:
-            data = p.read_text(errors="ignore")
-        if suf == ".srt":
-            return _parse_srt_text(data)
-        if suf == ".json":
-            try:
-                obj = json.loads(data)
-                # expect list of dicts or tuples
-                if isinstance(obj, list):
-                    tmp: List[Tuple[float, float, str]] = []
-                    for it in obj:
-                        if isinstance(it, dict):
-                            s = float(it.get("start", 0.0))
-                            e = float(it.get("end", it.get("stop", s)))
-                            txt = str(it.get("text", it.get("content", "")))
-                            if e > s and txt:
-                                tmp.append((s, e, txt))
-                        elif isinstance(it, (list, tuple)) and len(it) >= 3:
-                            s, e, txt = it[0], it[1], str(it[2])
-                            if float(e) > float(s) and txt:
-                                tmp.append((float(s), float(e), txt))
-                    return tmp
-            except Exception:
-                return []
-        # unknown extension
-        return []
-
-    def _normalize_caps(caps: Optional[Union[List[Tuple[float, float, str]], List[dict], str, Path]]) -> List[Tuple[float, float, str]]:
-        if caps is None:
-            return []
-        # If a path or string was passed (legacy call sites), load from file
-        if isinstance(caps, (str, Path)):
-            return _load_captions_from_path(Path(caps))
-        norm: List[Tuple[float, float, str]] = []
-        for it in caps:
-            if isinstance(it, dict):
-                s = float(it.get("start", 0.0))
-                e = float(it.get("end", it.get("stop", s)))
-                txt = str(it.get("text", it.get("content", "")))
-            else:
-                s, e, txt = it  # type: ignore[misc]
-            if e > s and txt:
-                norm.append((s, e, txt))
-        norm.sort(key=lambda x: x[0])
-        return norm
+    temp_video = output.with_suffix(".video.mp4")
 
     captions_norm = _normalize_caps(captions)
 
@@ -129,7 +169,6 @@ def render_vertical_with_captions(
         print(f"WARN: No captions parsed from {captions}. Proceeding without text.")
 
     def _current_caption_text(t: float) -> str:
-        # Binary search could be added; linear is fine for modest lists
         for (s, e, txt) in captions_norm:
             if s <= t < e:
                 return txt
@@ -159,112 +198,65 @@ def render_vertical_with_captions(
         t = cap.get(cv2.CAP_PROP_POS_MSEC) / 1000.0
         current_text = _current_caption_text(t)
 
-        # --- Build blurred background (cover 9:16) ---
-        h, w = frame.shape[:2]
-        scale_bg = max(frame_width / w, frame_height / h)
-        bg = cv2.resize(frame, (int(w * scale_bg), int(h * scale_bg)))
-        # center-crop to exact frame
-        y0 = max(0, (bg.shape[0] - frame_height) // 2)
-        x0 = max(0, (bg.shape[1] - frame_width) // 2)
-        bg = bg[y0:y0 + frame_height, x0:x0 + frame_width]
-        # gaussian blur (ksize must be odd)
-        k = blur_ksize if blur_ksize % 2 == 1 else blur_ksize + 1
-        bg = cv2.GaussianBlur(bg, (k, k), 0)
-        # slight dim for readability
-        bg = cv2.addWeighted(bg, 0.55, np.zeros_like(bg), 0.45, 0)
-
-        # --- Foreground scaled to a portion of the height and biased upward ---
-        fg_target_h = max(100, int(frame_height * fg_height_ratio))
-        scale_fg = fg_target_h / h
-        fg_w, fg_h = int(w * scale_fg), int(h * scale_fg)
-        fg = cv2.resize(frame, (fg_w, fg_h))
-        # position
-        x_fg = (frame_width - fg_w) // 2
-        center_y = int(frame_height * (0.5 - fg_vertical_bias))
-        y_fg = max(0, center_y - fg_h // 2)
-
-        canvas = bg.copy()
-        # --- Safe paste of FG into canvas with clipping ---
-        x1 = max(0, x_fg)
-        y1 = max(0, y_fg)
-        x2 = min(frame_width, x_fg + fg_w)
-        y2 = min(frame_height, y_fg + fg_h)
-        if x2 > x1 and y2 > y1:
-            src_x1 = max(0, -x_fg)
-            src_y1 = max(0, -y_fg)
-            src_x2 = src_x1 + (x2 - x1)
-            src_y2 = src_y1 + (y2 - y1)
-            canvas[y1:y2, x1:x2] = fg[src_y1:src_y2, src_x1:src_x2]
-
-        # --- Captions under FG, wrapped, centered, with outline ---
-        if current_text:
-            max_text_w = int(frame_width * wrap_width_px_ratio)
-            # simple greedy wrap by measuring getTextSize
-            words = current_text.replace("\n", " ").split()
-            lines: List[str] = []
-            cur = ""
-            for wtok in words:
-                test = (cur + " " + wtok).strip()
-                (tw, th), base = cv2.getTextSize(test, font, font_scale, thickness + outline)
-                if tw <= max_text_w or not cur:
-                    cur = test
-                else:
-                    lines.append(cur)
-                    cur = wtok
-            if cur:
-                lines.append(cur)
-
-            # place starting just below fg bottom, but above bottom safe area
-            bottom_safe = int(frame_height * bottom_safe_ratio)
-            # measure block height
-            sizes = [cv2.getTextSize(ln, font, font_scale, thickness + outline)[0] for ln in lines]
-            total_h = sum(sz[1] for sz in sizes) + line_spacing * max(0, len(lines) - 1)
-            under_fg_y = y_fg + fg_h + gap_below_fg
-            max_y = frame_height - bottom_safe - total_h
-            y_text = max(0, min(under_fg_y, max_y))
-
-            # draw each line centered with outline
-            for ln in lines:
-                (tw, th), base = cv2.getTextSize(ln, font, font_scale, thickness + outline)
-                x_text = (frame_width - tw) // 2
-                # outline
-                for dx in (-outline, 0, outline):
-                    for dy in (-outline, 0, outline):
-                        if dx == 0 and dy == 0:
-                            continue
-                        cv2.putText(canvas, ln, (x_text + dx, y_text + th + dy), font, font_scale, outline_bgr, thickness + outline, line_type)
-                # fill
-                cv2.putText(canvas, ln, (x_text, y_text + th), font, font_scale, fill_bgr, thickness, line_type)
-                y_text += th + line_spacing
-
+        bg = _prepare_background(frame, frame_width, frame_height, blur_ksize)
+        canvas, y_fg, fg_h = _place_foreground(
+            bg, frame, frame_width, frame_height, fg_height_ratio, fg_vertical_bias
+        )
+        canvas = _draw_captions(
+            canvas,
+            current_text,
+            frame_width,
+            frame_height,
+            y_fg,
+            fg_h,
+            gap_below_fg=gap_below_fg,
+            bottom_safe_ratio=bottom_safe_ratio,
+            line_spacing=line_spacing,
+            wrap_width_px_ratio=wrap_width_px_ratio,
+            font=font,
+            line_type=line_type,
+            font_scale=font_scale,
+            thickness=thickness,
+            outline=outline,
+            fill_bgr=fill_bgr,
+            outline_bgr=outline_bgr,
+        )
         writer.write(canvas)
 
     cap.release()
     writer.release()
 
-    # --- Mux original audio from source clip into the rendered video ---
-    # If the source has no audio, the optional map (1:a:0?) prevents failure.
     mux_cmd = [
-        "ffmpeg", "-y",
-        "-i", str(temp_video),
-        "-i", str(clip_path),
-        "-map", "0:v:0", "-map", "1:a:0?",
-        "-c:v", "copy", "-c:a", "copy",
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(temp_video),
+        "-i",
+        str(clip_path),
+        "-map",
+        "0:v:0",
+        "-map",
+        "1:a:0?",
+        "-c:v",
+        "copy",
+        "-c:a",
+        "copy",
         "-shortest",
         str(output),
     ]
     try:
-        res = subprocess.run(mux_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        subprocess.run(mux_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
     except subprocess.CalledProcessError as e:
-        # Fall back: just move the video-only file to the final path if mux fails
         try:
             if temp_video.exists():
                 temp_video.replace(output)
         except Exception:
             pass
-        print("WARN: Audio mux failed; wrote video-only. STDERR head:\n" + (e.stderr.decode(errors='ignore')[:800] if e.stderr else ""))
+        print(
+            "WARN: Audio mux failed; wrote video-only. STDERR head:\n"
+            + (e.stderr.decode(errors="ignore")[:800] if e.stderr else "")
+        )
     else:
-        # Cleanup temp video after successful mux
         try:
             if temp_video.exists():
                 os.remove(temp_video)

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+from server.steps.captions import (
+    _parse_srt_text,
+    _load_captions_from_path,
+)
+
+
+def test_parse_srt_text_valid() -> None:
+    srt = (
+        "1\n00:00:00,000 --> 00:00:01,000\nHello\n\n"
+        "2\n00:00:01,000 --> 00:00:02,000\nWorld\n"
+    )
+    assert _parse_srt_text(srt) == [(0.0, 1.0, "Hello"), (1.0, 2.0, "World")]
+
+
+def test_load_captions_json_valid(tmp_path: Path) -> None:
+    data = [{"start": 0, "end": 1, "text": "Hi"}, {"start": 1, "end": 2, "text": "There"}]
+    p = tmp_path / "caps.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    assert _load_captions_from_path(p) == [(0.0, 1.0, "Hi"), (1.0, 2.0, "There")]
+
+
+def test_load_captions_failure(tmp_path: Path) -> None:
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("{not json}")
+    assert _load_captions_from_path(bad_json) == []
+
+    bad_srt = tmp_path / "bad.srt"
+    bad_srt.write_text("no timestamps here")
+    assert _load_captions_from_path(bad_srt) == []
+

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+from server.steps.render import render_vertical_with_captions
+
+
+def test_render_vertical_with_captions(tmp_path: Path) -> None:
+    src = tmp_path / "src.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=blue:s=320x240",
+            "-t",
+            "1",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(src),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    caps = [(0.0, 0.5, "hello"), (0.5, 1.0, "world")]
+    out = tmp_path / "out.mp4"
+    result = render_vertical_with_captions(src, captions=caps, output_path=out)
+    assert result.exists()
+
+    probe = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=width,height",
+            "-of",
+            "csv=p=0",
+            str(result),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    w, h = map(int, probe.stdout.decode().strip().split(','))
+    assert (w, h) == (1080, 1920)
+


### PR DESCRIPTION
## Summary
- extract caption parsing helpers into `server/steps/captions.py`
- refactor video rendering into helper functions for background, foreground, and caption drawing
- add unit tests for caption parsing and rendering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af7db233508323a0f77a2791611e9b