### PR TITLE
Add CLI wrappers for download and transcribe steps

### DIFF
--- a/server/cli/download_cli.py
+++ b/server/cli/download_cli.py
@@ -1,0 +1,28 @@
+import argparse
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Download a transcript from a YouTube video"
+    )
+    parser.add_argument("yt_url", help="YouTube video URL or ID")
+    parser.add_argument(
+        "--output", default="transcript.txt", help="Path to save the transcript"
+    )
+    return parser
+
+
+def _get_download_transcript():
+    from server.steps.download import download_transcript
+
+    return download_transcript
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = create_parser().parse_args(argv)
+    download = _get_download_transcript()
+    download(args.yt_url, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/server/cli/transcribe_cli.py
+++ b/server/cli/transcribe_cli.py
@@ -1,0 +1,26 @@
+import argparse
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Transcribe an audio file")
+    parser.add_argument("audio_path", help="Path to the audio file")
+    parser.add_argument(
+        "--model-size", default="medium", help="Whisper model size to use"
+    )
+    return parser
+
+
+def _get_transcribe_audio():
+    from server.steps.transcribe import transcribe_audio
+
+    return transcribe_audio
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = create_parser().parse_args(argv)
+    transcribe = _get_transcribe_audio()
+    transcribe(args.audio_path, args.model_size)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/server/steps/transcribe.py
+++ b/server/steps/transcribe.py
@@ -1,5 +1,9 @@
 from faster_whisper import WhisperModel
 from server.interfaces.timer import Timer
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def transcribe_audio(file_path, model_size="medium"):
@@ -28,13 +32,15 @@ def transcribe_audio(file_path, model_size="medium"):
     }
 
 
-if __name__ == "__main__":
-    audio_path = "kfaf1.mp3"
-    model_name = "large-v3-turbo"
+def main(audio_path: str = "kfaf1.mp3", model_name: str = "large-v3-turbo") -> None:
     result = transcribe_audio(audio_path, model_name)
-    print("Transcription text (first 500 chars):")
-    print(result["text"][:500])
-    print("\nFirst 12 segments:")
-    print(result["segments"][:12])
-    print("\nTiming info:")
-    print(result["timing"]) 
+    logger.info("Transcription text (first 500 chars):")
+    logger.info(result["text"][:500])
+    logger.info("\nFirst 12 segments:")
+    logger.info(result["segments"][:12])
+    logger.info("\nTiming info:")
+    logger.info(result["timing"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_download_cli.py
+++ b/tests/test_download_cli.py
@@ -1,0 +1,27 @@
+from server.cli.download_cli import main as download_main
+
+
+def test_download_cli_invokes_download_transcript(monkeypatch):
+    called = {}
+
+    def fake_download(url, output):
+        called['args'] = (url, output)
+
+    monkeypatch.setattr(
+        'server.cli.download_cli._get_download_transcript', lambda: fake_download
+    )
+    download_main(['https://youtu.be/test', '--output', 'out.txt'])
+    assert called['args'] == ('https://youtu.be/test', 'out.txt')
+
+
+def test_download_cli_uses_default_output(monkeypatch):
+    called = {}
+
+    def fake_download(url, output):
+        called['args'] = (url, output)
+
+    monkeypatch.setattr(
+        'server.cli.download_cli._get_download_transcript', lambda: fake_download
+    )
+    download_main(['https://youtu.be/test'])
+    assert called['args'] == ('https://youtu.be/test', 'transcript.txt')

--- a/tests/test_transcribe_cli.py
+++ b/tests/test_transcribe_cli.py
@@ -1,0 +1,27 @@
+from server.cli.transcribe_cli import main as transcribe_main
+
+
+def test_transcribe_cli_invokes_transcribe_audio(monkeypatch):
+    called = {}
+
+    def fake_transcribe(path, model):
+        called['args'] = (path, model)
+
+    monkeypatch.setattr(
+        'server.cli.transcribe_cli._get_transcribe_audio', lambda: fake_transcribe
+    )
+    transcribe_main(['audio.mp3', '--model-size', 'small'])
+    assert called['args'] == ('audio.mp3', 'small')
+
+
+def test_transcribe_cli_uses_default_model(monkeypatch):
+    called = {}
+
+    def fake_transcribe(path, model):
+        called['args'] = (path, model)
+
+    monkeypatch.setattr(
+        'server.cli.transcribe_cli._get_transcribe_audio', lambda: fake_transcribe
+    )
+    transcribe_main(['audio.mp3'])
+    assert called['args'] == ('audio.mp3', 'medium')


### PR DESCRIPTION
## Summary
- refactor download and transcribe step demos into callable `main` functions with logging
- add argparse-based CLIs for downloading transcripts and transcribing audio
- test CLI argument parsing and ensure step functions are invoked

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af831f61ac8323abb49102ac60257f