### PR TITLE
test: add helper and utility tests

### DIFF
--- a/tests/test_ai_retry.py
+++ b/tests/test_ai_retry.py
@@ -1,0 +1,41 @@
+"""Tests for the retry helper."""
+
+from typing import List
+
+import pytest
+
+from server.helpers.ai import retry
+
+
+def test_retry_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Function should be retried until it succeeds."""
+    attempts: List[int] = []
+
+    def flaky() -> str:
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise ValueError("nope")
+        return "ok"
+
+    sleeps: List[float] = []
+    monkeypatch.setattr("time.sleep", lambda s: sleeps.append(s))
+
+    assert retry(flaky, attempts=5, backoff=2) == "ok"
+    assert attempts == [1, 1, 1]
+    assert sleeps == [1.0, 2.0]
+
+
+def test_retry_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After exhausting attempts, the last exception should be raised."""
+    count = 0
+
+    def always_fail() -> None:
+        nonlocal count
+        count += 1
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    with pytest.raises(RuntimeError):
+        retry(always_fail, attempts=3, backoff=1)
+    assert count == 3

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,51 @@
+"""Tests for ensuring audio acquisition logic."""
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from server.helpers import audio
+
+
+def test_ensure_audio_uses_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Should extract from existing video if download fails."""
+    audio_path = tmp_path / "a.mp3"
+    video_path = tmp_path / "v.mp4"
+    video_path.write_bytes(b"video")
+
+    def fail_download(url: str, out: str) -> None:  # pragma: no cover - mock
+        raise RuntimeError("fail")
+
+    called: List[str] = []
+
+    def succeed_extract(src: str, dst: str) -> None:  # pragma: no cover - mock
+        called.append("extract")
+        Path(dst).write_bytes(b"audio")
+
+    monkeypatch.setattr(audio, "download_audio", fail_download)
+    monkeypatch.setattr(audio, "extract_audio_from_video", succeed_extract)
+
+    ok = audio.ensure_audio("u", str(audio_path), str(video_path))
+
+    assert ok is True
+    assert audio_path.read_bytes() == b"audio"
+    assert called == ["extract"]
+
+
+def test_ensure_audio_failure_without_video(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Should return ``False`` if download fails and no video path is provided."""
+    audio_path = tmp_path / "a.mp3"
+
+    def fail_download(url: str, out: str) -> None:  # pragma: no cover - mock
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(audio, "download_audio", fail_download)
+
+    ok = audio.ensure_audio("u", str(audio_path))
+
+    assert ok is False

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,9 @@
+"""Tests for filename sanitization."""
+
+from server.helpers.formatting import sanitize_filename
+
+
+def test_sanitize_filename_replaces_unsafe_chars() -> None:
+    """Unsafe characters should be replaced with underscores."""
+    unsafe = "bad: file/name?.txt"
+    assert sanitize_filename(unsafe) == "bad__file_name_.txt"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,46 @@
+"""Tests for colored timing logs."""
+
+from typing import Iterator
+
+import pytest
+
+from server.helpers import logging as log_helpers
+from server.helpers.formatting import Fore
+
+
+def _counter(vals: list[float]) -> Iterator[float]:
+    for v in vals:
+        yield v
+
+
+def test_run_step_logs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """``run_step`` should print colored messages with elapsed time."""
+    times = _counter([0.0, 1.0])
+    monkeypatch.setattr(log_helpers.time, "perf_counter", lambda: next(times))
+
+    def fn() -> str:
+        return "ok"
+
+    assert log_helpers.run_step("STEP", fn) == "ok"
+    out = capsys.readouterr().out
+    assert Fore.CYAN in out
+    assert Fore.GREEN in out
+    assert "completed" in out
+
+
+def test_log_timing_context(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """``log_timing`` should log start/end with colors."""
+    times = _counter([0.0, 1.0])
+    monkeypatch.setattr(log_helpers.time, "perf_counter", lambda: next(times))
+
+    with log_helpers.log_timing("WORK"):
+        pass
+
+    out = capsys.readouterr().out
+    assert Fore.CYAN in out
+    assert Fore.GREEN in out
+    assert "completed" in out

--- a/tests/test_parse_ffmpeg_silences.py
+++ b/tests/test_parse_ffmpeg_silences.py
@@ -1,0 +1,14 @@
+"""Tests for parsing ffmpeg silencedetect logs."""
+
+from server.steps.candidates.silence import parse_ffmpeg_silences
+
+
+def test_parse_ffmpeg_silences_multiple() -> None:
+    """Should parse multiple silence intervals from sample log text."""
+    log = (
+        "[silencedetect] silence_start: 0.5\n"
+        "[silencedetect] silence_end: 1.0 | silence_duration: 0.5\n"
+        "[silencedetect] silence_start: 2.0\n"
+        "[silencedetect] silence_end: 3.5 | silence_duration: 1.5\n"
+    )
+    assert parse_ffmpeg_silences(log) == [(0.5, 1.0), (2.0, 3.5)]

--- a/tests/test_transcript_io.py
+++ b/tests/test_transcript_io.py
@@ -1,0 +1,28 @@
+"""Tests for transcript writer."""
+
+from pathlib import Path
+
+from server.helpers.transcript import write_transcript_txt
+
+
+def test_write_transcript(tmp_path: Path) -> None:
+    """Segments and timing should be written in a readable format."""
+    out = tmp_path / "t.txt"
+    result = {
+        "segments": [
+            {"start": 0.0, "end": 1.0, "text": "Hello\nworld"},
+            {"start": 1.5, "end": 2.0, "text": "Bye"},
+        ],
+        "timing": {"start_time": 0.0, "stop_time": 2.0, "total_time": 2.0},
+    }
+    write_transcript_txt(result, str(out))
+
+    content = out.read_text(encoding="utf-8")
+    assert content == (
+        "[0.00 -> 1.00] Hello world\n"
+        "[1.50 -> 2.00] Bye\n"
+        "\n# TIMING\n"
+        "start_time: 0.00 seconds\n"
+        "stop_time: 2.00 seconds\n"
+        "total_time: 2.00 seconds\n"
+    )


### PR DESCRIPTION
## Summary
- add sanitization, audio fallback, logging, transcript IO, retry, and silence parsing tests

## Testing
- `PYTHONPATH=. pytest tests/test_formatting.py tests/test_audio.py tests/test_logging.py tests/test_transcript_io.py tests/test_ai_retry.py tests/test_parse_ffmpeg_silences.py`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af8883e9188323a4cd36b744cd8ccc