### PR TITLE
Add dialog range detection and JSON utilities

### DIFF
--- a/server/steps/dialog.py
+++ b/server/steps/dialog.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+from .candidates.helpers import parse_transcript
+
+_KEYWORDS = {"haha", "lol", "joke", "laugh", "laughter"}
+
+
+def detect_dialog_ranges(transcript_path: str | Path, *, gap: float = 1.0) -> List[Tuple[float, float]]:
+    """Detect conversational or joke segments within ``transcript_path``.
+
+    The transcript is expected to contain lines formatted as
+    ``[start -> end] text``.  A simple heuristic is used: any line containing a
+    question mark, an exclamation mark, or one of several laugh-related
+    keywords is marked as dialog.  Consecutive dialog lines, or ones separated
+    by ``gap`` seconds or less, are merged into a single range.
+    """
+
+    items = parse_transcript(transcript_path)
+    ranges: List[Tuple[float, float]] = []
+    current_start: float | None = None
+    current_end: float | None = None
+
+    for start, end, text in items:
+        lowered = text.lower()
+        is_dialog = (
+            "?" in text
+            or "!" in text
+            or any(key in lowered for key in _KEYWORDS)
+        )
+        if is_dialog:
+            if current_start is None:
+                current_start, current_end = start, end
+            elif start - current_end <= gap:
+                current_end = end
+            else:
+                ranges.append((current_start, current_end))
+                current_start, current_end = start, end
+        else:
+            if current_start is not None:
+                ranges.append((current_start, current_end))
+                current_start, current_end = None, None
+
+    if current_start is not None:
+        ranges.append((current_start, current_end))
+
+    return ranges
+
+
+def write_dialog_ranges_json(ranges: Iterable[Tuple[float, float]], path: str | Path) -> None:
+    """Write ``ranges`` to ``path`` in JSON format."""
+    data = [{"start": s, "end": e} for s, e in ranges]
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def load_dialog_ranges_json(path: str | Path) -> List[Tuple[float, float]]:
+    """Load dialog ranges from a JSON file previously written by
+    :func:`write_dialog_ranges_json`."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return [(float(item["start"]), float(item["end"])) for item in data]

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+import sys
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+from server.steps.dialog import (
+    detect_dialog_ranges,
+    write_dialog_ranges_json,
+    load_dialog_ranges_json,
+)
+
+
+def _make_transcript(path: Path) -> None:
+    path.write_text(
+        """
+[0.0 -> 1.0] Hello.
+[1.0 -> 2.0] This is funny haha!
+[2.1 -> 3.0] Are you serious?
+[4.0 -> 5.0] Another statement.
+""".strip()
+    )
+
+
+def test_detect_dialog_ranges(tmp_path: Path) -> None:
+    transcript = tmp_path / "sample.txt"
+    _make_transcript(transcript)
+    ranges = detect_dialog_ranges(str(transcript))
+    assert ranges == [(1.0, 3.0)]
+
+
+def test_json_export_and_load(tmp_path: Path) -> None:
+    transcript = tmp_path / "sample.txt"
+    _make_transcript(transcript)
+    ranges = detect_dialog_ranges(str(transcript))
+    out = tmp_path / "dialog_ranges.json"
+    write_dialog_ranges_json(ranges, out)
+    loaded = load_dialog_ranges_json(out)
+    assert loaded == ranges


### PR DESCRIPTION
## Summary
- implement `detect_dialog_ranges` for parsing transcripts and identifying dialog segments using simple punctuation and keyword heuristics
- provide JSON export and loader helpers for dialog ranges
- add unit tests for detection logic and round-trip JSON serialization

## Testing
- `pytest tests/test_dialog.py -q`
- `pytest -q` *(fails: FileNotFoundError: 'ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68af99aa59708323900342e4910457c9