### PR TITLE
Adjust duration sweet spot for clip scoring

### DIFF
--- a/server/steps/candidates/helpers.py
+++ b/server/steps/candidates/helpers.py
@@ -192,8 +192,8 @@ def snap_end_to_dialog_end(end: float, ranges: List[Tuple[float, float]]) -> flo
 # Unified clip refinement + duration prior
 # -----------------------------
 
-def duration_score(d: float, sweet_min: float = 8.0, sweet_max: float = 30.0) -> float:
-    """Soft prior: 1.0 inside sweet spot; quadratic decay outside."""
+def duration_score(d: float, sweet_min: float = 10.0, sweet_max: float = 30.0) -> float:
+    """Soft prior: 1.0 inside sweet spot (default 10-30s); quadratic decay outside."""
     if d < sweet_min:
         return max(0.0, 1.0 - ((sweet_min - d) / sweet_min) ** 2)
     if d > sweet_max:
@@ -380,7 +380,7 @@ def _enforce_non_overlap(
 
     def score_key(x: ClipCandidate):
         d = x.end - x.start
-        prior = 0.65 + 0.35 * duration_score(d, 8.0, 30.0)
+        prior = 0.65 + 0.35 * duration_score(d, 10.0, 30.0)
         z = (x.rating - mean) / std
         tone_ok = bool(getattr(x, "tone_match", True))
         tone_penalty = 0 if tone_ok else 1


### PR DESCRIPTION
## Summary
- Raise `duration_score` sweet minimum to 10 seconds and document default range
- Update `_enforce_non_overlap` scoring to use new duration sweet spot

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af9e1aeacc8323b5b8bb3d2f0002b6