### PR TITLE
feat: drop short clips

### DIFF
--- a/server/steps/candidates/__init__.py
+++ b/server/steps/candidates/__init__.py
@@ -146,6 +146,7 @@ def find_clip_timestamps_batched(
     exclude_ranges: Optional[List[Tuple[float, float]]] = None,
     silences: Optional[List[Tuple[float, float]]] = None,
     words: Optional[List[dict]] = None,
+    min_duration_seconds: float = 10.0,
     return_all_stages: bool = False,
 ) -> List[ClipCandidate] | tuple[List[ClipCandidate], List[ClipCandidate], List[ClipCandidate]]:
     """Chunk the transcript and query the model per-chunk to avoid context/HTTP timeouts."""
@@ -228,7 +229,11 @@ def find_clip_timestamps_batched(
         silences=silences,
     )
     top_candidates = _enforce_non_overlap(
-        all_candidates, items, words=words, silences=silences
+        all_candidates,
+        items,
+        words=words,
+        silences=silences,
+        min_duration_seconds=min_duration_seconds,
     )
     print(f"[Batch] {len(top_candidates)} candidates remain after overlap enforcement.")
     verified_candidates = [
@@ -261,6 +266,7 @@ def find_clip_timestamps(
     options: Optional[dict] = None,
     silences: Optional[List[Tuple[float, float]]] = None,
     words: Optional[List[dict]] = None,
+    min_duration_seconds: float = 10.0,
     return_all_stages: bool = False,
 ) -> List[ClipCandidate] | tuple[List[ClipCandidate], List[ClipCandidate], List[ClipCandidate]]:
     """Use a local Ollama model (gemma3) to score transcript lines and propose clip windows."""
@@ -322,7 +328,11 @@ def find_clip_timestamps(
         silences=silences,
     )
     top_candidates = _enforce_non_overlap(
-        all_candidates, items, words=words, silences=silences
+        all_candidates,
+        items,
+        words=words,
+        silences=silences,
+        min_duration_seconds=min_duration_seconds,
     )
     verified_candidates = [
         c

--- a/tests/test_candidate_ranking.py
+++ b/tests/test_candidate_ranking.py
@@ -12,7 +12,7 @@ from server.interfaces.clip_candidate import ClipCandidate
 
 
 def test_tone_aligned_prioritized() -> None:
-    items = [(0.0, 2.0, "a"), (2.0, 4.0, "b")]
+    items = [(0.0, 12.0, "A"), (12.0, 24.0, "B")]
     good = ClipCandidate(start=0.0, end=1.0, rating=5.0, reason="", quote="")
     bad = ClipCandidate(start=0.0, end=1.0, rating=9.0, reason="", quote="")
     good.tone_match = True
@@ -22,7 +22,7 @@ def test_tone_aligned_prioritized() -> None:
     assert len(result) == 1
     chosen = result[0]
     assert chosen.rating == good.rating
-    assert chosen.start == 0.0 and chosen.end == 4.0
+    assert chosen.start == 0.0 and chosen.end == 12.0
 
 
 def test_sweet_spot_clip_preferred() -> None:
@@ -39,3 +39,10 @@ def test_sweet_spot_clip_preferred() -> None:
     assert len(result) == 1
     chosen = result[0]
     assert chosen.start == 0.0 and chosen.end == 16.0
+
+
+def test_short_clips_discarded() -> None:
+    items = [(0.0, 5.0, "A"), (5.0, 10.0, "B")]
+    short = ClipCandidate(start=0.0, end=4.0, rating=8.0, reason="", quote="")
+    result = _enforce_non_overlap([short], items)
+    assert result == []


### PR DESCRIPTION
## Summary
- add min_duration_seconds threshold to _enforce_non_overlap and filter short clips
- plumb min_duration_seconds through find_clip_timestamps and batched variant
- test that clips under 10 seconds are discarded

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afa063f41c8323886b1b3304cde70f