### PR TITLE
Add playlist support for YouTube processing

### DIFF
--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -1,5 +1,10 @@
 from steps.transcribe import transcribe_audio
-from steps.download import download_transcript, download_video, get_video_info
+from steps.download import (
+    download_transcript,
+    download_video,
+    get_video_info,
+    get_video_urls,
+)
 from steps.candidates.funny import find_funny_timestamps_batched
 from steps.candidates.inspiring import find_inspiring_timestamps_batched
 from steps.candidates.educational import find_educational_timestamps_batched
@@ -39,15 +44,8 @@ from helpers.logging import run_step
 from steps.candidates import ClipCandidate
 
 
-if __name__ == "__main__":
+def process_video(yt_url: str) -> None:
     overall_start = time.perf_counter()
-
-    # yt_url = "https://www.youtube.com/watch?v=GDbDRWzFfds" #KFAF 1
-    yt_url = "https://www.youtube.com/watch?v=zZYxqZFThls" #KFAF 2
-    # yt_url = "https://www.youtube.com/watch?v=K9aFbYd6AUI" #Superman
-    # yt_url = "https://www.youtube.com/watch?v=os2AyD_4RjM" #Dark phoenix
-    # yt_url = "https://www.youtube.com/watch?v=JM1KbE-C9XE" #KFAF Nicks 40th birthday
-    # yt_url = input("Enter YouTube video URL: ")
 
     CLIP_TYPE = "funny"  # change to 'inspiring' or 'educational'
     MIN_RATING = 7.0
@@ -274,3 +272,16 @@ if __name__ == "__main__":
     print(
         f"{Fore.MAGENTA}Full pipeline completed in {total_elapsed:.2f}s{Style.RESET_ALL}"
     )
+
+
+if __name__ == "__main__":
+    # yt_url = "https://www.youtube.com/watch?v=GDbDRWzFfds" #KFAF 1
+    yt_url = "https://www.youtube.com/watch?v=zZYxqZFThls"  # KFAF 2
+    # yt_url = "https://www.youtube.com/watch?v=K9aFbYd6AUI" #Superman
+    # yt_url = "https://www.youtube.com/watch?v=os2AyD_4RjM" #Dark phoenix
+    # yt_url = "https://www.youtube.com/watch?v=JM1KbE-C9XE" #KFAF Nicks 40th birthday
+    # yt_url = input("Enter YouTube video URL: ")
+
+    urls = get_video_urls(yt_url)
+    for url in urls:
+        process_video(url)

--- a/server/steps/download.py
+++ b/server/steps/download.py
@@ -18,6 +18,42 @@ def extract_video_id(url: str) -> str:
         video_id = url
     return video_id
 
+
+def get_video_urls(url: str) -> list[str]:
+    """Return a list of video URLs for the provided YouTube link.
+
+    If the URL points to a playlist, this returns URLs for each entry.
+    Otherwise the original URL is returned in a single-item list. Entries
+    that cannot be resolved to a usable URL are skipped.
+    """
+
+    ydl_opts = {
+        "quiet": True,
+        "extract_flat": True,
+        "force_flat_playlist": True,
+        "no_warnings": True,
+    }
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(url, download=False)
+
+    if not info:
+        return []
+
+    entries = info.get("entries")
+    if not entries:
+        return [url]
+
+    urls: list[str] = []
+    for entry in entries:
+        entry_url = entry.get("url")
+        if not entry_url:
+            video_id = entry.get("id")
+            if video_id:
+                entry_url = f"https://www.youtube.com/watch?v={video_id}"
+        if entry_url:
+            urls.append(entry_url)
+    return urls
+
 def get_video_info(url):
     ydl_opts = {
         'quiet': True,

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -1,0 +1,27 @@
+import yt_dlp
+from unittest.mock import MagicMock, patch
+
+from server.steps.download import get_video_urls
+
+
+def test_get_video_urls_playlist():
+    ydl = MagicMock()
+    ydl.__enter__.return_value = ydl
+    ydl.extract_info.return_value = {
+        "entries": [{"id": "abc"}, {"id": "def"}]
+    }
+    with patch("server.steps.download.yt_dlp.YoutubeDL", return_value=ydl):
+        urls = get_video_urls("https://www.youtube.com/playlist?list=xyz")
+    assert urls == [
+        "https://www.youtube.com/watch?v=abc",
+        "https://www.youtube.com/watch?v=def",
+    ]
+
+
+def test_get_video_urls_single_video():
+    ydl = MagicMock()
+    ydl.__enter__.return_value = ydl
+    ydl.extract_info.return_value = {"id": "abc"}
+    with patch("server.steps.download.yt_dlp.YoutubeDL", return_value=ydl):
+        urls = get_video_urls("https://www.youtube.com/watch?v=abc")
+    assert urls == ["https://www.youtube.com/watch?v=abc"]


### PR DESCRIPTION
## Summary
- Allow determining playlist URLs and expanding them into video URLs
- Run pipeline on every video in a playlist while still supporting single videos
- Test playlist URL expansion logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afb06b59a88323adaa12c8a457b46a