### PR TITLE
Make candidate merging optional

### DIFF
--- a/server/steps/candidates/__init__.py
+++ b/server/steps/candidates/__init__.py
@@ -148,6 +148,7 @@ def find_clip_timestamps_batched(
     silences: Optional[List[Tuple[float, float]]] = None,
     words: Optional[List[dict]] = None,
     min_duration_seconds: float = MIN_DURATION_SECONDS,
+    merge_overlapping: bool = False,
     return_all_stages: bool = False,
 ) -> List[ClipCandidate] | tuple[List[ClipCandidate], List[ClipCandidate], List[ClipCandidate]]:
     """Chunk the transcript and query the model per-chunk to avoid context/HTTP timeouts."""
@@ -229,6 +230,7 @@ def find_clip_timestamps_batched(
         max_duration_seconds=MAX_DURATION_SECONDS,
         words=words,
         silences=silences,
+        merge_overlaps=merge_overlapping,
     )
     top_candidates = _enforce_non_overlap(
         filtered_candidates,
@@ -269,6 +271,7 @@ def find_clip_timestamps(
     silences: Optional[List[Tuple[float, float]]] = None,
     words: Optional[List[dict]] = None,
     min_duration_seconds: float = MIN_DURATION_SECONDS,
+    merge_overlapping: bool = False,
     return_all_stages: bool = False,
 ) -> List[ClipCandidate] | tuple[List[ClipCandidate], List[ClipCandidate], List[ClipCandidate]]:
     """Use a local Ollama model (gemma3) to score transcript lines and propose clip windows."""
@@ -328,6 +331,7 @@ def find_clip_timestamps(
         max_duration_seconds=MAX_DURATION_SECONDS,
         words=words,
         silences=silences,
+        merge_overlaps=merge_overlapping,
     )
     top_candidates = _enforce_non_overlap(
         all_candidates,

--- a/server/steps/candidates/helpers.py
+++ b/server/steps/candidates/helpers.py
@@ -302,8 +302,9 @@ def _merge_adjacent_candidates(
     max_duration_seconds: float = MAX_DURATION_SECONDS,
     words: Optional[List[dict]] = None,
     silences: Optional[List[Tuple[float, float]]] = None,
+    merge_overlaps: bool = False,
 ) -> List[ClipCandidate]:
-    """Merge candidates that overlap or are separated by a tiny gap, to preserve full jokes/bits."""
+    """Snap candidate boundaries and optionally merge adjacent/overlapping candidates."""
     if not candidates:
         return []
 
@@ -322,6 +323,9 @@ def _merge_adjacent_candidates(
         return []
 
     snapped.sort(key=lambda c: (c.start, c.end))
+    if not merge_overlaps:
+        return snapped
+
     merged: List[ClipCandidate] = []
     cur = snapped[0]
 

--- a/tests/test_candidate_ranking.py
+++ b/tests/test_candidate_ranking.py
@@ -46,7 +46,7 @@ def test_shorter_clip_preferred() -> None:
 def test_short_clips_discarded() -> None:
     items = [(0.0, 5.0, "A"), (5.0, 10.0, "B")]
     short = ClipCandidate(start=0.0, end=4.0, rating=8.0, reason="", quote="")
-    result = _enforce_non_overlap([short], items)
+    result = _enforce_non_overlap([short], items, min_duration_seconds=10.0)
     assert result == []
 
 
@@ -59,7 +59,7 @@ def test_clips_under_ten_seconds_excluded() -> None:
     ]
     short = ClipCandidate(start=0.0, end=5.0, rating=7.0, reason="", quote="")
     long = ClipCandidate(start=0.0, end=14.0, rating=7.0, reason="", quote="")
-    result = _enforce_non_overlap([short, long], items)
+    result = _enforce_non_overlap([short, long], items, min_duration_seconds=10.0)
     assert len(result) == 1
     chosen = result[0]
     assert chosen.start == 0.0 and chosen.end == 20.0

--- a/tests/test_merge_optional.py
+++ b/tests/test_merge_optional.py
@@ -1,0 +1,19 @@
+from server.interfaces.clip_candidate import ClipCandidate
+from server.steps.candidates.helpers import _merge_adjacent_candidates
+
+
+def test_merge_overlaps_flag_controls_behavior():
+    items = [(0.0, 1.0, "a"), (1.0, 2.0, "b")]
+    c1 = ClipCandidate(start=0.0, end=1.0, rating=5, reason="", quote="")
+    c2 = ClipCandidate(start=1.0, end=2.0, rating=6, reason="", quote="")
+
+    without_merge = _merge_adjacent_candidates(
+        [c1, c2], items, merge_overlaps=False
+    )
+    assert len(without_merge) == 2
+
+    with_merge = _merge_adjacent_candidates(
+        [c1, c2], items, merge_overlaps=True
+    )
+    assert len(with_merge) == 1
+    assert with_merge[0].start == 0.0 and with_merge[0].end == 2.0


### PR DESCRIPTION
## Summary
- Allow `_merge_adjacent_candidates` to optionally merge overlapping windows and disable merging by default
- Expose `merge_overlapping` flag in `find_clip_timestamps` APIs
- Test optional merging behavior and update candidate ranking tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afbafa7a90832388597539435ec1a7