### PR TITLE
feat: add multi-platform upload pipeline

### DIFF
--- a/server/upload/__init__.py
+++ b/server/upload/__init__.py
@@ -1,0 +1,3 @@
+from .pipeline import UploadConfig, upload_video_to_all
+
+__all__ = ["UploadConfig", "upload_video_to_all"]

--- a/server/upload/pipeline.py
+++ b/server/upload/pipeline.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+
+from helpers.logging import run_step
+from .steps.instagram import upload_instagram
+from .steps.tiktok import upload_tiktok
+from .steps.youtube import upload_youtube
+from .steps.facebook import upload_facebook
+from .steps.snapchat import upload_snapchat
+from .steps.twitter import upload_twitter
+
+
+@dataclass
+class UploadConfig:
+    """Configuration for upload targets."""
+
+    instagram_account: str
+    tiktok_account: str
+    youtube_account: str
+    facebook_page: str
+    snapchat_account: str
+    twitter_account: str
+
+
+def upload_video_to_all(
+    video_path: str,
+    caption: str,
+    title: str,
+    description: str,
+    config: UploadConfig,
+) -> None:
+    """Upload ``video_path`` to all configured platforms.
+
+    Each step is wrapped in ``run_step`` for consistent logging.
+    """
+
+    run_step(
+        "Upload to Instagram",
+        upload_instagram,
+        video_path,
+        caption,
+        config.instagram_account,
+    )
+    run_step(
+        "Upload to TikTok",
+        upload_tiktok,
+        video_path,
+        caption,
+        config.tiktok_account,
+    )
+    run_step(
+        "Upload to YouTube",
+        upload_youtube,
+        video_path,
+        title,
+        description,
+        config.youtube_account,
+    )
+    run_step(
+        "Upload to Facebook",
+        upload_facebook,
+        video_path,
+        caption,
+        config.facebook_page,
+    )
+    run_step(
+        "Upload to Snapchat",
+        upload_snapchat,
+        video_path,
+        caption,
+        config.snapchat_account,
+    )
+    run_step(
+        "Upload to Twitter",
+        upload_twitter,
+        video_path,
+        caption,
+        config.twitter_account,
+    )

--- a/server/upload/steps/__init__.py
+++ b/server/upload/steps/__init__.py
@@ -1,0 +1,15 @@
+from .instagram import upload_instagram
+from .tiktok import upload_tiktok
+from .youtube import upload_youtube
+from .facebook import upload_facebook
+from .snapchat import upload_snapchat
+from .twitter import upload_twitter
+
+__all__ = [
+    "upload_instagram",
+    "upload_tiktok",
+    "upload_youtube",
+    "upload_facebook",
+    "upload_snapchat",
+    "upload_twitter",
+]

--- a/server/upload/steps/facebook.py
+++ b/server/upload/steps/facebook.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+
+def upload_facebook(video_path: str, caption: str, page_id: str, token: Optional[str] = None) -> None:
+    """Upload and publish a video to a Facebook page.
+
+    Facebook uploads use the Graph API. A real implementation would
+    POST the file to the page's /videos edge with a valid user token.
+    """
+    print(f"Uploading {video_path} to Facebook page {page_id}")
+    # Example structure for a real implementation:
+    # import requests
+    # api_url = f"https://graph-video.facebook.com/v18.0/{page_id}/videos"
+    # files = {"file": open(video_path, "rb")}
+    # data = {"description": caption, "access_token": token}
+    # response = requests.post(api_url, files=files, data=data, timeout=30)
+    # response.raise_for_status()

--- a/server/upload/steps/instagram.py
+++ b/server/upload/steps/instagram.py
@@ -1,0 +1,18 @@
+from typing import Optional
+
+
+def upload_instagram(video_path: str, caption: str, account: str, token: Optional[str] = None) -> None:
+    """Upload and post a video to an Instagram account.
+
+    This is a placeholder demonstrating how an upload might be structured.
+    A real implementation must obtain a valid access token and adhere to
+    Instagram's Graph API requirements.
+    """
+    print(f"Uploading {video_path} to Instagram account {account}")
+    # Example structure for a real implementation:
+    # import requests
+    # api_url = f"https://graph.facebook.com/v18.0/{account}/media"
+    # files = {"video": open(video_path, "rb")}
+    # data = {"caption": caption, "access_token": token}
+    # response = requests.post(api_url, files=files, data=data, timeout=30)
+    # response.raise_for_status()

--- a/server/upload/steps/snapchat.py
+++ b/server/upload/steps/snapchat.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+
+def upload_snapchat(video_path: str, caption: str, account: str, token: Optional[str] = None) -> None:
+    """Upload and post a video to Snapchat Spotlight or a public profile.
+
+    Snapchat's Marketing API can be used for uploads; this function is a stub
+    indicating where that integration would occur.
+    """
+    print(f"Uploading {video_path} to Snapchat account {account}")
+    # Example structure for a real implementation:
+    # import requests
+    # api_url = "https://adsapi.snapchat.com/v1/media/upload"
+    # files = {"file": open(video_path, "rb")}
+    # headers = {"Authorization": f"Bearer {token}"}
+    # response = requests.post(api_url, files=files, headers=headers, timeout=30)
+    # response.raise_for_status()

--- a/server/upload/steps/tiktok.py
+++ b/server/upload/steps/tiktok.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+
+def upload_tiktok(video_path: str, caption: str, account: str, token: Optional[str] = None) -> None:
+    """Upload and post a video to a TikTok account.
+
+    The TikTok API requires an OAuth flow and video upload endpoint.
+    This function serves as a placeholder for that interaction.
+    """
+    print(f"Uploading {video_path} to TikTok account {account}")
+    # Example structure for a real implementation:
+    # import requests
+    # api_url = "https://open-api.tiktok.com/video/upload/"
+    # files = {"video": open(video_path, "rb")}
+    # data = {"caption": caption, "access_token": token}
+    # response = requests.post(api_url, files=files, data=data, timeout=30)
+    # response.raise_for_status()

--- a/server/upload/steps/twitter.py
+++ b/server/upload/steps/twitter.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+
+def upload_twitter(video_path: str, caption: str, account: str, token: Optional[str] = None) -> None:
+    """Upload and tweet a video on Twitter (X).
+
+    Twitter's v2 API uses a chunked media upload sequence. This function is a
+    placeholder showing where that logic would be implemented.
+    """
+    print(f"Uploading {video_path} to Twitter account {account}")
+    # Example structure for a real implementation:
+    # import requests
+    # INIT, APPEND and FINALIZE upload steps would be performed here using
+    # the 'media/upload' endpoint followed by a POST to 'tweets'.

--- a/server/upload/steps/youtube.py
+++ b/server/upload/steps/youtube.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+
+def upload_youtube(video_path: str, title: str, description: str, account: str, token: Optional[str] = None) -> None:
+    """Upload a video to YouTube and publish it.
+
+    A complete implementation would use the Google API client to
+    authenticate and send the video to the YouTube Data API.
+    """
+    print(f"Uploading {video_path} to YouTube channel {account}")
+    # Example structure for a real implementation:
+    # from googleapiclient.discovery import build
+    # youtube = build("youtube", "v3", developerKey=token)
+    # request = youtube.videos().insert(
+    #     part="snippet,status",
+    #     body={
+    #         "snippet": {"title": title, "description": description},
+    #         "status": {"privacyStatus": "public"},
+    #     },
+    #     media_body=video_path,
+    # )
+    # request.execute()


### PR DESCRIPTION
## Summary
- add upload pipeline with configurable accounts per platform
- create stub upload steps for Instagram, TikTok, YouTube, Facebook, Snapchat, and Twitter

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afc7ae227883238e81a91c33ca971c