### PR TITLE
Filter promotional ad reads from clip candidates

### DIFF
--- a/tests/test_ad_filter.py
+++ b/tests/test_ad_filter.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+import server.steps.candidates as cand_pkg
+from server.steps.candidates.funny import find_funny_timestamps
+
+
+def test_promotional_segments_rejected(tmp_path: Path, monkeypatch) -> None:
+    transcript = tmp_path / "t.txt"
+    transcript.write_text(
+        "[0.00 -> 5.00] This episode is brought to you by our patrons on Patreon.\n",
+        encoding="utf-8",
+    )
+
+    def fake_ollama_call_json(model, prompt, options=None, timeout=None):
+        if not hasattr(fake_ollama_call_json, "calls"):
+            fake_ollama_call_json.calls = 0
+        fake_ollama_call_json.calls += 1
+        if fake_ollama_call_json.calls == 1:
+            return [
+                {
+                    "start": 0.0,
+                    "end": 5.0,
+                    "rating": 9,
+                    "reason": "promo",
+                    "quote": "patreon plug",
+                }
+            ]
+        return {"match": True}
+
+    monkeypatch.setattr(cand_pkg, "ollama_call_json", fake_ollama_call_json)
+
+    result = find_funny_timestamps(str(transcript), min_words=1)
+    assert result == []


### PR DESCRIPTION
## Summary
- filter candidates mentioning sponsors, ads, or Patreon
- add regression test for promotional clip rejection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b04a69fba483239aacbaefd9e61a28