### PR TITLE
Add LM Studio support and default to it on macOS

### DIFF
--- a/server/helpers/ai.py
+++ b/server/helpers/ai.py
@@ -1,17 +1,25 @@
 import json
 import os
+import platform
 import re
 import time
-from typing import Callable, Any, Optional, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 import requests
 from requests.exceptions import RequestException
 
-# Default URL for a local Ollama server. Can be overridden via environment.
+# Default URLs for local model servers. Can be overridden via environment.
 OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+LMSTUDIO_URL = os.environ.get("LMSTUDIO_URL", "http://localhost:1234")
 
 # Regex to salvage the first JSON array from a response.
 DEFAULT_JSON_EXTRACT = re.compile(r"\[(?:.|\n)*\]")
+
+# Determine which local LLM provider to use. Default to LM Studio on macOS.
+LOCAL_LLM_PROVIDER = os.environ.get(
+    "LOCAL_LLM_PROVIDER",
+    "lmstudio" if platform.system() == "Darwin" else "ollama",
+)
 
 
 def ollama_generate(
@@ -21,10 +29,7 @@ def ollama_generate(
     options: Optional[dict] = None,
     timeout: int = 120,
 ) -> str:
-    """Call Ollama's /api/generate endpoint.
-
-    Returns the raw response string.
-    """
+    """Call Ollama's /api/generate endpoint and return the raw response string."""
     payload = {
         "model": model,
         "prompt": prompt,
@@ -74,6 +79,92 @@ def ollama_call_json(
     return json.loads(m.group(0))
 
 
+def lmstudio_generate(
+    model: str,
+    prompt: str,
+    json_format: bool = True,
+    options: Optional[dict] = None,
+    timeout: int = 120,
+) -> str:
+    """Call LM Studio's OpenAI compatible endpoint and return raw content."""
+    payload: Dict[str, Any] = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+    }
+    if json_format:
+        payload["response_format"] = {"type": "json_object"}
+    if options:
+        payload.update(options)
+    url = f"{LMSTUDIO_URL}/v1/chat/completions"
+    resp = requests.post(url, json=payload, timeout=timeout)
+    resp.raise_for_status()
+    data = resp.json()
+    choices = data.get("choices", [])
+    if not choices:
+        return ""
+    return choices[0].get("message", {}).get("content", "").strip()
+
+
+def lmstudio_call_json(
+    model: str,
+    prompt: str,
+    *,
+    options: Optional[dict] = None,
+    timeout: int = 120,
+    extract_re: re.Pattern[str] = DEFAULT_JSON_EXTRACT,
+) -> List[Dict]:
+    """Call LM Studio and return parsed JSON array with robust fallback."""
+    try:
+        raw = lmstudio_generate(
+            model=model,
+            prompt=prompt,
+            json_format=True,
+            options=options,
+            timeout=timeout,
+        )
+    except RequestException as e:
+        raise RuntimeError(f"LM Studio request failed: {e}")
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict) and "items" in parsed:
+            parsed = parsed["items"]
+        if isinstance(parsed, list):
+            return parsed
+    except Exception:
+        pass
+    m = extract_re.search(raw)
+    if not m:
+        raise ValueError(f"Model did not return JSON array. Raw head: {raw[:300]}")
+    return json.loads(m.group(0))
+
+
+def local_llm_call_json(
+    model: str,
+    prompt: str,
+    *,
+    options: Optional[dict] = None,
+    timeout: int = 120,
+    extract_re: re.Pattern[str] = DEFAULT_JSON_EXTRACT,
+) -> List[Dict]:
+    """Call the configured local LLM provider and parse JSON array output."""
+    if LOCAL_LLM_PROVIDER.lower() == "lmstudio":
+        return lmstudio_call_json(
+            model=model,
+            prompt=prompt,
+            options=options,
+            timeout=timeout,
+            extract_re=extract_re,
+        )
+    return ollama_call_json(
+        model=model,
+        prompt=prompt,
+        options=options,
+        timeout=timeout,
+        extract_re=extract_re,
+    )
+
+
 def retry(fn: Callable[[], Any], *, attempts: int = 3, backoff: float = 1.5):
     """Retry ``fn`` up to ``attempts`` times with exponential backoff."""
     last_exc = None
@@ -84,12 +175,15 @@ def retry(fn: Callable[[], Any], *, attempts: int = 3, backoff: float = 1.5):
             last_exc = e
             if i == attempts - 1:
                 break
-            time.sleep(backoff ** i)
+            time.sleep(backoff**i)
     raise last_exc
 
 
 __all__ = [
     "ollama_generate",
     "ollama_call_json",
+    "lmstudio_generate",
+    "lmstudio_call_json",
+    "local_llm_call_json",
     "retry",
 ]

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -41,7 +41,7 @@ from helpers.audio import ensure_audio
 from helpers.transcript import write_transcript_txt
 from helpers.formatting import Fore, Style, sanitize_filename
 from helpers.logging import run_step
-from helpers.ai import ollama_call_json
+from helpers.ai import local_llm_call_json
 from steps.candidates import ClipCandidate
 
 
@@ -280,7 +280,7 @@ def process_video(yt_url: str) -> None:
                 f"Quote: {candidate.quote}"
             )
             try:
-                tags = ollama_call_json(
+                tags = local_llm_call_json(
                     model="gemma3",
                     prompt=prompt,
                     options={"temperature": 0.0},

--- a/server/steps/candidates/__init__.py
+++ b/server/steps/candidates/__init__.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Tuple
 from pathlib import Path
 import re
 
-from helpers.ai import ollama_call_json, retry
+from helpers.ai import local_llm_call_json, retry
 from interfaces.clip_candidate import ClipCandidate
 from .config import MAX_DURATION_SECONDS, MIN_DURATION_SECONDS
 
@@ -111,7 +111,7 @@ def _verify_tone(
         )
         try:
             try:
-                out = ollama_call_json(
+                out = local_llm_call_json(
                     model=model,
                     prompt=prompt,
                     options={"temperature": 0.0},
@@ -119,7 +119,7 @@ def _verify_tone(
                     extract_re=JSON_OBJECT_EXTRACT,
                 )
             except TypeError:
-                out = ollama_call_json(
+                out = local_llm_call_json(
                     model=model,
                     prompt=prompt,
                     options={"temperature": 0.0},
@@ -198,7 +198,7 @@ def find_clip_timestamps_batched(
         prompt = f"{system_instructions}\n\nTRANSCRIPT (time-coded):\n{condensed}\n\nReturn JSON now."
 
         def _call():
-            return ollama_call_json(
+            return local_llm_call_json(
                 model=model,
                 prompt=prompt,
                 options=combined_options,
@@ -324,7 +324,7 @@ def find_clip_timestamps(
     )
 
     print("[Single] Sending transcript to model for timestamp extraction...")
-    parsed = ollama_call_json(model=model, prompt=prompt, options=options)
+    parsed = local_llm_call_json(model=model, prompt=prompt, options=options)
     print(f"[Single] Model returned {len(parsed)} raw candidates before filtering.")
     candidates: List[ClipCandidate] = []
     for it in parsed:

--- a/tests/test_ad_filter.py
+++ b/tests/test_ad_filter.py
@@ -19,11 +19,11 @@ def test_promotional_segments_rejected(tmp_path: Path, monkeypatch) -> None:
         encoding="utf-8",
     )
 
-    def fake_ollama_call_json(model, prompt, options=None, timeout=None):
-        if not hasattr(fake_ollama_call_json, "calls"):
-            fake_ollama_call_json.calls = 0
-        fake_ollama_call_json.calls += 1
-        if fake_ollama_call_json.calls == 1:
+    def fake_local_llm_call_json(model, prompt, options=None, timeout=None):
+        if not hasattr(fake_local_llm_call_json, "calls"):
+            fake_local_llm_call_json.calls = 0
+        fake_local_llm_call_json.calls += 1
+        if fake_local_llm_call_json.calls == 1:
             return [
                 {
                     "start": 0.0,
@@ -35,7 +35,7 @@ def test_promotional_segments_rejected(tmp_path: Path, monkeypatch) -> None:
             ]
         return {"match": True}
 
-    monkeypatch.setattr(cand_pkg, "ollama_call_json", fake_ollama_call_json)
+    monkeypatch.setattr(cand_pkg, "local_llm_call_json", fake_local_llm_call_json)
 
     result = find_funny_timestamps(str(transcript), min_words=1)
     assert result == []

--- a/tests/test_funny_filter.py
+++ b/tests/test_funny_filter.py
@@ -15,11 +15,11 @@ def test_non_funny_segments_rejected(tmp_path: Path, monkeypatch) -> None:
     transcript = tmp_path / "t.txt"
     transcript.write_text("[0.00 -> 3.00] This is a very serious discussion about science.\n", encoding="utf-8")
 
-    def fake_ollama_call_json(model, prompt, options=None, timeout=None):
-        if not hasattr(fake_ollama_call_json, "calls"):
-            fake_ollama_call_json.calls = 0
-        fake_ollama_call_json.calls += 1
-        if fake_ollama_call_json.calls == 1:
+    def fake_local_llm_call_json(model, prompt, options=None, timeout=None):
+        if not hasattr(fake_local_llm_call_json, "calls"):
+            fake_local_llm_call_json.calls = 0
+        fake_local_llm_call_json.calls += 1
+        if fake_local_llm_call_json.calls == 1:
             return [
                 {
                     "start": 0.0,
@@ -31,7 +31,7 @@ def test_non_funny_segments_rejected(tmp_path: Path, monkeypatch) -> None:
             ]
         return {"match": False}
 
-    monkeypatch.setattr(cand_pkg, "ollama_call_json", fake_ollama_call_json)
+    monkeypatch.setattr(cand_pkg, "local_llm_call_json", fake_local_llm_call_json)
 
     result = find_funny_timestamps(str(transcript), min_words=1)
     assert result == []


### PR DESCRIPTION
## Summary
- add LM Studio client and environment-based provider selection
- use provider-agnostic `local_llm_call_json` throughout pipeline
- update tests for new interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b05ca821b083239df7ed3242c96f17