### PR TITLE
Enforce strict rating threshold above seven

### DIFF
--- a/server/steps/candidates/__init__.py
+++ b/server/steps/candidates/__init__.py
@@ -221,7 +221,7 @@ def find_clip_timestamps_batched(
                 continue
             if not (min_ts <= start < end <= max_ts):
                 continue
-            if rating < min_rating:
+            if rating <= min_rating:
                 continue
             all_candidates.append(
                 ClipCandidate(
@@ -337,7 +337,7 @@ def find_clip_timestamps(
             continue
         if not (min_ts <= start < end <= max_ts):
             continue
-        if rating < min_rating:
+        if rating <= min_rating:
             continue
         candidates.append(
             ClipCandidate(

--- a/server/steps/candidates/prompts.py
+++ b/server/steps/candidates/prompts.py
@@ -32,9 +32,9 @@ def _build_system_instructions(prompt_desc: str, min_rating: float) -> str:
     return (
         f"You are ranking moments that are most aligned with this target: {prompt_desc}\n"
         "Return a JSON array ONLY. Each item MUST be: "
-        '{"start": number, "end": number, "rating": 1-10 number, '
+        '{"start": number, "end": number, "rating": 0-10 number, '
         '"reason": string, "quote": string, "tags": string[]}\n'
-        f"Include ONLY items with rating >= {min_rating}.\n"
+        f"Include ONLY items with rating > {min_rating}.\n"
         "RUBRIC (all must be true for inclusion):\n"
         "- Relevance: The moment strongly reflects the target described above.\n"
         "- Coherence: It forms a self-contained beat; the audience will understand without extra context.\n"
@@ -52,6 +52,10 @@ def _build_system_instructions(prompt_desc: str, min_rating: float) -> str:
         "9–10: extremely aligned, highly engaging, shareable.\n"
         "8: clearly strong, likely to resonate with most viewers.\n"
         "7: decent; include only if there are few stronger options in this span.\n"
+        "6: borderline; noticeable issues with relevance, clarity, or engagement.\n"
+        "5: weak; minimal relevance or impact.\n"
+        "3–4: poor; off-target or confusing.\n"
+        "0–2: not relevant, incoherent, or unusable.\n"
         "POST-PROCESSING (automated filters applied after your response; craft clips that survive them):\n"
         "- Segments with promotional content are dropped—avoid promos entirely.\n"
         "- Start/end times snap to dialog boundaries and adjacent or overlapping clips may merge—pick clean boundaries and limit overlap.\n"

--- a/tests/test_funny_filter.py
+++ b/tests/test_funny_filter.py
@@ -36,3 +36,26 @@ def test_non_funny_segments_rejected(tmp_path: Path, monkeypatch) -> None:
     result = find_funny_timestamps(str(transcript), min_words=1)
     assert result == []
 
+
+def test_rating_threshold_excludes_seven(tmp_path: Path, monkeypatch) -> None:
+    transcript = tmp_path / "t.txt"
+    transcript.write_text("[0.00 -> 3.00] Placeholder text.\n", encoding="utf-8")
+
+    def fake_local_llm_call_json(model, prompt, options=None, timeout=None):
+        assert not hasattr(fake_local_llm_call_json, "called"), "tone check should not run"
+        fake_local_llm_call_json.called = True
+        return [
+            {
+                "start": 0.0,
+                "end": 3.0,
+                "rating": 7,
+                "reason": "meh",
+                "quote": "placeholder",
+            }
+        ]
+
+    monkeypatch.setattr(cand_pkg, "local_llm_call_json", fake_local_llm_call_json)
+
+    result = find_funny_timestamps(str(transcript), min_rating=7.0, min_words=1)
+    assert result == []
+


### PR DESCRIPTION
## Summary
- Allow LLM prompts to use a 0-10 rating scale
- Require clip candidates to have ratings above the minimum threshold
- Clarify scoring guide with descriptions for ratings below seven
- Add test ensuring rating 7 is filtered out

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0624cb4448323b5aae2b07a7b1ab4