### PR TITLE
Link descriptions to clip start timestamps

### DIFF
--- a/server/helpers/formatting.py
+++ b/server/helpers/formatting.py
@@ -8,4 +8,11 @@ def sanitize_filename(title: str) -> str:
     """Return a filesystem-safe version of ``title``."""
     return ''.join(char if char.isalnum() or char in '._-' else '_' for char in title)
 
-__all__ = ["Fore", "Style", "sanitize_filename"]
+
+def youtube_timestamp_url(url: str, start: float) -> str:
+    """Return the given YouTube ``url`` with a timestamp for ``start`` seconds."""
+    delimiter = '&' if '?' in url else '?'
+    seconds = int(round(start))
+    return f"{url}{delimiter}t={seconds}s"
+
+__all__ = ["Fore", "Style", "sanitize_filename", "youtube_timestamp_url"]

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -40,7 +40,12 @@ from pathlib import Path
 
 from helpers.audio import ensure_audio
 from helpers.transcript import write_transcript_txt
-from helpers.formatting import Fore, Style, sanitize_filename
+from helpers.formatting import (
+    Fore,
+    Style,
+    sanitize_filename,
+    youtube_timestamp_url,
+)
 from helpers.logging import run_step
 from helpers.ai import local_llm_call_json
 from steps.candidates import ClipCandidate
@@ -307,8 +312,9 @@ def process_video(yt_url: str) -> None:
                 ][:3]
                 hashtags.extend(fallback)
             hashtags.extend(["#shorts", "#madebyatropos"])
+            full_video_link = youtube_timestamp_url(yt_url, candidate.start)
             description = (
-                f"Full video: {yt_url}\n"
+                f"Full video: {full_video_link}\n"
                 f"Credit: {video_info.get('uploader', 'Unknown Channel')}\n"
                 "Made by Atropos\n\n"
                 + " ".join(hashtags)

--- a/tests/test_youtube_timestamp_url.py
+++ b/tests/test_youtube_timestamp_url.py
@@ -1,0 +1,12 @@
+from server.helpers.formatting import youtube_timestamp_url
+
+
+def test_youtube_timestamp_url_with_query():
+    url = "https://www.youtube.com/watch?v=abc"
+    assert youtube_timestamp_url(url, 12.34) == "https://www.youtube.com/watch?v=abc&t=12s"
+
+
+def test_youtube_timestamp_url_without_query():
+    url = "https://youtu.be/abc"
+    assert youtube_timestamp_url(url, 12.34) == "https://youtu.be/abc?t=12s"
+


### PR DESCRIPTION
## Summary
- add helper to generate timestamped YouTube URLs
- use timestamped link in clip descriptions
- test timestamp helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0914cfce08323b8f0c964a26a392f