### PR TITLE
Allow custom rating descriptions

### DIFF
--- a/server/steps/candidates/__init__.py
+++ b/server/steps/candidates/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 from pathlib import Path
 import re
 
@@ -156,6 +156,7 @@ def find_clip_timestamps_batched(
     *,
     prompt_desc: str = FUNNY_PROMPT_DESC,
     min_rating: float = 7.0,
+    rating_descriptions: Optional[Dict[str, str]] = None,
     min_words: int = 0,
     model: str = "gemma3",
     options: Optional[dict] = None,
@@ -179,7 +180,9 @@ def find_clip_timestamps_batched(
     )
     print(f"[Batch] Processing {len(chunks)} transcript chunks...")
 
-    system_instructions = _build_system_instructions(prompt_desc, min_rating)
+    system_instructions = _build_system_instructions(
+        prompt_desc, min_rating, rating_descriptions
+    )
 
     all_candidates: List[ClipCandidate] = []
     filtered_candidates: List[ClipCandidate] = []
@@ -290,6 +293,7 @@ def find_clip_timestamps(
     *,
     prompt_desc: str = FUNNY_PROMPT_DESC,
     min_rating: float = 7.0,
+    rating_descriptions: Optional[Dict[str, str]] = None,
     min_words: int = 0,
     model: str = "gemma3",
     options: Optional[dict] = None,
@@ -319,7 +323,9 @@ def find_clip_timestamps(
         total += ln
     condensed = "\n".join(condensed)
 
-    system_instructions = _build_system_instructions(prompt_desc, min_rating)
+    system_instructions = _build_system_instructions(
+        prompt_desc, min_rating, rating_descriptions
+    )
 
     prompt = (
         f"{system_instructions}\n\n"

--- a/tests/test_prompt_ratings.py
+++ b/tests/test_prompt_ratings.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from server.steps.candidates.prompts import _build_system_instructions
+
+
+def test_custom_rating_descriptions_included() -> None:
+    custom = {"10": "top tier"}
+    instructions = _build_system_instructions(
+        "desc", 5.0, rating_descriptions=custom
+    )
+    assert "9–10: extremely aligned" in instructions
+    assert "10: top tier" in instructions


### PR DESCRIPTION
## Summary
- allow callers to supply extra rating descriptions for tone prompts
- pass custom descriptions through clip timestamp helpers
- test that custom rating descriptors appear in prompt instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0b10eaf4c832391b7a7dc2c363de8