### PR TITLE
Send email notifications on processing failures

### DIFF
--- a/server/helpers/logging.py
+++ b/server/helpers/logging.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from typing import Callable, TypeVar, Any, Generator
 
 from .formatting import Fore, Style
+from .notifications import send_failure_email
 
 T = TypeVar('T')
 
@@ -32,6 +33,10 @@ def run_step(name: str, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
         elapsed = time.perf_counter() - start
         print(
             f"{Fore.RED}  ↳ failed after {Fore.MAGENTA}{elapsed:.2f}s{Fore.RED}: {exc}{Style.RESET_ALL}"
+        )
+        send_failure_email(
+            f"Pipeline step failed: {name}",
+            f"Step '{name}' failed after {elapsed:.2f}s with error: {exc}",
         )
         raise
     else:

--- a/server/helpers/notifications.py
+++ b/server/helpers/notifications.py
@@ -1,0 +1,43 @@
+"""Helper functions for sending notification emails."""
+
+from __future__ import annotations
+
+import os
+import smtplib
+from email.message import EmailMessage
+from typing import Optional
+
+
+def send_failure_email(subject: str, body: str) -> None:
+    """Send a failure notification email using SMTP.
+
+    SMTP configuration is taken from environment variables:
+    ``SMTP_HOST``, ``SMTP_PORT``, ``SMTP_USERNAME``, ``SMTP_PASSWORD``,
+    ``ALERT_EMAIL_FROM`` and ``ALERT_EMAIL_TO``.
+    If the required configuration is missing, the function silently returns.
+    """
+
+    smtp_host = os.getenv("SMTP_HOST")
+    to_addr = os.getenv("ALERT_EMAIL_TO")
+    if not smtp_host or not to_addr:
+        return
+
+    smtp_port = int(os.getenv("SMTP_PORT", "587"))
+    smtp_user = os.getenv("SMTP_USERNAME")
+    smtp_pass = os.getenv("SMTP_PASSWORD")
+    from_addr = os.getenv("ALERT_EMAIL_FROM", smtp_user)
+
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = from_addr or ""
+    msg["To"] = to_addr
+    msg.set_content(body)
+
+    try:
+        with smtplib.SMTP(smtp_host, smtp_port) as server:
+            server.starttls()
+            if smtp_user and smtp_pass:
+                server.login(smtp_user, smtp_pass)
+            server.send_message(msg)
+    except Exception as exc:
+        print(f"[Email] failed to send notification: {exc}")


### PR DESCRIPTION
## Summary
- add notifications helper to send SMTP emails
- notify on pipeline step errors using `send_failure_email`
- report failures for audio, transcript, clip cutting, hashtags, and missing candidates

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b0b516f5c083239ff4f3df1f3a32c4