### PR TITLE
feat: limit segment extension

### DIFF
--- a/server/steps/cut.py
+++ b/server/steps/cut.py
@@ -111,7 +111,9 @@ def save_clip_from_candidate(
     if transcript_path:
         items = parse_transcript(transcript_path)
         start = _snap_start_to_segment_start(start, items)
-        end = _snap_end_to_segment_end(end, items)
+        end = _snap_end_to_segment_end(
+            end, items, max_extension=max_duration_seconds
+        )
 
     if end - start > max_duration_seconds:
         end = start + max_duration_seconds


### PR DESCRIPTION
## Summary
- add `max_extension` parameter to segment snapping logic
- stop extending clips when adjacent segments would exceed limit
- wire new limit through candidate merging and clip saving

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0d13e8f288323b589b728e7aefc9e