### PR TITLE
Add folder-based batch video uploader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ env
 /out
 
 .env
+upload_config.json

--- a/server/upload/__init__.py
+++ b/server/upload/__init__.py
@@ -1,3 +1,4 @@
 from .pipeline import UploadConfig, upload_video_to_all
+from .batch import upload_folder
 
-__all__ = ["UploadConfig", "upload_video_to_all"]
+__all__ = ["UploadConfig", "upload_video_to_all", "upload_folder"]

--- a/server/upload/__main__.py
+++ b/server/upload/__main__.py
@@ -1,0 +1,37 @@
+"""Command-line interface for batch video uploads."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from .batch import upload_folder
+from .pipeline import UploadConfig
+
+
+def load_config(path: str) -> UploadConfig:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return UploadConfig(**data)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Upload every video in a folder using per-file metadata",
+    )
+    parser.add_argument(
+        "folder",
+        help="Folder containing videos and JSON metadata",
+    )
+    parser.add_argument(
+        "--config",
+        default="upload_config.json",
+        help="Path to JSON file with account names and access tokens",
+    )
+    args = parser.parse_args()
+    config = load_config(args.config)
+    upload_folder(args.folder, config)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/upload/batch.py
+++ b/server/upload/batch.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+from .pipeline import UploadConfig, upload_video_to_all
+
+
+def upload_folder(
+    folder_path: str,
+    config: UploadConfig,
+    extensions: Iterable[str] = (".mp4", ".mov"),
+) -> None:
+    """Upload all videos in ``folder_path`` to all configured accounts.
+
+    Each video file must have an accompanying ``.json`` file with the same
+    name containing ``title``, ``description`` and optional ``hashtags`` (list
+    of strings). Hashtags are appended to both the caption and the description
+    when uploading.
+    """
+    folder = Path(folder_path)
+    for ext in extensions:
+        for video_path in folder.glob(f"*{ext}"):
+            metadata_path = video_path.with_suffix(".json")
+            if not metadata_path.exists():
+                continue
+            with metadata_path.open("r", encoding="utf-8") as f:
+                metadata = json.load(f)
+            title = metadata.get("title", video_path.stem)
+            description = metadata.get("description", "")
+            hashtags = metadata.get("hashtags", [])
+            hashtags_str = " ".join(hashtags).strip()
+            caption_parts = [description.strip()]
+            if hashtags_str:
+                caption_parts.append(hashtags_str)
+            caption = " ".join(part for part in caption_parts if part)
+            if hashtags_str:
+                description_full = f"{description}\n\n{hashtags_str}".strip()
+            else:
+                description_full = description
+            upload_video_to_all(
+                str(video_path),
+                caption,
+                title,
+                description_full,
+                config,
+            )

--- a/server/upload/pipeline.py
+++ b/server/upload/pipeline.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 from helpers.logging import run_step
 from .steps.instagram import upload_instagram
@@ -19,6 +20,12 @@ class UploadConfig:
     facebook_page: str
     snapchat_account: str
     twitter_account: str
+    instagram_token: Optional[str] = None
+    tiktok_token: Optional[str] = None
+    youtube_token: Optional[str] = None
+    facebook_token: Optional[str] = None
+    snapchat_token: Optional[str] = None
+    twitter_token: Optional[str] = None
 
 
 def upload_video_to_all(
@@ -39,6 +46,7 @@ def upload_video_to_all(
         video_path,
         caption,
         config.instagram_account,
+        config.instagram_token,
     )
     run_step(
         "Upload to TikTok",
@@ -46,6 +54,7 @@ def upload_video_to_all(
         video_path,
         caption,
         config.tiktok_account,
+        config.tiktok_token,
     )
     run_step(
         "Upload to YouTube",
@@ -54,6 +63,7 @@ def upload_video_to_all(
         title,
         description,
         config.youtube_account,
+        config.youtube_token,
     )
     run_step(
         "Upload to Facebook",
@@ -61,6 +71,7 @@ def upload_video_to_all(
         video_path,
         caption,
         config.facebook_page,
+        config.facebook_token,
     )
     run_step(
         "Upload to Snapchat",
@@ -68,6 +79,7 @@ def upload_video_to_all(
         video_path,
         caption,
         config.snapchat_account,
+        config.snapchat_token,
     )
     run_step(
         "Upload to Twitter",
@@ -75,4 +87,5 @@ def upload_video_to_all(
         video_path,
         caption,
         config.twitter_account,
+        config.twitter_token,
     )

--- a/tests/test_upload_folder.py
+++ b/tests/test_upload_folder.py
@@ -1,0 +1,33 @@
+import json
+from unittest.mock import patch
+
+from server.upload.batch import upload_folder
+from server.upload.pipeline import UploadConfig
+
+
+def test_upload_folder_calls_upload_video_to_all(tmp_path):
+    video_file = tmp_path / "clip.mp4"
+    video_file.write_bytes(b"data")
+    metadata = {
+        "title": "My Clip",
+        "description": "A description",
+        "hashtags": ["#one", "#two"],
+    }
+    (tmp_path / "clip.json").write_text(json.dumps(metadata))
+    config = UploadConfig(
+        instagram_account="insta",
+        tiktok_account="tiktok",
+        youtube_account="youtube",
+        facebook_page="facebook",
+        snapchat_account="snap",
+        twitter_account="twitter",
+    )
+    with patch("server.upload.batch.upload_video_to_all") as mock_upload:
+        upload_folder(str(tmp_path), config)
+        mock_upload.assert_called_once_with(
+            str(video_file),
+            "A description #one #two",
+            "My Clip",
+            "A description\n\n#one #two",
+            config,
+        )

--- a/tests/test_upload_tokens.py
+++ b/tests/test_upload_tokens.py
@@ -1,0 +1,34 @@
+from server.upload.pipeline import UploadConfig, upload_video_to_all
+from unittest.mock import patch
+
+
+def test_upload_video_to_all_passes_tokens():
+    config = UploadConfig(
+        instagram_account="insta",
+        instagram_token="insta_token",
+        tiktok_account="tiktok",
+        tiktok_token="tiktok_token",
+        youtube_account="youtube",
+        youtube_token="youtube_token",
+        facebook_page="facebook",
+        facebook_token="facebook_token",
+        snapchat_account="snap",
+        snapchat_token="snap_token",
+        twitter_account="twitter",
+        twitter_token="twitter_token",
+    )
+    with (
+        patch("server.upload.pipeline.upload_instagram") as m_inst,
+        patch("server.upload.pipeline.upload_tiktok") as m_tiktok,
+        patch("server.upload.pipeline.upload_youtube") as m_yt,
+        patch("server.upload.pipeline.upload_facebook") as m_fb,
+        patch("server.upload.pipeline.upload_snapchat") as m_snap,
+        patch("server.upload.pipeline.upload_twitter") as m_tw,
+    ):
+        upload_video_to_all("video.mp4", "cap", "title", "desc", config)
+        m_inst.assert_called_once_with("video.mp4", "cap", "insta", "insta_token")
+        m_tiktok.assert_called_once_with("video.mp4", "cap", "tiktok", "tiktok_token")
+        m_yt.assert_called_once_with("video.mp4", "title", "desc", "youtube", "youtube_token")
+        m_fb.assert_called_once_with("video.mp4", "cap", "facebook", "facebook_token")
+        m_snap.assert_called_once_with("video.mp4", "cap", "snap", "snap_token")
+        m_tw.assert_called_once_with("video.mp4", "cap", "twitter", "twitter_token")

--- a/upload_config.example.json
+++ b/upload_config.example.json
@@ -1,0 +1,14 @@
+{
+  "instagram_account": "INSTAGRAM_ACCOUNT_ID",
+  "instagram_token": "INSTAGRAM_ACCESS_TOKEN",
+  "tiktok_account": "TIKTOK_ACCOUNT_ID",
+  "tiktok_token": "TIKTOK_ACCESS_TOKEN",
+  "youtube_account": "YOUTUBE_CHANNEL_ID",
+  "youtube_token": "YOUTUBE_API_KEY",
+  "facebook_page": "FACEBOOK_PAGE_ID",
+  "facebook_token": "FACEBOOK_ACCESS_TOKEN",
+  "snapchat_account": "SNAPCHAT_ACCOUNT_ID",
+  "snapchat_token": "SNAPCHAT_ACCESS_TOKEN",
+  "twitter_account": "TWITTER_HANDLE",
+  "twitter_token": "TWITTER_BEARER_TOKEN"
+}


### PR DESCRIPTION
## Summary
- extend `UploadConfig` with optional API tokens and forward them to each platform uploader
- add CLI entry point (`python -m server.upload`) that batches a folder of videos using a JSON config
- provide `upload_config.example.json` template and tests for token forwarding

## Testing
- `apt-get update`
- `apt-get install -y ffmpeg`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0e81873c08323bcc75baaf2ab7cb2