### PR TITLE
Add detailed rating descriptions for funny and general clips

### DIFF
--- a/server/steps/candidates/funny.py
+++ b/server/steps/candidates/funny.py
@@ -5,7 +5,7 @@ from typing import List
 
 from . import ClipCandidate, find_clip_timestamps, find_clip_timestamps_batched
 from .config import FUNNY_MIN_RATING, FUNNY_MIN_WORDS
-from .prompts import FUNNY_PROMPT_DESC
+from .prompts import FUNNY_PROMPT_DESC, FUNNY_RATING_DESCRIPTIONS
 
 
 def find_funny_timestamps_batched(
@@ -21,6 +21,7 @@ def find_funny_timestamps_batched(
         transcript_path,
         prompt_desc=FUNNY_PROMPT_DESC,
         min_rating=min_rating,
+        rating_descriptions=FUNNY_RATING_DESCRIPTIONS,
         min_words=min_words,
         return_all_stages=return_all_stages,
         **kwargs,
@@ -40,6 +41,7 @@ def find_funny_timestamps(
         transcript_path,
         prompt_desc=FUNNY_PROMPT_DESC,
         min_rating=min_rating,
+        rating_descriptions=FUNNY_RATING_DESCRIPTIONS,
         min_words=min_words,
         return_all_stages=return_all_stages,
         **kwargs,

--- a/server/steps/candidates/prompts.py
+++ b/server/steps/candidates/prompts.py
@@ -18,6 +18,36 @@ FUNNY_PROMPT_DESC = (
     "Exclude promotional segments, sponsor mentions, or Patreon shoutouts."
 )
 
+
+GENERAL_RATING_DESCRIPTIONS: Dict[str, str] = {
+    "10": "extremely aligned, highly engaging, shareable.",
+    "9": "extremely aligned, highly engaging, shareable.",
+    "8": "clearly strong, likely to resonate with most viewers.",
+    "7": "decent; include only if there are few stronger options in this span.",
+    "6": "borderline; noticeable issues with relevance, clarity, or engagement.",
+    "5": "weak; minimal relevance or impact.",
+    "4": "poor; off-target or confusing.",
+    "3": "poor; off-target or confusing.",
+    "2": "not relevant, incoherent, or unusable.",
+    "1": "not relevant, incoherent, or unusable.",
+    "0": "not relevant, incoherent, or unusable.",
+}
+
+
+FUNNY_RATING_DESCRIPTIONS: Dict[str, str] = {
+    "10": "hysterical; likely to make most viewers burst out laughing.",
+    "9": "extremely funny with excellent setup and payoff.",
+    "8": "very funny; strong laugh for many viewers.",
+    "7": "solid joke; produces a clear chuckle.",
+    "6": "mildly amusing; may prompt a smile.",
+    "5": "weak humor; unlikely to get a laugh.",
+    "4": "poor joke or muddled setup.",
+    "3": "barely humorous; off-tone or confusing.",
+    "2": "not funny; flat or irrelevant.",
+    "1": "not funny at all; dull or contextless.",
+    "0": "actively unfunny or potentially offensive.",
+}
+
 INSPIRING_PROMPT_DESC = (
     "uplifting or motivational moments that stir positive emotion, showcase overcoming "
     "challenges, or deliver heartfelt advice. Exclude generic compliments, shallow positivity, or "
@@ -34,13 +64,7 @@ def _build_system_instructions(
     prompt_desc: str, min_rating: float, rating_descriptions: Optional[Dict[str, str]] = None
 ) -> str:
     scoring_lines = [
-        "9\u201310: extremely aligned, highly engaging, shareable.",
-        "8: clearly strong, likely to resonate with most viewers.",
-        "7: decent; include only if there are few stronger options in this span.",
-        "6: borderline; noticeable issues with relevance, clarity, or engagement.",
-        "5: weak; minimal relevance or impact.",
-        "3\u20134: poor; off-target or confusing.",
-        "0\u20132: not relevant, incoherent, or unusable.",
+        f"{rating}: {desc}" for rating, desc in GENERAL_RATING_DESCRIPTIONS.items()
     ]
     if rating_descriptions:
         for rating, desc in rating_descriptions.items():
@@ -82,5 +106,7 @@ __all__ = [
     "FUNNY_PROMPT_DESC",
     "INSPIRING_PROMPT_DESC",
     "EDUCATIONAL_PROMPT_DESC",
+    "GENERAL_RATING_DESCRIPTIONS",
+    "FUNNY_RATING_DESCRIPTIONS",
     "_build_system_instructions",
 ]

--- a/tests/test_prompt_ratings.py
+++ b/tests/test_prompt_ratings.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
-from server.steps.candidates.prompts import _build_system_instructions
+from server.steps.candidates.prompts import (
+    _build_system_instructions,
+    FUNNY_RATING_DESCRIPTIONS,
+)
+
+
+def test_default_rating_descriptions_present() -> None:
+    instructions = _build_system_instructions("desc", 5.0)
+    assert "10: extremely aligned" in instructions
+    assert "0: not relevant" in instructions
 
 
 def test_custom_rating_descriptions_included() -> None:
@@ -8,5 +17,14 @@ def test_custom_rating_descriptions_included() -> None:
     instructions = _build_system_instructions(
         "desc", 5.0, rating_descriptions=custom
     )
-    assert "9–10: extremely aligned" in instructions
+    assert "10: extremely aligned" in instructions
     assert "10: top tier" in instructions
+
+
+def test_funny_rating_descriptions_included() -> None:
+    instructions = _build_system_instructions(
+        "desc", 5.0, rating_descriptions=FUNNY_RATING_DESCRIPTIONS
+    )
+    assert "10: hysterical" in instructions
+    assert "0: actively unfunny" in instructions
+


### PR DESCRIPTION
## Summary
- define per-score descriptions for general and funny clip ratings
- include funny-specific ratings when generating funny clip candidates
- test that default, custom, and funny rating descriptions are all applied

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1dddce2b883239f989b102e20e4c7