### PR TITLE
Allow configuring silence detection thresholds

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -17,6 +17,10 @@ SNAP_TO_SENTENCE = True
 # Export silence-only "raw" clips for debugging comparisons
 EXPORT_RAW_CLIPS = False
 
+# Silence detection thresholds
+SILENCE_DETECTION_NOISE = "-30dB"
+SILENCE_DETECTION_MIN_DURATION = 0.3
+
 # ---------------------------------------
 # Candidate selection heuristics
 # ---------------------------------------
@@ -43,6 +47,8 @@ __all__ = [
     "SNAP_TO_DIALOG",
     "SNAP_TO_SENTENCE",
     "EXPORT_RAW_CLIPS",
+    "SILENCE_DETECTION_NOISE",
+    "SILENCE_DETECTION_MIN_DURATION",
     "MIN_DURATION_SECONDS",
     "MAX_DURATION_SECONDS",
     "SWEET_SPOT_MIN_SECONDS",

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -45,6 +45,8 @@ from config import (
     SNAP_TO_DIALOG,
     SNAP_TO_SENTENCE,
     EXPORT_RAW_CLIPS,
+    SILENCE_DETECTION_NOISE,
+    SILENCE_DETECTION_MIN_DURATION,
 )
 
 import sys
@@ -183,7 +185,15 @@ def process_video(yt_url: str) -> None:
     silences_path = project_dir / "silences.json"
 
     def step_silences() -> list[tuple[float, float]]:
-        silences = detect_silences(str(audio_output_path)) if audio_ok else []
+        silences = (
+            detect_silences(
+                str(audio_output_path),
+                noise=SILENCE_DETECTION_NOISE,
+                min_duration=SILENCE_DETECTION_MIN_DURATION,
+            )
+            if audio_ok
+            else []
+        )
         write_silences_json(silences, silences_path)
         return silences
 

--- a/server/steps/silence.py
+++ b/server/steps/silence.py
@@ -7,12 +7,17 @@ from typing import Iterable, List, Tuple
 SILENCE_START_RE = re.compile(r"silence_start: (?P<time>\d+(?:\.\d+)?)")
 SILENCE_END_RE = re.compile(r"silence_end: (?P<time>\d+(?:\.\d+)?)")
 
+from ..config import (
+    SILENCE_DETECTION_NOISE,
+    SILENCE_DETECTION_MIN_DURATION,
+)
+
 
 def detect_silences(
     audio_path: str | Path,
     *,
-    noise: str = "-30dB",
-    min_duration: float = 0.3,
+    noise: str = SILENCE_DETECTION_NOISE,
+    min_duration: float = SILENCE_DETECTION_MIN_DURATION,
 ) -> List[Tuple[float, float]]:
     """Return a list of (start, end) silence segments for ``audio_path``."""
     cmd = [


### PR DESCRIPTION
## Summary
- add `SILENCE_DETECTION_NOISE` and `SILENCE_DETECTION_MIN_DURATION` config values
- use configurable thresholds in silence detection step and pipeline

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4782f674c8323abeeaf7806d919b0