### PR TITLE
Add multi-platform upload script

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -3,6 +3,8 @@
 Sections are grouped by feature for easier editing.
 """
 
+from pathlib import Path
+
 # ---------------------------------------
 # Rendering and clip boundary parameters
 # ---------------------------------------
@@ -43,6 +45,18 @@ EDUCATIONAL_MIN_WORDS = 8
 INSPIRING_MIN_RATING = 7.0
 INSPIRING_MIN_WORDS = 8
 
+# ---------------------------------------
+# Multi-platform upload settings
+# ---------------------------------------
+TOKENS_DIR = Path(__file__).with_name("tokens")
+
+YOUTUBE_PRIVACY = "public"
+YOUTUBE_CATEGORY_ID = "23"
+
+# PRIVACY_LEVEL can be PUBLIC_TO_EVERYONE, MUTUAL_FOLLOW_FRIENDS, or SELF_ONLY
+TIKTOK_PRIVACY_LEVEL = "SELF_ONLY"
+TIKTOK_CHUNK_SIZE = 10_000_000  # bytes
+
 __all__ = [
     "CAPTION_FONT_SCALE",
     "SNAP_TO_SILENCE",
@@ -63,4 +77,9 @@ __all__ = [
     "EDUCATIONAL_MIN_WORDS",
     "INSPIRING_MIN_RATING",
     "INSPIRING_MIN_WORDS",
+    "TOKENS_DIR",
+    "YOUTUBE_PRIVACY",
+    "YOUTUBE_CATEGORY_ID",
+    "TIKTOK_PRIVACY_LEVEL",
+    "TIKTOK_CHUNK_SIZE",
 ]

--- a/server/integrations/instagram/__init__.py
+++ b/server/integrations/instagram/__init__.py
@@ -1,0 +1,2 @@
+"""Instagram integration package."""
+

--- a/server/integrations/tiktok/__init__.py
+++ b/server/integrations/tiktok/__init__.py
@@ -1,0 +1,2 @@
+"""TikTok integration package."""
+

--- a/server/integrations/tiktok/auth.py
+++ b/server/integrations/tiktok/auth.py
@@ -1,14 +1,18 @@
 # tiktok_desktop_pkce_demo.py
 import os
+from pathlib import Path
 # Constants you edit once:
 CLIENT_KEY = os.environ.get("TIKTOK_CLIENT_KEY")
 CLIENT_SECRET = os.environ.get("TIKTOK_CLIENT_SECRET")  # some flows accept without; include if your app requires it
 SCOPES = ["user.info.basic", "video.publish"]          # comma-separated in URL (TikTok desktop spec)
 REDIRECT_PATH = "/tiktok/auth/callback/"  # note trailing slash (keep it stable)
 
-TOKENS_FILE = ".tiktok_tokens.json"
+TOKENS_FILE = Path(
+    os.getenv("TIKTOK_TOKENS_FILE")
+    or Path(__file__).resolve().parents[2] / "tokens" / "tiktok.json"
+)
 
-import http.server, socket, webbrowser, urllib.parse, hashlib, os, secrets, json, requests, threading
+import http.server, socket, webbrowser, urllib.parse, hashlib, secrets, json, requests, threading
 
 def random_free_port():
     s = socket.socket()

--- a/server/integrations/tiktok/upload.py
+++ b/server/integrations/tiktok/upload.py
@@ -6,10 +6,18 @@ import mimetypes
 import requests
 from pathlib import Path
 
+TOKENS_FILE = Path(
+    os.getenv("TIKTOK_TOKENS_FILE")
+    or Path(__file__).resolve().parents[2] / "tokens" / "tiktok.json"
+)
+
 # Load access token from JSON file
-with open(".tiktok_tokens.json", "r", encoding="utf-8") as f:
-    data = json.load(f)
-ACCESS_TOKEN = data["access_token"]
+try:
+    with open(TOKENS_FILE, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    ACCESS_TOKEN = data["access_token"]
+except FileNotFoundError:  # pragma: no cover - runtime setup
+    ACCESS_TOKEN = ""
 
 # ------------ CONFIG (edit these) ------------
 VIDEO_PATH   = Path("/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2_vertical.mp4")

--- a/server/integrations/upload_all.py
+++ b/server/integrations/upload_all.py
@@ -1,0 +1,180 @@
+"""Upload video(s) to all configured integrations.
+
+This module authenticates with each platform and posts the provided video and
+description. Platform defaults live in :mod:`server.config` and can be
+overridden at runtime via the :func:`run` function.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from typing import Callable, Dict
+import os
+
+from server import config as server_config
+
+DEFAULT_VIDEO = Path("video.mp4")
+DEFAULT_DESC = Path("description.txt")
+
+
+def _ensure_tiktok_tokens(tokens_file: Path) -> None:
+    """Ensure TikTok tokens exist by running the auth flow if needed."""
+    if not tokens_file.exists():
+        from .tiktok import auth as tiktok_auth
+
+        tiktok_auth.run()
+
+
+def _upload_youtube(video: Path, desc: Path, privacy: str, category_id: str) -> None:
+    from .youtube import upload as yt_upload
+
+    title, description = yt_upload.read_description(desc)
+    response = yt_upload.upload_video(video, title, description, privacy, category_id)
+    print("YouTube upload ID:", response.get("id"))
+
+
+def _upload_instagram(video: Path, desc: Path) -> None:
+    from .instagram import upload as ig_upload
+
+    caption = ig_upload._read_caption(desc)
+    client = ig_upload.build_client()
+    ig_upload.login_or_resume(client, ig_upload.USERNAME, ig_upload.PASSWORD)
+    result = ig_upload.clip_upload_with_retries(client, video, caption)
+    print("Instagram upload:", result)
+
+
+def _upload_tiktok(
+    video: Path,
+    desc: Path,
+    chunk_size: int,
+    privacy_level: str,
+    tokens_file: Path,
+) -> None:
+    _ensure_tiktok_tokens(tokens_file)
+    tt_upload = import_module("server.integrations.tiktok.upload")
+
+    caption = tt_upload.read_caption(desc)
+    size = video.stat().st_size
+    publish_id, upload_url = tt_upload.init_direct_post(
+        size, chunk_size, caption, privacy_level
+    )
+    tt_upload.upload_video(upload_url, video, chunk_size)
+    result = tt_upload.poll_status(publish_id)
+    print("TikTok upload:", result)
+
+
+def upload_all(
+    video: Path,
+    desc: Path,
+    *,
+    yt_privacy: str,
+    yt_category_id: str,
+    tt_chunk_size: int,
+    tt_privacy: str,
+    tokens_file: Path,
+) -> None:
+    """Upload the given video and description to all platforms."""
+
+    uploaders: Dict[str, Callable[[], None]] = {
+        "youtube": lambda: _upload_youtube(video, desc, yt_privacy, yt_category_id),
+        "instagram": lambda: _upload_instagram(video, desc),
+        "tiktok": lambda: _upload_tiktok(
+            video, desc, tt_chunk_size, tt_privacy, tokens_file
+        ),
+    }
+
+    for name, func in uploaders.items():
+        print(f"== Uploading to {name} ==")
+        try:
+            func()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            print(f"{name} upload failed: {exc}")
+
+
+def run(
+    video: Path | None = None,
+    desc: Path | None = None,
+    folder: Path | None = None,
+    *,
+    yt_privacy: str | None = None,
+    yt_category_id: str | None = None,
+    tt_chunk_size: int | None = None,
+    tt_privacy: str | None = None,
+    tokens_dir: Path | None = None,
+) -> None:
+    """Run uploads using configuration defaults with optional overrides.
+
+    If ``folder`` is provided, all ``.mp4`` files inside it will be uploaded
+    sequentially, each expecting a matching ``.txt`` description file.
+    """
+
+    tokens_dir = Path(tokens_dir) if tokens_dir else server_config.TOKENS_DIR
+    tokens_dir.mkdir(parents=True, exist_ok=True)
+    os.environ["YT_TOKENS_FILE"] = str(tokens_dir / "youtube.json")
+    os.environ["TIKTOK_TOKENS_FILE"] = str(tokens_dir / "tiktok.json")
+    tokens_file = Path(os.environ["TIKTOK_TOKENS_FILE"])
+
+    yt_privacy = yt_privacy or server_config.YOUTUBE_PRIVACY
+    yt_category_id = yt_category_id or server_config.YOUTUBE_CATEGORY_ID
+    tt_chunk_size = tt_chunk_size or server_config.TIKTOK_CHUNK_SIZE
+    tt_privacy = tt_privacy or server_config.TIKTOK_PRIVACY_LEVEL
+
+    if folder:
+        for vid in sorted(Path(folder).glob("*.mp4")):
+            desc_path = vid.with_suffix(".txt")
+            if not desc_path.exists():
+                print(f"No description for {vid}, skipping")
+                continue
+            upload_all(
+                vid,
+                desc_path,
+                yt_privacy=yt_privacy,
+                yt_category_id=yt_category_id,
+                tt_chunk_size=tt_chunk_size,
+                tt_privacy=tt_privacy,
+                tokens_file=tokens_file,
+            )
+    else:
+        video = Path(video) if video else DEFAULT_VIDEO
+        desc = Path(desc) if desc else DEFAULT_DESC
+        upload_all(
+            video,
+            desc,
+            yt_privacy=yt_privacy,
+            yt_category_id=yt_category_id,
+            tt_chunk_size=tt_chunk_size,
+            tt_privacy=tt_privacy,
+            tokens_file=tokens_file,
+        )
+
+
+def main() -> None:
+    """Entry point for manual invocation.
+
+    Modify the variables below to override configuration defaults.
+    """
+
+    video = DEFAULT_VIDEO
+    desc = DEFAULT_DESC
+    folder = None
+    yt_privacy = server_config.YOUTUBE_PRIVACY
+    yt_category_id = server_config.YOUTUBE_CATEGORY_ID
+    tt_chunk_size = server_config.TIKTOK_CHUNK_SIZE
+    tt_privacy = server_config.TIKTOK_PRIVACY_LEVEL
+    tokens_dir = server_config.TOKENS_DIR
+
+    run(
+        video=video,
+        desc=desc,
+        folder=folder,
+        yt_privacy=yt_privacy,
+        yt_category_id=yt_category_id,
+        tt_chunk_size=tt_chunk_size,
+        tt_privacy=tt_privacy,
+        tokens_dir=tokens_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/server/integrations/youtube/auth.py
+++ b/server/integrations/youtube/auth.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 """YouTube auth helper (single account).
 
-- Stores credentials for ONE account in a single file: .youtube_tokens.json
+- Stores credentials for ONE account in ``server/tokens/youtube.json``
 - Desktop OAuth (InstalledAppFlow.run_local_server)
 - Refreshes & persists tokens automatically.
 
@@ -28,7 +28,10 @@ from googleapiclient.discovery import build
 # --- Constants (edit here, no argparse) --------------------------------------
 SCOPES = ["https://www.googleapis.com/auth/youtube.upload"]
 CLIENT_SECRETS_FILE = os.getenv("YT_CLIENT_SECRETS", "yt_client_secret.json")
-TOKENS_FILE = Path(os.getenv("YT_TOKENS_FILE", ".youtube_tokens.json"))
+TOKENS_FILE = Path(
+    os.getenv("YT_TOKENS_FILE")
+    or Path(__file__).resolve().parents[2] / "tokens" / "youtube.json"
+)
 
 
 # --- Token helpers ------------------------------------------------------------

--- a/server/integrations/youtube/upload.py
+++ b/server/integrations/youtube/upload.py
@@ -9,7 +9,7 @@ from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
 from googleapiclient.errors import HttpError
 
-from auth import ensure_creds
+from .auth import ensure_creds
 
 # --- Configuration ---
 VIDEO_PATH = Path("/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2_vertical.mp4")

--- a/server/tokens/.gitignore
+++ b/server/tokens/.gitignore
@@ -1,0 +1,1 @@
+*\n!.gitignore\n


### PR DESCRIPTION
## Summary
- centralize platform settings and tokens directory in `server/config.py`
- enhance `upload_all` with configurable default paths and batch folder uploads
- store YouTube and TikTok tokens under `server/tokens` and update auth modules accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7988fc6f88323986286004637a34e