### PR TITLE
Clarify funny prompt with weird humor and no R-rating ban

### DIFF
--- a/server/steps/candidates/prompts.py
+++ b/server/steps/candidates/prompts.py
@@ -11,6 +11,7 @@ from config import (
 
 FUNNY_PROMPT_DESC = (
     "Find self-contained funny beats that will make most viewers laugh. "
+    "Embrace strange, weird, or delightfully crazy moments if they land a punchline. "
     "Prefer short setups with a clear punchline or twist (deadpan contradiction, playful roast, absurd confession, misdirection, escalation, wordplay). "
     "The punchline must occur inside the clip window; do not return pure setup. Start slightly before the setup line and end just after the laugh/beat lands (≤1.5s). "
     "Favor tight beats (often ≤25s) over long stories unless the payoff is exceptional. "
@@ -37,8 +38,8 @@ GENERAL_RATING_DESCRIPTIONS: Dict[str, str] = {
 
 
 FUNNY_RATING_DESCRIPTIONS: Dict[str, str] = {
-    "10": "hysterical; broad laugh for most viewers",
-    "9":  "extremely funny; tight setup and clean punchline",
+    "10": "hysterical or delightfully weird; broad laugh for most viewers",
+    "9":  "extremely funny; tight setup and clean punchline; may be cleverly absurd",
     "8":  "very funny; strong laugh for many",
     "7":  "clearly funny; earns a chuckle",
     "6":  "lightly amusing; smile more than laugh",

--- a/tests/test_prompt_ratings.py
+++ b/tests/test_prompt_ratings.py
@@ -30,6 +30,6 @@ def test_funny_rating_descriptions_included() -> None:
     instructions = _build_system_instructions(
         "desc", 5.0, rating_descriptions=FUNNY_RATING_DESCRIPTIONS
     )
-    assert "10: hysterical" in instructions
-    assert "0: reject; offensive" in instructions
+    assert "10: hysterical or delightfully weird" in instructions
+    assert "0: reject; offensive without comedic value" in instructions
 


### PR DESCRIPTION
## Summary
- Allow delightfully weird humor in funny prompt instructions
- Drop the R-rating-based rejection from funny rating descriptions
- Update tests for revised funny rating descriptors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7a89f5580832386c49fa9e9b2a30f