### PR TITLE
Save unfiltered LLM candidates and hide rating threshold

### DIFF
--- a/server/steps/candidates/prompts.py
+++ b/server/steps/candidates/prompts.py
@@ -73,7 +73,6 @@ def _build_system_instructions(
         "OUTPUT FORMAT (strict):\n"
         "Return ONLY a valid JSON array, no prose, matching this schema:\n"
         "[{\"start\": number, \"end\": number, \"rating\": number, \"reason\": string, \"quote\": string, \"tags\": string[]}]\n\n"
-        f"Quality threshold: include only items with rating > {min_rating} (0–10 numeric).\n"
         f"Duration: each item must be between {MIN_DURATION_SECONDS:.0f} and {MAX_DURATION_SECONDS:.0f} seconds; ideal is {SWEET_SPOT_MIN_SECONDS:.0f}–{SWEET_SPOT_MAX_SECONDS:.0f} seconds.\n"
         "If no suitable moments exist, return [].\n\n"
         "HARD RULES (must all be satisfied):\n"


### PR DESCRIPTION
## Summary
- Stop revealing rating thresholds in system instructions to prevent score inflation
- Capture every LLM candidate before rating filters so `candidates_all.json` contains the raw model output

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b82ce7e4288323af2833ae980e0b5e