### PR TITLE
feat: configurable website link in descriptions

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -57,6 +57,10 @@ YOUTUBE_CATEGORY_ID = "23"
 TIKTOK_PRIVACY_LEVEL = "SELF_ONLY"
 TIKTOK_CHUNK_SIZE = 10_000_000  # bytes
 
+# Optional website link to append to video descriptions
+INCLUDE_WEBSITE_LINK = True
+WEBSITE_URL = "https://atropos-video.com"
+
 __all__ = [
     "CAPTION_FONT_SCALE",
     "SNAP_TO_SILENCE",
@@ -82,4 +86,6 @@ __all__ = [
     "YOUTUBE_CATEGORY_ID",
     "TIKTOK_PRIVACY_LEVEL",
     "TIKTOK_CHUNK_SIZE",
+    "INCLUDE_WEBSITE_LINK",
+    "WEBSITE_URL",
 ]

--- a/server/helpers/description.py
+++ b/server/helpers/description.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Helpers for handling clip descriptions."""
+
+from config import INCLUDE_WEBSITE_LINK, WEBSITE_URL
+
+
+def maybe_append_website_link(text: str) -> str:
+    """Append the website link to *text* when enabled via configuration.
+
+    The link is only appended if ``INCLUDE_WEBSITE_LINK`` is ``True`` and the
+    link is not already present in *text*.
+    """
+    if INCLUDE_WEBSITE_LINK and WEBSITE_URL and WEBSITE_URL not in text:
+        if text and not text.endswith("\n"):
+            text += "\n"
+        text += WEBSITE_URL
+    return text

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -65,6 +65,7 @@ from helpers.formatting import (
 from helpers.logging import run_step
 from helpers.notifications import send_failure_email
 from helpers.ai import local_llm_call_json
+from helpers.description import maybe_append_website_link
 from steps.candidates import ClipCandidate
 
 
@@ -416,9 +417,10 @@ def process_video(yt_url: str) -> None:
             description = (
                 f"Full video: {full_video_link}\n"
                 f"Credit: {video_info.get('uploader', 'Unknown Channel')}\n"
-                "Made by Atropos\n\n"
-                + " ".join(hashtags)
+                "Made by Atropos\n"
             )
+            description = maybe_append_website_link(description)
+            description += "\n" + " ".join(hashtags)
             description_path.write_text(description, encoding="utf-8")
             return description_path
 

--- a/tests/test_description_link.py
+++ b/tests/test_description_link.py
@@ -1,0 +1,25 @@
+from server.helpers.description import maybe_append_website_link
+
+
+def test_maybe_appends_website_link_when_enabled(monkeypatch):
+    monkeypatch.setattr(
+        "server.helpers.description.INCLUDE_WEBSITE_LINK", True
+    )
+    monkeypatch.setattr(
+        "server.helpers.description.WEBSITE_URL", "https://atropos-video.com"
+    )
+    text = "Full video: link"
+    result = maybe_append_website_link(text)
+    assert result.endswith("https://atropos-video.com")
+
+
+def test_maybe_skips_website_link_when_disabled(monkeypatch):
+    monkeypatch.setattr(
+        "server.helpers.description.INCLUDE_WEBSITE_LINK", False
+    )
+    monkeypatch.setattr(
+        "server.helpers.description.WEBSITE_URL", "https://atropos-video.com"
+    )
+    text = "Full video: link"
+    result = maybe_append_website_link(text)
+    assert "https://atropos-video.com" not in result


### PR DESCRIPTION
## Summary
- add helper to optionally append the website link to description text
- insert website link during description file generation instead of in upload helpers
- update tests for configurable website link handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8f84450388323a767a388656f48bf