### PR TITLE
Add cleanup for scheduled uploads

### DIFF
--- a/server/upload_all.py
+++ b/server/upload_all.py
@@ -15,11 +15,22 @@ from pathlib import Path
 from typing import Callable, Dict
 import os
 
-from config import TIKTOK_CHUNK_SIZE, TIKTOK_PRIVACY_LEVEL, TOKENS_DIR, YOUTUBE_CATEGORY_ID, YOUTUBE_PRIVACY
-import integrations.tiktok.upload as tt_upload
-from integrations.youtube.auth import ensure_creds
-from integrations.tiktok.auth import run as run_tiktok_auth
-from integrations.instagram.upload import login_or_resume, build_client, USERNAME, PASSWORD
+from .config import (
+    TIKTOK_CHUNK_SIZE,
+    TIKTOK_PRIVACY_LEVEL,
+    TOKENS_DIR,
+    YOUTUBE_CATEGORY_ID,
+    YOUTUBE_PRIVACY,
+)
+from .integrations.tiktok import upload as tt_upload
+from .integrations.youtube.auth import ensure_creds
+from .integrations.tiktok.auth import run as run_tiktok_auth
+from .integrations.instagram.upload import (
+    login_or_resume,
+    build_client,
+    USERNAME,
+    PASSWORD,
+)
 
 DEFAULT_VIDEO = Path("../out/Can_We_Spend_5_Gift_Cards_in_1_Hour__-_KF_AF_20190116/shorts/clip_1990.90-2080.90_r8.5_vertical.mp4")
 DEFAULT_DESC = Path("../out/Can_We_Spend_5_Gift_Cards_in_1_Hour__-_KF_AF_20190116/shorts/clip_1990.90-2080.90_r8.5_description.txt")
@@ -150,15 +161,19 @@ def run(
             if not desc_path.exists():
                 print(f"No description for {vid}, skipping")
                 continue
-            upload_all(
-                vid,
-                desc_path,
-                yt_privacy=yt_privacy,
-                yt_category_id=yt_category_id,
-                tt_chunk_size=tt_chunk_size,
-                tt_privacy=tt_privacy,
-                tokens_file=tokens_file,
-            )
+            try:
+                upload_all(
+                    vid,
+                    desc_path,
+                    yt_privacy=yt_privacy,
+                    yt_category_id=yt_category_id,
+                    tt_chunk_size=tt_chunk_size,
+                    tt_privacy=tt_privacy,
+                    tokens_file=tokens_file,
+                )
+            finally:
+                desc_path.unlink(missing_ok=True)
+                vid.unlink(missing_ok=True)
     else:
         video = Path(video) if video else DEFAULT_VIDEO
         desc = Path(desc) if desc else DEFAULT_DESC

--- a/tests/test_schedule_upload.py
+++ b/tests/test_schedule_upload.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import os
 import time
 
-from server.schedule_upload import find_oldest_clip
+import server.schedule_upload as schedule_upload
 
 
 def test_find_oldest_clip(tmp_path: Path) -> None:
@@ -29,5 +29,40 @@ def test_find_oldest_clip(tmp_path: Path) -> None:
     new_desc = new_video.with_suffix(".txt")
     new_desc.write_text("desc2")
 
-    found = find_oldest_clip(out)
+    found = schedule_upload.find_oldest_clip(out)
     assert found == (old_video, old_desc)
+
+
+def test_main_cleans_and_deletes(tmp_path: Path, monkeypatch) -> None:
+    out = tmp_path / "out"
+    project = out / "proj"
+    shorts = project / "shorts"
+    shorts.mkdir(parents=True)
+    video = shorts / "clip.mp4"
+    video.write_bytes(b"a")
+    desc = video.with_suffix(".txt")
+    desc.write_text("desc")
+    extra_file = project / "note.txt"
+    extra_file.write_text("junk")
+    extra_dir = project / "raw"
+    extra_dir.mkdir()
+    (extra_dir / "raw.txt").write_text("raw")
+
+    calls: list[tuple[Path, Path]] = []
+
+    def fake_run(*, video: Path, desc: Path) -> None:
+        calls.append((video, desc))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(schedule_upload, "run", fake_run)
+
+    schedule_upload.main()
+
+    assert len(calls) == 1
+    assert calls[0] == (video.relative_to(tmp_path), desc.relative_to(tmp_path))
+    assert not video.exists()
+    assert not desc.exists()
+    assert not extra_file.exists()
+    assert not extra_dir.exists()
+    assert not shorts.exists()
+    assert not project.exists()


### PR DESCRIPTION
## Summary
- resolve imports and ensure uploaded shorts and descriptions are removed once processed
- clean up project folders and uploaded clips with package-relative modules
- cover folder uploads with a test confirming processed files are deleted

## Testing
- `python -m pytest tests/test_schedule_upload.py tests/test_upload_retry.py tests/test_upload_run_cleanup.py`
- `python -m pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg')*

------
https://chatgpt.com/codex/tasks/task_e_68b8f8d24a948323acca5bc6c3e18ef2