### PR TITLE
Remove clip and description suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ from common.env import load_env
 3. Place the videos and caption files in the folder specified by
    ``UPLOAD_FOLDER`` in ``server/scripts/run_bulk_upload.py`` (defaults to
    ``upload_queue``). For each ``video.mp4`` provide a caption file named
-   ``video_description.txt`` or ``video.txt`` in the same directory.
+   ``video.txt`` in the same directory.
 
 ## Running
 

--- a/server/integrations/instagram/upload.py
+++ b/server/integrations/instagram/upload.py
@@ -8,8 +8,12 @@ import time
 # --- Constants (no argparse, edit here) ---
 USERNAME = os.getenv("IG_USERNAME")
 PASSWORD = os.getenv("IG_PASSWORD")
-VIDEO_PATH = Path("/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2_vertical.mp4")
-DESC_PATH = Path("/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2_description.txt")
+VIDEO_PATH = Path(
+    "/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2.mp4"
+)
+DESC_PATH = Path(
+    "/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2.txt"
+)
 SESSION_PATH = Path(__file__).with_name("instagrapi_session.json")
 STATE_PATH = Path(__file__).with_name("instagrapi_state.json")  # optional debug
 

--- a/server/integrations/tiktok/upload.py
+++ b/server/integrations/tiktok/upload.py
@@ -20,8 +20,12 @@ except FileNotFoundError:  # pragma: no cover - runtime setup
     ACCESS_TOKEN = ""
 
 # ------------ CONFIG (edit these) ------------
-VIDEO_PATH   = Path("/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2_vertical.mp4")
-CAPTION_TXT  = Path("/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2_description.txt")
+VIDEO_PATH = Path(
+    "/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2.mp4"
+)
+CAPTION_TXT = Path(
+    "/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2.txt"
+)
 PRIVACY_LEVEL = "SELF_ONLY"  # or PUBLIC_TO_EVERYONE / MUTUAL_FOLLOW_FRIENDS / SELF_ONLY
 CHUNK_SIZE = 10_000_000  # decimal 10MB; TikTok validates against this exact value
 POLL_INTERVAL_SEC = 3

--- a/server/integrations/youtube/upload.py
+++ b/server/integrations/youtube/upload.py
@@ -12,8 +12,12 @@ from googleapiclient.errors import HttpError
 from .auth import ensure_creds
 
 # --- Configuration ---
-VIDEO_PATH = Path("/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2_vertical.mp4")
-DESC_PATH = Path("/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2_description.txt")
+VIDEO_PATH = Path(
+    "/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2.mp4"
+)
+DESC_PATH = Path(
+    "/Users/noahperkins/Documents/Feryv/Clipit/out/Andy_and_Nick_Do_the_Bird_Box_Challenge_-_KF_AF_20190109/shorts/clip_0.00-49.30_r9.2.txt"
+)
 PRIVACY = "public"        # or 'unlisted' or 'private'
 CATEGORY_ID = "23"        # e.g., 22 for People & Blogs, 23 for Comedy
 

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -353,7 +353,7 @@ def process_video(yt_url: str) -> None:
             f"STEP 7.{idx}: Generating subtitles -> {srt_path}", step_subtitles
         )
 
-        vertical_output = shorts_dir / f"{clip_path.stem}_vertical.mp4"
+        vertical_output = shorts_dir / f"{clip_path.stem}.mp4"
 
         def step_render() -> Path:
             return render_vertical_with_captions(
@@ -367,7 +367,7 @@ def process_video(yt_url: str) -> None:
             step_render,
         )
 
-        description_path = shorts_dir / f"{clip_path.stem}_description.txt"
+        description_path = shorts_dir / f"{clip_path.stem}.txt"
 
         def step_description() -> Path:
             prompt = (

--- a/server/schedule_upload.py
+++ b/server/schedule_upload.py
@@ -65,8 +65,9 @@ def main() -> None:
     try:
         run(video=video, desc=desc)
     finally:
-        desc.unlink(missing_ok=True)
-        video.unlink(missing_ok=True)
+        for f in video.parent.glob(f"{video.stem}.*"):
+            if f.is_file():
+                f.unlink(missing_ok=True)
         _tidy_empty_dirs(video.parent, project)
 
 

--- a/server/upload_all.py
+++ b/server/upload_all.py
@@ -32,8 +32,12 @@ from .integrations.instagram.upload import (
     PASSWORD,
 )
 
-DEFAULT_VIDEO = Path("../out/Can_We_Spend_5_Gift_Cards_in_1_Hour__-_KF_AF_20190116/shorts/clip_1990.90-2080.90_r8.5_vertical.mp4")
-DEFAULT_DESC = Path("../out/Can_We_Spend_5_Gift_Cards_in_1_Hour__-_KF_AF_20190116/shorts/clip_1990.90-2080.90_r8.5_description.txt")
+DEFAULT_VIDEO = Path(
+    "../out/Can_We_Spend_5_Gift_Cards_in_1_Hour__-_KF_AF_20190116/shorts/clip_1990.90-2080.90_r8.5.mp4"
+)
+DEFAULT_DESC = Path(
+    "../out/Can_We_Spend_5_Gift_Cards_in_1_Hour__-_KF_AF_20190116/shorts/clip_1990.90-2080.90_r8.5.txt"
+)
 
 
 def _ensure_tiktok_tokens(tokens_file: Path) -> None:
@@ -172,8 +176,9 @@ def run(
                     tokens_file=tokens_file,
                 )
             finally:
-                desc_path.unlink(missing_ok=True)
-                vid.unlink(missing_ok=True)
+                for f in vid.parent.glob(f"{vid.stem}.*"):
+                    if f.is_file():
+                        f.unlink(missing_ok=True)
     else:
         video = Path(video) if video else DEFAULT_VIDEO
         desc = Path(desc) if desc else DEFAULT_DESC

--- a/tests/test_schedule_upload.py
+++ b/tests/test_schedule_upload.py
@@ -42,6 +42,8 @@ def test_main_cleans_and_deletes(tmp_path: Path, monkeypatch) -> None:
     video.write_bytes(b"a")
     desc = video.with_suffix(".txt")
     desc.write_text("desc")
+    extra_clip = shorts / "clip.srt"
+    extra_clip.write_text("subs")
     extra_file = project / "note.txt"
     extra_file.write_text("junk")
     extra_dir = project / "raw"
@@ -62,6 +64,7 @@ def test_main_cleans_and_deletes(tmp_path: Path, monkeypatch) -> None:
     assert calls[0] == (video.relative_to(tmp_path), desc.relative_to(tmp_path))
     assert not video.exists()
     assert not desc.exists()
+    assert not extra_clip.exists()
     assert not extra_file.exists()
     assert not extra_dir.exists()
     assert not shorts.exists()

--- a/tests/test_upload_run_cleanup.py
+++ b/tests/test_upload_run_cleanup.py
@@ -10,6 +10,8 @@ def test_run_folder_deletes_files(tmp_path, monkeypatch) -> None:
     video.write_bytes(b"a")
     desc = folder / "clip.txt"
     desc.write_text("d")
+    extra = folder / "clip.srt"
+    extra.write_text("subs")
 
     calls: list[tuple[Path, Path]] = []
 
@@ -38,4 +40,5 @@ def test_run_folder_deletes_files(tmp_path, monkeypatch) -> None:
     assert calls == [(video, desc)]
     assert not video.exists()
     assert not desc.exists()
+    assert not extra.exists()
 


### PR DESCRIPTION
## Summary
- drop `_clip` and `_description` suffixes so outputs use only extensions
- update default media paths for uploads
- document simplified caption naming
- remove all same-name files after uploading to clean up auxiliary assets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b98239acbc8323a0c3c6315b3fdb40