### PR TITLE
Use refresh tokens before full auth for uploads

### DIFF
--- a/server/integrations/youtube/auth.py
+++ b/server/integrations/youtube/auth.py
@@ -66,6 +66,17 @@ def load_creds() -> Optional[Credentials]:
     return None
 
 
+def refresh_creds() -> bool:
+    """Attempt to load and refresh credentials without user interaction.
+
+    Returns ``True`` if valid credentials are available, ``False`` otherwise.
+    """
+    try:
+        return load_creds() is not None
+    except Exception:
+        return False
+
+
 def ensure_creds() -> Credentials:
     """Ensure we have valid credentials saved to .youtube_tokens.json.
     Opens a browser on first-time auth; then refreshes silently next runs.

--- a/tests/test_auth_refreshers.py
+++ b/tests/test_auth_refreshers.py
@@ -1,0 +1,78 @@
+from server import upload_all
+
+
+def test_youtube_refresh_then_full(monkeypatch):
+    calls = []
+
+    def mock_refresh():
+        calls.append("refresh")
+        return False
+
+    def mock_full():
+        calls.append("full")
+
+    monkeypatch.setattr(upload_all, "refresh_creds", mock_refresh)
+    monkeypatch.setattr(upload_all, "ensure_creds", mock_full)
+
+    refreshers = upload_all._get_auth_refreshers()
+    refreshers["youtube"]()
+
+    assert calls == ["refresh", "full"]
+
+
+def test_youtube_refresh_success(monkeypatch):
+    calls = []
+
+    def mock_refresh():
+        calls.append("refresh")
+        return True
+
+    def mock_full():
+        calls.append("full")
+
+    monkeypatch.setattr(upload_all, "refresh_creds", mock_refresh)
+    monkeypatch.setattr(upload_all, "ensure_creds", mock_full)
+
+    refreshers = upload_all._get_auth_refreshers()
+    refreshers["youtube"]()
+
+    assert calls == ["refresh"]
+
+
+def test_tiktok_refresh_then_full(monkeypatch):
+    calls = []
+
+    def mock_refresh():
+        calls.append("refresh")
+        return False
+
+    def mock_full():
+        calls.append("full")
+
+    monkeypatch.setattr(upload_all, "refresh_tiktok_tokens", mock_refresh)
+    monkeypatch.setattr(upload_all, "run_tiktok_auth", mock_full)
+
+    refreshers = upload_all._get_auth_refreshers()
+    refreshers["tiktok"]()
+
+    assert calls == ["refresh", "full"]
+
+
+def test_tiktok_refresh_success(monkeypatch):
+    calls = []
+
+    def mock_refresh():
+        calls.append("refresh")
+        return True
+
+    def mock_full():
+        calls.append("full")
+
+    monkeypatch.setattr(upload_all, "refresh_tiktok_tokens", mock_refresh)
+    monkeypatch.setattr(upload_all, "run_tiktok_auth", mock_full)
+
+    refreshers = upload_all._get_auth_refreshers()
+    refreshers["tiktok"]()
+
+    assert calls == ["refresh"]
+


### PR DESCRIPTION
## Summary
- refresh TikTok access tokens before re-running auth
- try refreshing YouTube credentials before launching browser-based auth
- test refresh-first fallbacks for both platforms
- use absolute imports for integrations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b98ab70cf883239fba58dda8ef21f6