### PR TITLE
feat: support niche-specific uploads

### DIFF
--- a/server/integrations/instagram/upload.py
+++ b/server/integrations/instagram/upload.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from pathlib import Path
-from typing import Optional, Callable
+from typing import Optional
 import json
 import os
 import time
@@ -85,7 +85,13 @@ def login_or_resume(cl: Client, username: str, password: str, session_path: Path
         pass
 
 
-def clip_upload_with_retries(cl: Client, video_path: Path, caption: str) -> dict:
+def clip_upload_with_retries(
+    cl: Client,
+    video_path: Path,
+    caption: str,
+    username: str = USERNAME,
+    password: str = PASSWORD,
+) -> dict:
     last_exc: Optional[Exception] = None
     for attempt in range(1, MAX_RETRIES + 1):
         try:
@@ -106,7 +112,7 @@ def clip_upload_with_retries(cl: Client, video_path: Path, caption: str) -> dict
             }
         except LoginRequired:
             print("Session expired: re-login…")
-            login_or_resume(cl, USERNAME, PASSWORD)
+            login_or_resume(cl, username, password)
         except PleaseWaitFewMinutes as e:
             print(f"Upload throttled (attempt {attempt}/{MAX_RETRIES}): {e}")
             time.sleep(RETRY_BACKOFF_SEC * attempt)
@@ -133,7 +139,7 @@ def main() -> None:
     cl = build_client()
     login_or_resume(cl, USERNAME, PASSWORD)
 
-    result = clip_upload_with_retries(cl, VIDEO_PATH, caption)
+    result = clip_upload_with_retries(cl, VIDEO_PATH, caption, USERNAME, PASSWORD)
     print("Uploaded:", result)
     save_state(STATE_PATH, {"uploaded": result, "video": str(VIDEO_PATH), "caption": caption})
 

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -69,7 +69,7 @@ from helpers.description import maybe_append_website_link
 from steps.candidates import ClipCandidate
 
 
-def process_video(yt_url: str) -> None:
+def process_video(yt_url: str, niche: str | None = None) -> None:
     overall_start = time.perf_counter()
 
     CLIP_TYPE = "funny"  # change to 'inspiring' or 'educational'
@@ -101,6 +101,8 @@ def process_video(yt_url: str) -> None:
 
     # Create a dedicated output directory for this run
     base_output_dir = Path(__file__).resolve().parent.parent / "out"
+    if niche:
+        base_output_dir /= niche
     project_dir = base_output_dir / non_suffix_filename
     project_dir.mkdir(parents=True, exist_ok=True)
 
@@ -449,5 +451,6 @@ if __name__ == "__main__":
 
     urls = get_video_urls(yt_url)
     urls.reverse() # If the playlist is newest first, reverse to process oldest first
+    niche = None  # Set to a niche/account name to output under out/<niche>
     for url in urls[1:2]:
-        process_video(url)
+        process_video(url, niche=niche)

--- a/tests/test_auth_refreshers.py
+++ b/tests/test_auth_refreshers.py
@@ -14,7 +14,7 @@ def test_youtube_refresh_then_full(monkeypatch):
     monkeypatch.setattr(upload_all, "refresh_creds", mock_refresh)
     monkeypatch.setattr(upload_all, "ensure_creds", mock_full)
 
-    refreshers = upload_all._get_auth_refreshers()
+    refreshers = upload_all._get_auth_refreshers("u", "p")
     refreshers["youtube"]()
 
     assert calls == ["refresh", "full"]
@@ -33,7 +33,7 @@ def test_youtube_refresh_success(monkeypatch):
     monkeypatch.setattr(upload_all, "refresh_creds", mock_refresh)
     monkeypatch.setattr(upload_all, "ensure_creds", mock_full)
 
-    refreshers = upload_all._get_auth_refreshers()
+    refreshers = upload_all._get_auth_refreshers("u", "p")
     refreshers["youtube"]()
 
     assert calls == ["refresh"]
@@ -52,7 +52,7 @@ def test_tiktok_refresh_then_full(monkeypatch):
     monkeypatch.setattr(upload_all, "refresh_tiktok_tokens", mock_refresh)
     monkeypatch.setattr(upload_all, "run_tiktok_auth", mock_full)
 
-    refreshers = upload_all._get_auth_refreshers()
+    refreshers = upload_all._get_auth_refreshers("u", "p")
     refreshers["tiktok"]()
 
     assert calls == ["refresh", "full"]
@@ -71,7 +71,7 @@ def test_tiktok_refresh_success(monkeypatch):
     monkeypatch.setattr(upload_all, "refresh_tiktok_tokens", mock_refresh)
     monkeypatch.setattr(upload_all, "run_tiktok_auth", mock_full)
 
-    refreshers = upload_all._get_auth_refreshers()
+    refreshers = upload_all._get_auth_refreshers("u", "p")
     refreshers["tiktok"]()
 
     assert calls == ["refresh"]

--- a/tests/test_upload_retry.py
+++ b/tests/test_upload_retry.py
@@ -15,12 +15,12 @@ def test_retry_auth_on_failure(monkeypatch, tmp_path):
         calls["auth"] += 1
 
     monkeypatch.setattr(upload_all, "_upload_youtube", mock_upload)
-    monkeypatch.setattr(upload_all, "_upload_instagram", lambda v, d: None)
+    monkeypatch.setattr(upload_all, "_upload_instagram", lambda v, d, u, p: None)
     monkeypatch.setattr(
         upload_all, "_upload_tiktok", lambda v, d, cs, p, tf: None
     )
     monkeypatch.setattr(
-        upload_all, "_get_auth_refreshers", lambda: {"youtube": mock_auth}
+        upload_all, "_get_auth_refreshers", lambda u, p: {"youtube": mock_auth}
     )
 
     upload_all.upload_all(
@@ -31,6 +31,8 @@ def test_retry_auth_on_failure(monkeypatch, tmp_path):
         tt_chunk_size=1,
         tt_privacy="PRIVATE",
         tokens_file=tmp_path / "t.json",
+        ig_username="u",
+        ig_password="p",
     )
 
     assert calls == {"upload": 2, "auth": 1}

--- a/tests/test_upload_run_cleanup.py
+++ b/tests/test_upload_run_cleanup.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 
 import server.upload_all as upload_all
 
@@ -23,10 +24,16 @@ def test_run_folder_deletes_files(tmp_path, monkeypatch) -> None:
         tt_chunk_size: int,
         tt_privacy: str,
         tokens_file: Path,
+        ig_username: str,
+        ig_password: str,
     ) -> None:
         calls.append((video, desc))
 
     monkeypatch.setattr(upload_all, "upload_all", fake_upload_all)
+
+    (tmp_path / "instagram.json").write_text(
+        json.dumps({"username": "u", "password": "p"})
+    )
 
     upload_all.run(
         folder=folder,


### PR DESCRIPTION
## Summary
- allow selecting niche-specific output and token directories for uploads
- add `niche` parameter to pipeline and upload helpers
- ensure schedule uploader handles per-niche folders and account selection
- read Instagram username/password from `tokens/<niche>/instagram.json` instead of environment variables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9a08051b88323bd240e3e28f71e29