### PR TITLE
Use top hashtags for YouTube titles

### DIFF
--- a/server/integrations/youtube/upload.py
+++ b/server/integrations/youtube/upload.py
@@ -10,6 +10,7 @@ from googleapiclient.http import MediaFileUpload
 from googleapiclient.errors import HttpError
 
 from .auth import ensure_creds
+from server.helpers.description import maybe_append_website_link
 
 # --- Configuration ---
 VIDEO_PATH = Path(
@@ -27,63 +28,30 @@ CHUNKSIZE = 8 * 1024 * 1024  # 8MB works well; library handles resumable uploadi
 def read_description(path: Path) -> tuple[str, str]:
     """
     Reads the description file and splits into (title, rest_description).
-    Default: first non-empty, non-hashtag-only line is the title; the rest is the description.
-    Enforces YouTube limits (title<=100 chars, description<=5000 bytes approx.).
+    The title is composed exclusively of the first few hashtags found in the
+    description text (up to four). The rest of the text becomes the video
+    description.
     """
     if not path.exists():
         return ("Untitled clip", "")
+
     raw = path.read_text(encoding="utf-8", errors="ignore").strip()
-    lines = [ln.strip() for ln in raw.splitlines() if ln.strip()]
-    # choose first line that is not just hashtags
-    title_line = next((ln for ln in lines if not ln.lstrip().startswith('#')), "Untitled clip")
-    # sanitize title: remove angle brackets which are not allowed by API
-    title_clean = title_line.replace('<', '').replace('>', '').strip()
-    if not title_clean:
-        title_clean = "Untitled clip"
-    # enforce max 100 characters per API
-    title_clean = title_clean[:100]
+    desc_text = maybe_append_website_link(raw)
 
-    # description is everything except the chosen title line
-    rest_lines = [ln for ln in lines if ln is not title_line]
-    desc_text = "\n".join(rest_lines).strip()
-
-    # --- Hashtag extraction and appending to title ---
     import re
-    # Extract hashtags from the description text
-    hashtag_pattern = r"(?:^|\s)(#\w+)"
-    hashtags = re.findall(hashtag_pattern, desc_text)
-    hashtags = [tag.strip() for tag in hashtags if tag.strip()]
-    first_hashtags = hashtags[:3]  # up to 3
-    # Compose hashtags as a string to append
-    hashtags_str = " ".join(first_hashtags)
-    if hashtags_str:
-        # Try to append hashtags to title_clean, respecting 100 char limit
-        # Leave a space if needed
-        available = 100 - len(title_clean)
-        if available > 0:
-            # Add a space if title_clean doesn't already end with space and hashtags_str isn't empty
-            sep = "" if title_clean.endswith(" ") or not title_clean else " "
-            hashtags_to_add = hashtags_str
-            # If too long, truncate hashtags_str
-            if len(sep + hashtags_str) > available:
-                # Try to fit as many hashtags as possible
-                tags = []
-                total = len(sep)
-                for tag in first_hashtags:
-                    taglen = len(tag) + (1 if tags else 0)
-                    if total + taglen > available:
-                        break
-                    tags.append(tag)
-                    total += taglen
-                hashtags_to_add = " ".join(tags)
-            if hashtags_to_add:
-                title_clean = (title_clean + sep + hashtags_to_add).strip()
-        # Ensure final title is max 100 chars
-        title_clean = title_clean[:100]
 
-    # keep within ~5000 chars
+    hashtag_pattern = r"(?:^|\s)(#\w+)"
+    hashtags = [tag.strip() for tag in re.findall(hashtag_pattern, desc_text)]
+    title_hashtags = hashtags[:4]
+    if title_hashtags:
+        title_clean = " ".join(title_hashtags)
+    else:
+        title_clean = "Untitled clip"
+    title_clean = title_clean.strip()[:100]
+
     if len(desc_text) > 4900:
         desc_text = desc_text[:4900]
+
     return title_clean, desc_text
 
 

--- a/tests/test_description_link.py
+++ b/tests/test_description_link.py
@@ -1,4 +1,5 @@
 from server.helpers.description import maybe_append_website_link
+from server.integrations.youtube.upload import read_description
 
 
 def test_maybe_appends_website_link_when_enabled(monkeypatch):
@@ -23,3 +24,22 @@ def test_maybe_skips_website_link_when_disabled(monkeypatch):
     text = "Full video: link"
     result = maybe_append_website_link(text)
     assert "https://atropos-video.com" not in result
+
+
+def test_read_description_appends_link_to_description_only(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "server.helpers.description.INCLUDE_WEBSITE_LINK", True
+    )
+    monkeypatch.setattr(
+        "server.helpers.description.WEBSITE_URL", "https://atropos-video.com"
+    )
+    desc_file = tmp_path / "desc.txt"
+    desc_file.write_text(
+        "Full video line\nCredit line\n#funny #cool #wow #amazing #extra",
+        encoding="utf-8",
+    )
+    title, description = read_description(desc_file)
+    assert title == "#funny #cool #wow #amazing"
+    assert "https://atropos-video.com" not in title
+    assert description.endswith("https://atropos-video.com")
+


### PR DESCRIPTION
## Summary
- restore pipeline's website-link helper
- derive YouTube titles from the first few hashtags
- test that titles contain only hashtags and link stays in descriptions

## Testing
- `pytest` *(fails: No module named 'server' / other modules)*
- `PYTHONPATH=.:server pytest tests/test_description_link.py`

------
https://chatgpt.com/codex/tasks/task_e_68b9f990c6788323896e2060d14339f4