### PR TITLE
Ensure transcribe step captures all segments

### DIFF
--- a/server/steps/transcribe.py
+++ b/server/steps/transcribe.py
@@ -6,8 +6,9 @@ def transcribe_audio(file_path, model_size="medium"):
     """Transcribe an audio file using faster_whisper."""
     with Timer() as t:
         model = WhisperModel(model_size, device="auto")
-        segments, info = model.transcribe(file_path)
-    text = "".join([s.text for s in segments])
+        segments_iter, info = model.transcribe(file_path)
+        segments = list(segments_iter)
+    text = "".join(s.text for s in segments)
     segment_list = [
         {
             "start": s.start,

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,0 +1,46 @@
+"""Tests for the transcribe step."""
+
+import sys
+import types
+from pathlib import Path
+
+
+class FakeSegment:
+    def __init__(self, start, end, text):
+        self.start = start
+        self.end = end
+        self.text = text
+
+
+class FakeModel:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def transcribe(self, file_path):
+        segments = (
+            seg
+            for seg in [
+                FakeSegment(0.0, 1.0, "Hello "),
+                FakeSegment(1.0, 2.0, "world!"),
+            ]
+        )
+        return segments, {}
+
+
+fake_fw = types.SimpleNamespace(WhisperModel=FakeModel)
+sys.modules["faster_whisper"] = fake_fw
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+from server.steps import transcribe
+
+
+def test_transcribe_audio_handles_generator():
+    result = transcribe.transcribe_audio("dummy", model_size="fake")
+    assert result["text"] == "Hello world!"
+    assert result["segments"] == [
+        {"start": 0.0, "end": 1.0, "text": "Hello "},
+        {"start": 1.0, "end": 2.0, "text": "world!"},
+    ]
+    assert result["timing"]["total_time"] >= 0
+


### PR DESCRIPTION
## Summary
- Prevent faster-whisper's generator from being consumed twice by converting segments iterator into a list
- Add regression test covering transcribe_audio generator handling

## Testing
- `pytest` *(fails: No module named 'requests')*
- `pip install -r requirements.txt` *(fails: conflicting dependencies)*
- `pytest tests/test_transcribe.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba0bc6c4a88323b196c1f058254d20