### PR TITLE
Refine transcript segments with LLM

### DIFF
--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -21,7 +21,11 @@ from steps.candidates.helpers import (
     snap_end_to_dialog_end,
     dedupe_candidates,
 )
-from steps.segment import segment_transcript_items, write_segments_json
+from steps.segment import (
+    segment_transcript_items,
+    refine_segments_with_llm,
+    write_segments_json,
+)
 from steps.cut import save_clip_from_candidate
 from steps.subtitle import build_srt_for_range
 from steps.render import render_vertical_with_captions
@@ -276,6 +280,7 @@ def process_video(yt_url: str, niche: str | None = None) -> None:
     # Parse transcript once for snapping boundaries
     items = parse_transcript(transcript_output_path)
     segments = segment_transcript_items(items)
+    segments = refine_segments_with_llm(segments)
     write_segments_json(segments, project_dir / "segments.json")
 
     dialog_ranges_path = project_dir / "dialog_ranges.json"

--- a/server/steps/segment.py
+++ b/server/steps/segment.py
@@ -5,6 +5,8 @@ import re
 from pathlib import Path
 from typing import List, Tuple
 
+from helpers.ai import local_llm_call_json
+
 _SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
 
 
@@ -36,6 +38,67 @@ def segment_transcript_items(
             segments.append((cur, seg_end, sent))
             cur = seg_end
     return segments
+
+
+def refine_segments_with_llm(
+    segments: List[Tuple[float, float, str]],
+    *,
+    model: str = "google/gemma-3-4b",
+    timeout: int = 120,
+) -> List[Tuple[float, float, str]]:
+    """Use an LLM to merge or split segments into complete sentences.
+
+    Parameters
+    ----------
+    segments:
+        Existing list of ``(start, end, text)`` entries.
+    model:
+        Local LLM model identifier.
+    timeout:
+        Request timeout in seconds for the LLM call.
+
+    Returns
+    -------
+    List[Tuple[float, float, str]]
+        Adjusted segments or the original ``segments`` if the LLM call fails
+        or returns an empty list.
+    """
+
+    prompt_lines = [
+        "Combine or split the following transcript segments so each is a",
+        "complete sentence or phrase. Return a JSON array of objects with",
+        "`start`, `end`, and `text` fields. Use provided times when merging",
+        "segments; if splitting, divide the time span proportionally by",
+        "sentence length. Output only JSON.",
+        "",
+        "Segments:",
+    ]
+    prompt_lines.extend(f"[{s:.2f}-{e:.2f}] {t}" for s, e, t in segments)
+    prompt = "\n".join(prompt_lines)
+
+    try:
+        out = local_llm_call_json(
+            model=model,
+            prompt=prompt,
+            options={"temperature": 0.0},
+            timeout=timeout,
+        )
+    except Exception:
+        return segments
+
+    refined: List[Tuple[float, float, str]] = []
+    if isinstance(out, list):
+        for obj in out:
+            try:
+                s = float(obj.get("start"))
+                e = float(obj.get("end"))
+                t = str(obj.get("text", "")).strip()
+            except Exception:
+                continue
+            if t:
+                refined.append((s, e, t))
+
+    return refined or segments
 
 
 def write_segments_json(

--- a/tests/test_segment_llm.py
+++ b/tests/test_segment_llm.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+import server.steps.segment as seg_pkg
+from server.steps.segment import segment_transcript_items, refine_segments_with_llm
+
+
+def test_refine_segments_with_llm_merges(monkeypatch) -> None:
+    items = [
+        (0.0, 0.5, "Hello"),
+        (0.5, 1.0, "world."),
+        (1.0, 2.0, "This is test."),
+    ]
+    segments = segment_transcript_items(items)
+
+    def fake_llm(model, prompt, options=None, timeout=None):
+        return [
+            {"start": 0.0, "end": 1.0, "text": "Hello world."},
+            {"start": 1.0, "end": 2.0, "text": "This is test."},
+        ]
+
+    monkeypatch.setattr(seg_pkg, "local_llm_call_json", fake_llm)
+
+    refined = refine_segments_with_llm(segments)
+    assert refined == [
+        (0.0, 1.0, "Hello world."),
+        (1.0, 2.0, "This is test."),
+    ]
+
+
+def test_refine_segments_with_llm_fallback(monkeypatch) -> None:
+    items = [
+        (0.0, 1.0, "Hi."),
+        (1.0, 2.0, "Bye."),
+    ]
+    segments = segment_transcript_items(items)
+
+    def fake_llm(model, prompt, options=None, timeout=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(seg_pkg, "local_llm_call_json", fake_llm)
+
+    refined = refine_segments_with_llm(segments)
+    assert refined == segments


### PR DESCRIPTION
## Summary
- add `refine_segments_with_llm` to merge or split transcript segments using a local LLM
- call LLM-based refinement in the pipeline before writing segments JSON
- test segment refinement and fallback behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba023129588323aea5235ca6e14288