### PR TITLE
Refine transcript segments with LLM

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -18,6 +18,9 @@ SNAP_TO_SILENCE = True
 SNAP_TO_DIALOG = False
 SNAP_TO_SENTENCE = True
 
+# Toggle LLM-based refinement of transcript segments
+REFINE_SEGMENTS_WITH_LLM = True
+
 # Export silence-only "raw" clips for debugging comparisons
 EXPORT_RAW_CLIPS = False
 
@@ -72,6 +75,7 @@ __all__ = [
     "SNAP_TO_SILENCE",
     "SNAP_TO_DIALOG",
     "SNAP_TO_SENTENCE",
+    "REFINE_SEGMENTS_WITH_LLM",
     "EXPORT_RAW_CLIPS",
     "SILENCE_DETECTION_NOISE",
     "SILENCE_DETECTION_MIN_DURATION",

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -21,7 +21,11 @@ from steps.candidates.helpers import (
     snap_end_to_dialog_end,
     dedupe_candidates,
 )
-from steps.segment import segment_transcript_items, write_segments_json
+from steps.segment import (
+    segment_transcript_items,
+    maybe_refine_segments_with_llm,
+    write_segments_json,
+)
 from steps.cut import save_clip_from_candidate
 from steps.subtitle import build_srt_for_range
 from steps.render import render_vertical_with_captions
@@ -276,6 +280,7 @@ def process_video(yt_url: str, niche: str | None = None) -> None:
     # Parse transcript once for snapping boundaries
     items = parse_transcript(transcript_output_path)
     segments = segment_transcript_items(items)
+    segments = maybe_refine_segments_with_llm(segments)
     write_segments_json(segments, project_dir / "segments.json")
 
     dialog_ranges_path = project_dir / "dialog_ranges.json"

--- a/tests/test_segment_llm.py
+++ b/tests/test_segment_llm.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+import server.steps.segment as seg_pkg
+from server.steps.segment import (
+    segment_transcript_items,
+    refine_segments_with_llm,
+    maybe_refine_segments_with_llm,
+)
+
+
+def test_refine_segments_with_llm_merges(monkeypatch) -> None:
+    items = [
+        (0.0, 0.5, "Hello"),
+        (0.5, 1.0, "world."),
+        (1.0, 2.0, "This is test."),
+    ]
+    segments = segment_transcript_items(items)
+
+    def fake_llm(model, prompt, options=None, timeout=None):
+        return [
+            {"start": 0.0, "end": 1.0, "text": "Hello world."},
+            {"start": 1.0, "end": 2.0, "text": "This is test."},
+        ]
+
+    monkeypatch.setattr(seg_pkg, "local_llm_call_json", fake_llm)
+
+    refined = refine_segments_with_llm(segments)
+    assert refined == [
+        (0.0, 1.0, "Hello world."),
+        (1.0, 2.0, "This is test."),
+    ]
+
+
+def test_refine_segments_with_llm_fallback(monkeypatch) -> None:
+    items = [
+        (0.0, 1.0, "Hi."),
+        (1.0, 2.0, "Bye."),
+    ]
+    segments = segment_transcript_items(items)
+
+    def fake_llm(model, prompt, options=None, timeout=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(seg_pkg, "local_llm_call_json", fake_llm)
+
+    refined = refine_segments_with_llm(segments)
+    assert refined == segments
+
+
+def test_maybe_refine_segments_with_llm_respects_config(monkeypatch) -> None:
+    items = [(0.0, 1.0, "Hello world.")]
+    segments = segment_transcript_items(items)
+
+    def fake_refine(seg, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError("refine_segments_with_llm should not be called")
+
+    monkeypatch.setattr(seg_pkg, "refine_segments_with_llm", fake_refine)
+    monkeypatch.setattr(seg_pkg.config, "REFINE_SEGMENTS_WITH_LLM", False)
+
+    refined = maybe_refine_segments_with_llm(segments)
+    assert refined == segments


### PR DESCRIPTION
## Summary
- add `REFINE_SEGMENTS_WITH_LLM` config flag to enable or skip LLM-based segment refinement
- wrap LLM segment logic in `maybe_refine_segments_with_llm` and use it in pipeline
- test that segment refinement is bypassed when the config flag is disabled

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests', 'dotenv', 'googleapiclient', 'colorama')*

------
https://chatgpt.com/codex/tasks/task_e_68ba023129588323aea5235ca6e14288