### PR TITLE
Support Twitch VOD downloads

### DIFF
--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -7,6 +7,7 @@ from steps.download import (
     download_video,
     get_video_info,
     get_video_urls,
+    is_twitch_url,
 )
 from steps.candidates.funny import find_funny_timestamps_batched
 from steps.candidates.inspiring import find_inspiring_timestamps_batched
@@ -78,6 +79,8 @@ from steps.candidates import ClipCandidate
 
 def process_video(yt_url: str, niche: str | None = None) -> None:
     overall_start = time.perf_counter()
+    twitch = is_twitch_url(yt_url)
+    transcript_source = "whisper" if twitch else TRANSCRIPT_SOURCE
 
     CLIP_TYPE = "funny"  # change to 'inspiring' or 'educational'
     rating_defaults = {
@@ -165,7 +168,7 @@ def process_video(yt_url: str, niche: str | None = None) -> None:
         write_transcript_txt(result, str(transcript_output_path))
         return True
 
-    if TRANSCRIPT_SOURCE == "whisper":
+    if transcript_source == "whisper":
         transcribed = False
         if audio_ok:
             transcribed = run_step(

--- a/tests/test_twitch.py
+++ b/tests/test_twitch.py
@@ -1,0 +1,13 @@
+from server.steps.download import get_video_urls, download_transcript
+
+
+def test_get_video_urls_non_youtube():
+    url = "https://www.twitch.tv/videos/12345"
+    assert get_video_urls(url) == [url]
+
+
+def test_download_transcript_non_youtube(tmp_path):
+    url = "https://www.twitch.tv/videos/12345"
+    out = tmp_path / "t.txt"
+    assert download_transcript(url, str(out)) is False
+    assert not out.exists()


### PR DESCRIPTION
## Summary
- handle Twitch URLs in video downloader and info extraction
- always transcribe with Whisper for Twitch videos
- test Twitch URL handling

## Testing
- `pytest` *(fails: test_description_link.py::test_read_description_appends_link_to_description_only, test_schedule_upload.py::test_main_cleans_and_deletes, test_schedule_upload.py::test_main_respects_kind, test_schedule_upload.py::test_main_accepts_platforms, test_transcribe.py::test_whisper_model_env_override)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1a0553ec8323bbf34023c161f1df