### PR TITLE
Add optional LLM-based dialog range detection

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -24,6 +24,9 @@ SNAP_TO_SENTENCE = True
 # Toggle LLM-based refinement of transcript segments
 REFINE_SEGMENTS_WITH_LLM = True
 
+# Toggle LLM-based detection of dialog ranges
+DETECT_DIALOG_WITH_LLM = False
+
 # Export silence-only "raw" clips for debugging comparisons
 EXPORT_RAW_CLIPS = False
 
@@ -82,6 +85,7 @@ __all__ = [
     "SNAP_TO_DIALOG",
     "SNAP_TO_SENTENCE",
     "REFINE_SEGMENTS_WITH_LLM",
+    "DETECT_DIALOG_WITH_LLM",
     "EXPORT_RAW_CLIPS",
     "SILENCE_DETECTION_NOISE",
     "SILENCE_DETECTION_MIN_DURATION",

--- a/server/steps/dialog.py
+++ b/server/steps/dialog.py
@@ -2,22 +2,17 @@ import json
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
+import config
+from helpers.ai import local_llm_call_json
 from .candidates.helpers import parse_transcript
 
 _KEYWORDS = {"haha", "lol", "joke", "laugh", "laughter"}
 
 
-def detect_dialog_ranges(transcript_path: str | Path, *, gap: float = 1.0) -> List[Tuple[float, float]]:
-    """Detect conversational or joke segments within ``transcript_path``.
-
-    The transcript is expected to contain lines formatted as
-    ``[start -> end] text``.  A simple heuristic is used: any line containing a
-    question mark, an exclamation mark, or one of several laugh-related
-    keywords is marked as dialog.  Consecutive dialog lines, or ones separated
-    by ``gap`` seconds or less, are merged into a single range.
-    """
-
-    items = parse_transcript(transcript_path)
+def _heuristic_dialog_ranges(
+    items: List[Tuple[float, float, str]], gap: float
+) -> List[Tuple[float, float]]:
+    """Detect dialog ranges using a simple keyword heuristic."""
     ranges: List[Tuple[float, float]] = []
     current_start: float | None = None
     current_end: float | None = None
@@ -46,6 +41,62 @@ def detect_dialog_ranges(transcript_path: str | Path, *, gap: float = 1.0) -> Li
         ranges.append((current_start, current_end))
 
     return ranges
+
+
+def _llm_dialog_ranges(
+    items: List[Tuple[float, float, str]], *, model: str = "google/gemma-3-4b", timeout: int = 120
+) -> List[Tuple[float, float]]:
+    """Detect dialog ranges using an LLM."""
+    prompt_lines = [
+        "Determine the start and end times of coherent dialog in the following",  # noqa: E501
+        "transcript lines. Return a JSON array of objects with `start` and",
+        "`end` fields. Only output JSON.",
+        "",
+        "Lines:",
+    ]
+    prompt_lines.extend(f"[{s:.2f}-{e:.2f}] {t}" for s, e, t in items)
+    prompt = "\n".join(prompt_lines)
+
+    out = local_llm_call_json(
+        model=model,
+        prompt=prompt,
+        options={"temperature": 0.0},
+        timeout=timeout,
+    )
+
+    ranges: List[Tuple[float, float]] = []
+    if isinstance(out, list):
+        for obj in out:
+            try:
+                s = float(obj.get("start"))
+                e = float(obj.get("end"))
+            except Exception:
+                continue
+            ranges.append((s, e))
+    return ranges
+
+
+def detect_dialog_ranges(
+    transcript_path: str | Path, *, gap: float = 1.0
+) -> List[Tuple[float, float]]:
+    """Detect dialog ranges in ``transcript_path``.
+
+    When :data:`config.DETECT_DIALOG_WITH_LLM` is true, this function first
+    attempts to use an LLM to determine ranges. If the LLM call fails or
+    returns no data, a simple keyword heuristic is used as a fallback.
+    """
+
+    items = parse_transcript(transcript_path)
+
+    if getattr(config, "DETECT_DIALOG_WITH_LLM", False):
+        try:
+            ranges = _llm_dialog_ranges(items)
+            if ranges:
+                return ranges
+        except Exception:
+            pass
+
+    return _heuristic_dialog_ranges(items, gap)
 
 
 def write_dialog_ranges_json(ranges: Iterable[Tuple[float, float]], path: str | Path) -> None:

--- a/tests/test_dialog_llm.py
+++ b/tests/test_dialog_llm.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+import server.steps.dialog as dialog_pkg
+from server.steps.dialog import detect_dialog_ranges
+
+
+def _make_transcript(path: Path) -> None:
+    path.write_text(
+        """\
+[0.0 -> 1.0] Hello.
+[1.0 -> 2.0] This is funny haha!
+[2.1 -> 3.0] Are you serious?
+[4.0 -> 5.0] Another statement.
+""".strip()
+    )
+
+
+def test_detect_dialog_ranges_with_llm(monkeypatch, tmp_path: Path) -> None:
+    transcript = tmp_path / "sample.txt"
+    _make_transcript(transcript)
+
+    def fake_llm(model, prompt, options=None, timeout=None):
+        return [
+            {"start": 0.0, "end": 1.0},
+            {"start": 4.0, "end": 5.0},
+        ]
+
+    monkeypatch.setattr(dialog_pkg, "local_llm_call_json", fake_llm)
+    monkeypatch.setattr(dialog_pkg.config, "DETECT_DIALOG_WITH_LLM", True)
+
+    ranges = detect_dialog_ranges(str(transcript))
+    assert ranges == [(0.0, 1.0), (4.0, 5.0)]
+
+
+def test_detect_dialog_ranges_llm_fallback(monkeypatch, tmp_path: Path) -> None:
+    transcript = tmp_path / "sample.txt"
+    _make_transcript(transcript)
+
+    def fake_llm(model, prompt, options=None, timeout=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(dialog_pkg, "local_llm_call_json", fake_llm)
+    monkeypatch.setattr(dialog_pkg.config, "DETECT_DIALOG_WITH_LLM", True)
+
+    ranges = detect_dialog_ranges(str(transcript))
+    assert ranges == [(1.0, 3.0)]
+
+
+def test_detect_dialog_ranges_llm_respects_config(monkeypatch, tmp_path: Path) -> None:
+    transcript = tmp_path / "sample.txt"
+    _make_transcript(transcript)
+
+    def fake_llm(model, prompt, options=None, timeout=None):  # pragma: no cover
+        raise AssertionError("LLM should not be called")
+
+    monkeypatch.setattr(dialog_pkg, "local_llm_call_json", fake_llm)
+    monkeypatch.setattr(dialog_pkg.config, "DETECT_DIALOG_WITH_LLM", False)
+
+    ranges = detect_dialog_ranges(str(transcript))
+    assert ranges == [(1.0, 3.0)]


### PR DESCRIPTION
## Summary
- add `DETECT_DIALOG_WITH_LLM` configuration flag
- use an LLM to compute dialog ranges with keyword heuristic fallback
- test dialog range detection with LLM and config overrides

## Testing
- `pytest tests/test_dialog.py tests/test_dialog_llm.py`
- `pytest` *(fails: FileNotFoundError for `ffmpeg`, schedule upload asserts, env override assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3a2f73c08323a467fc9bc711ca1f