### PR TITLE
Clean up empty project directories after uploads

### DIFF
--- a/server/upload_all.py
+++ b/server/upload_all.py
@@ -114,6 +114,15 @@ def _get_auth_refreshers(username: str, password: str) -> Dict[str, Callable[[],
     }
 
 
+def _tidy_empty_dirs(shorts: Path, project: Path) -> None:
+    """Delete empty ``shorts`` and project directories."""
+
+    if not any(shorts.iterdir()):
+        shorts.rmdir()
+        if not any(project.iterdir()):
+            project.rmdir()
+
+
 def upload_all(
     video: Path,
     desc: Path,
@@ -209,7 +218,8 @@ def run(
     tt_privacy = tt_privacy or TIKTOK_PRIVACY_LEVEL
 
     if folder:
-        for vid in sorted(Path(folder).glob("*.mp4")):
+        folder = Path(folder)
+        for vid in sorted(folder.glob("*.mp4")):
             desc_path = vid.with_suffix(".txt")
             if not desc_path.exists():
                 print(f"No description for {vid}, skipping")
@@ -231,6 +241,8 @@ def run(
                 for f in vid.parent.glob(f"{vid.stem}.*"):
                     if f.is_file():
                         f.unlink(missing_ok=True)
+        if folder.exists():
+            _tidy_empty_dirs(folder, folder.parent)
     else:
         video = Path(video) if video else DEFAULT_VIDEO
         desc = Path(desc) if desc else DEFAULT_DESC

--- a/tests/test_upload_run_cleanup.py
+++ b/tests/test_upload_run_cleanup.py
@@ -6,8 +6,9 @@ import server.upload_all as upload_all
 
 
 def test_run_folder_deletes_files(tmp_path, monkeypatch) -> None:
-    folder = tmp_path / "clips"
-    folder.mkdir()
+    project = tmp_path / "proj"
+    folder = project / "shorts"
+    folder.mkdir(parents=True)
     video = folder / "clip.mp4"
     video.write_bytes(b"a")
     desc = folder / "clip.txt"
@@ -50,4 +51,6 @@ def test_run_folder_deletes_files(tmp_path, monkeypatch) -> None:
     assert not video.exists()
     assert not desc.exists()
     assert not extra.exists()
+    assert not folder.exists()
+    assert not project.exists()
 


### PR DESCRIPTION
## Summary
- remove empty shorts/project folders after bulk uploads
- test that uploading a folder cleans up project directory

## Testing
- `OUT_ROOT=out pytest` *(fails: ffmpeg missing, whisper model override, description link test)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8258139483238771d27d213231f0