### PR TITLE
Improve transcript gating and structural candidate batching

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -46,10 +46,10 @@ WHISPER_MODEL = "tiny"
 # ---------------------------------------
 # Candidate selection heuristics
 # ---------------------------------------
-MIN_DURATION_SECONDS = 3.0
-MAX_DURATION_SECONDS = 90.0
-SWEET_SPOT_MIN_SECONDS = 5.0
-SWEET_SPOT_MAX_SECONDS = 15.0
+MIN_DURATION_SECONDS = 6.0
+MAX_DURATION_SECONDS = 60.0
+SWEET_SPOT_MIN_SECONDS = 8.0
+SWEET_SPOT_MAX_SECONDS = 20.0
 
 DEFAULT_MIN_RATING = 7.0
 DEFAULT_MIN_WORDS = 0
@@ -62,6 +62,17 @@ EDUCATIONAL_MIN_WORDS = 8
 
 INSPIRING_MIN_RATING = 7.0
 INSPIRING_MIN_WORDS = 8
+
+# ---------------------------------------
+# Pipeline and batching controls
+# ---------------------------------------
+FORCE_REBUILD = False
+WINDOW_SIZE_SECONDS = 30.0
+WINDOW_OVERLAP_SECONDS = 10.0
+WINDOW_CONTEXT_SECONDS = 2.0
+RATING_MIN = 0.0
+RATING_MAX = 10.0
+MIN_EXTENSION_MARGIN = 0.3
 
 # ---------------------------------------
 # Multi-platform upload settings
@@ -104,6 +115,13 @@ __all__ = [
     "EDUCATIONAL_MIN_WORDS",
     "INSPIRING_MIN_RATING",
     "INSPIRING_MIN_WORDS",
+    "FORCE_REBUILD",
+    "WINDOW_SIZE_SECONDS",
+    "WINDOW_OVERLAP_SECONDS",
+    "WINDOW_CONTEXT_SECONDS",
+    "RATING_MIN",
+    "RATING_MAX",
+    "MIN_EXTENSION_MARGIN",
     "TOKENS_DIR",
     "YOUTUBE_PRIVACY",
     "YOUTUBE_CATEGORY_ID",

--- a/server/helpers/transcript_quality.py
+++ b/server/helpers/transcript_quality.py
@@ -1,0 +1,35 @@
+import string
+from typing import List
+
+
+def score_transcript_quality(text: str) -> float:
+    """Return a heuristic quality score in [0,1] for a transcript.
+
+    The score is the average of four boolean heuristics:
+    - average token length >= 3 characters
+    - punctuation density >= 1% of characters
+    - non-alphanumeric character ratio <= 20%
+    - type/token ratio (unique words / total words) >= 0.3
+    """
+    if not text:
+        return 0.0
+    tokens: List[str] = text.split()
+    if not tokens:
+        return 0.0
+    avg_token_len = sum(len(t) for t in tokens) / len(tokens)
+    punct_count = sum(1 for c in text if c in string.punctuation)
+    punct_density = punct_count / max(len(text), 1)
+    non_alnum_ratio = (
+        sum(1 for c in text if not (c.isalnum() or c.isspace()))
+        / max(len(text), 1)
+    )
+    unique_tokens = {t.lower() for t in tokens}
+    type_token_ratio = len(unique_tokens) / len(tokens)
+
+    checks = [
+        avg_token_len >= 3,
+        punct_density >= 0.01,
+        non_alnum_ratio <= 0.2,
+        type_token_ratio >= 0.3,
+    ]
+    return sum(checks) / len(checks)

--- a/server/steps/candidates/educational.py
+++ b/server/steps/candidates/educational.py
@@ -1,11 +1,54 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
+from typing import List, Tuple, Any
 
-from . import ClipCandidate, find_clip_timestamps, find_clip_timestamps_batched
-from config import EDUCATIONAL_MIN_RATING, EDUCATIONAL_MIN_WORDS
-from .prompts import EDUCATIONAL_PROMPT_DESC
+from helpers.ai import local_llm_call_json
+from config import (
+    EDUCATIONAL_MIN_RATING,
+    EDUCATIONAL_MIN_WORDS,
+    MIN_DURATION_SECONDS,
+    RATING_MIN,
+    RATING_MAX,
+    WINDOW_SIZE_SECONDS,
+    WINDOW_OVERLAP_SECONDS,
+    WINDOW_CONTEXT_SECONDS,
+)
+from . import ClipCandidate
+from .helpers import (
+    parse_transcript,
+    _get_field,
+    _to_float,
+    _merge_adjacent_candidates,
+    _enforce_non_overlap,
+    snap_start_to_dialog_start,
+    snap_end_to_dialog_end,
+    _snap_start_to_sentence_start,
+    _snap_end_to_sentence_end,
+)
+from ..silence import snap_start_to_silence, snap_end_to_silence
+from .prompts import EDUCATIONAL_PROMPT_DESC, build_window_prompt
+
+
+def _window_items(
+    items: List[Tuple[float, float, str]],
+    window: float = WINDOW_SIZE_SECONDS,
+    overlap: float = WINDOW_OVERLAP_SECONDS,
+) -> List[Tuple[float, float, List[Tuple[float, float, str]]]]:
+    if not items:
+        return []
+    start = items[0][0]
+    end = items[-1][1]
+    step = window - overlap
+    windows: List[Tuple[float, float, List[Tuple[float, float, str]]]] = []
+    t = start
+    while t < end:
+        w_end = t + window
+        win = [it for it in items if it[1] > t and it[0] < w_end]
+        if win:
+            windows.append((t, w_end, win))
+        t += step
+    return windows
 
 
 def find_educational_timestamps_batched(
@@ -14,36 +57,77 @@ def find_educational_timestamps_batched(
     min_rating: float = EDUCATIONAL_MIN_RATING,
     min_words: int = EDUCATIONAL_MIN_WORDS,
     return_all_stages: bool = False,
-    **kwargs,
-) -> List[ClipCandidate]:
-    """Find educational clip candidates using batched processing."""
-    return find_clip_timestamps_batched(
-        transcript_path,
-        prompt_desc=EDUCATIONAL_PROMPT_DESC,
+    segments: Any | None = None,
+    dialog_ranges: Any | None = None,
+    silences: Any | None = None,
+    **kwargs: Any,
+) -> List[ClipCandidate] | tuple[List[ClipCandidate], List[ClipCandidate], List[ClipCandidate]]:
+    items = parse_transcript(transcript_path)
+    windows = _window_items(items)
+    all_candidates: List[ClipCandidate] = []
+    for win_start, win_end, win_items in windows:
+        ctx_items = [
+            it
+            for it in items
+            if it[1] > win_start - WINDOW_CONTEXT_SECONDS and it[0] < win_end + WINDOW_CONTEXT_SECONDS
+        ]
+        text = "\n".join(f"[{s:.2f}-{e:.2f}] {t}" for s, e, t in ctx_items)
+        prompt = build_window_prompt(EDUCATIONAL_PROMPT_DESC, text)
+        try:
+            arr = local_llm_call_json(
+                model="google/gemma-3-4b",
+                prompt=prompt,
+                options={"temperature": 0.2},
+            )
+        except Exception as e:
+            print(f"[Finder] window {win_start:.2f}-{win_end:.2f} failed: {e}")
+            continue
+        for it in arr:
+            start = _to_float(_get_field(it, "start"))
+            end = _to_float(_get_field(it, "end"))
+            rating = _to_float(_get_field(it, "rating"))
+            reason = str(_get_field(it, "reason", ""))
+            quote = str(_get_field(it, "quote", ""))
+            if start is None or end is None or rating is None:
+                continue
+            start = float(start)
+            end = float(end)
+            rating = round(float(rating), 1)
+            if not (RATING_MIN <= rating <= RATING_MAX):
+                continue
+            if segments is not None:
+                start = _snap_start_to_sentence_start(start, segments)
+                end = _snap_end_to_sentence_end(end, segments)
+            if dialog_ranges is not None:
+                start = snap_start_to_dialog_start(start, dialog_ranges)
+                end = snap_end_to_dialog_end(end, dialog_ranges)
+            if silences is not None:
+                start = snap_start_to_silence(start, silences)
+                end = snap_end_to_silence(end, silences)
+            all_candidates.append(
+                ClipCandidate(
+                    start=start, end=end, rating=rating, reason=reason, quote=quote
+                )
+            )
+    filtered = [c for c in all_candidates if c.rating >= min_rating]
+    merged = _merge_adjacent_candidates(filtered, items, silences=silences)
+    top = _enforce_non_overlap(
+        merged,
+        items,
+        silences=silences,
+        min_duration_seconds=MIN_DURATION_SECONDS,
         min_rating=min_rating,
-        min_words=min_words,
-        return_all_stages=return_all_stages,
-        **kwargs,
     )
+    if return_all_stages:
+        return top, merged, all_candidates
+    return top
 
 
 def find_educational_timestamps(
     transcript_path: str | Path,
-    *,
-    min_rating: float = EDUCATIONAL_MIN_RATING,
-    min_words: int = EDUCATIONAL_MIN_WORDS,
-    return_all_stages: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> List[ClipCandidate]:
-    """Find educational clip candidates."""
-    return find_clip_timestamps(
-        transcript_path,
-        prompt_desc=EDUCATIONAL_PROMPT_DESC,
-        min_rating=min_rating,
-        min_words=min_words,
-        return_all_stages=return_all_stages,
-        **kwargs,
-    )
+    return find_educational_timestamps_batched(transcript_path, **kwargs)
 
 
 __all__ = ["find_educational_timestamps_batched", "find_educational_timestamps"]

--- a/server/steps/candidates/funny.py
+++ b/server/steps/candidates/funny.py
@@ -1,11 +1,55 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
+from typing import List, Tuple, Any
 
-from . import ClipCandidate, find_clip_timestamps, find_clip_timestamps_batched
-from config import FUNNY_MIN_RATING, FUNNY_MIN_WORDS
-from .prompts import FUNNY_PROMPT_DESC, FUNNY_RATING_DESCRIPTIONS
+from helpers.ai import local_llm_call_json
+from config import (
+    FUNNY_MIN_RATING,
+    FUNNY_MIN_WORDS,
+    MIN_DURATION_SECONDS,
+    RATING_MIN,
+    RATING_MAX,
+    WINDOW_SIZE_SECONDS,
+    WINDOW_OVERLAP_SECONDS,
+    WINDOW_CONTEXT_SECONDS,
+)
+from . import ClipCandidate
+from .helpers import (
+    parse_transcript,
+    _get_field,
+    _to_float,
+    _merge_adjacent_candidates,
+    _enforce_non_overlap,
+    snap_start_to_dialog_start,
+    snap_end_to_dialog_end,
+    _snap_start_to_sentence_start,
+    _snap_end_to_sentence_end,
+)
+from ..silence import snap_start_to_silence, snap_end_to_silence
+from .prompts import FUNNY_PROMPT_DESC, build_window_prompt
+
+
+def _window_items(
+    items: List[Tuple[float, float, str]],
+    window: float = WINDOW_SIZE_SECONDS,
+    overlap: float = WINDOW_OVERLAP_SECONDS,
+) -> List[Tuple[float, float, List[Tuple[float, float, str]]]]:
+    """Return sliding windows across the transcript items."""
+    if not items:
+        return []
+    start = items[0][0]
+    end = items[-1][1]
+    step = window - overlap
+    windows: List[Tuple[float, float, List[Tuple[float, float, str]]]] = []
+    t = start
+    while t < end:
+        w_end = t + window
+        win = [it for it in items if it[1] > t and it[0] < w_end]
+        if win:
+            windows.append((t, w_end, win))
+        t += step
+    return windows
 
 
 def find_funny_timestamps_batched(
@@ -14,38 +58,78 @@ def find_funny_timestamps_batched(
     min_rating: float = FUNNY_MIN_RATING,
     min_words: int = FUNNY_MIN_WORDS,
     return_all_stages: bool = False,
-    **kwargs,
-) -> List[ClipCandidate]:
-    """Find humorous clip candidates using batched processing."""
-    return find_clip_timestamps_batched(
-        transcript_path,
-        prompt_desc=FUNNY_PROMPT_DESC,
+    segments: Any | None = None,
+    dialog_ranges: Any | None = None,
+    silences: Any | None = None,
+    **kwargs: Any,
+) -> List[ClipCandidate] | tuple[List[ClipCandidate], List[ClipCandidate], List[ClipCandidate]]:
+    """Find humorous clip candidates using time-windowed batching."""
+    items = parse_transcript(transcript_path)
+    windows = _window_items(items)
+    all_candidates: List[ClipCandidate] = []
+    for win_start, win_end, win_items in windows:
+        ctx_items = [
+            it
+            for it in items
+            if it[1] > win_start - WINDOW_CONTEXT_SECONDS and it[0] < win_end + WINDOW_CONTEXT_SECONDS
+        ]
+        text = "\n".join(f"[{s:.2f}-{e:.2f}] {t}" for s, e, t in ctx_items)
+        prompt = build_window_prompt(FUNNY_PROMPT_DESC, text)
+        try:
+            arr = local_llm_call_json(
+                model="google/gemma-3-4b",
+                prompt=prompt,
+                options={"temperature": 0.2},
+            )
+        except Exception as e:
+            print(f"[Finder] window {win_start:.2f}-{win_end:.2f} failed: {e}")
+            continue
+        for it in arr:
+            start = _to_float(_get_field(it, "start"))
+            end = _to_float(_get_field(it, "end"))
+            rating = _to_float(_get_field(it, "rating"))
+            reason = str(_get_field(it, "reason", ""))
+            quote = str(_get_field(it, "quote", ""))
+            if start is None or end is None or rating is None:
+                continue
+            start = float(start)
+            end = float(end)
+            rating = round(float(rating), 1)
+            if not (RATING_MIN <= rating <= RATING_MAX):
+                continue
+            if segments is not None:
+                start = _snap_start_to_sentence_start(start, segments)
+                end = _snap_end_to_sentence_end(end, segments)
+            if dialog_ranges is not None:
+                start = snap_start_to_dialog_start(start, dialog_ranges)
+                end = snap_end_to_dialog_end(end, dialog_ranges)
+            if silences is not None:
+                start = snap_start_to_silence(start, silences)
+                end = snap_end_to_silence(end, silences)
+            all_candidates.append(
+                ClipCandidate(
+                    start=start, end=end, rating=rating, reason=reason, quote=quote
+                )
+            )
+    filtered = [c for c in all_candidates if c.rating >= min_rating]
+    merged = _merge_adjacent_candidates(filtered, items, silences=silences)
+    top = _enforce_non_overlap(
+        merged,
+        items,
+        silences=silences,
+        min_duration_seconds=MIN_DURATION_SECONDS,
         min_rating=min_rating,
-        rating_descriptions=FUNNY_RATING_DESCRIPTIONS,
-        min_words=min_words,
-        return_all_stages=return_all_stages,
-        **kwargs,
     )
+    if return_all_stages:
+        return top, merged, all_candidates
+    return top
 
 
 def find_funny_timestamps(
     transcript_path: str | Path,
-    *,
-    min_rating: float = FUNNY_MIN_RATING,
-    min_words: int = FUNNY_MIN_WORDS,
-    return_all_stages: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> List[ClipCandidate]:
-    """Find humorous clip candidates."""
-    return find_clip_timestamps(
-        transcript_path,
-        prompt_desc=FUNNY_PROMPT_DESC,
-        min_rating=min_rating,
-        rating_descriptions=FUNNY_RATING_DESCRIPTIONS,
-        min_words=min_words,
-        return_all_stages=return_all_stages,
-        **kwargs,
-    )
+    return find_funny_timestamps_batched(transcript_path, **kwargs)
 
 
 __all__ = ["find_funny_timestamps_batched", "find_funny_timestamps"]

--- a/server/steps/candidates/inspiring.py
+++ b/server/steps/candidates/inspiring.py
@@ -1,11 +1,54 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
+from typing import List, Tuple, Any
 
-from . import ClipCandidate, find_clip_timestamps, find_clip_timestamps_batched
-from config import INSPIRING_MIN_RATING, INSPIRING_MIN_WORDS
-from .prompts import INSPIRING_PROMPT_DESC
+from helpers.ai import local_llm_call_json
+from config import (
+    INSPIRING_MIN_RATING,
+    INSPIRING_MIN_WORDS,
+    MIN_DURATION_SECONDS,
+    RATING_MIN,
+    RATING_MAX,
+    WINDOW_SIZE_SECONDS,
+    WINDOW_OVERLAP_SECONDS,
+    WINDOW_CONTEXT_SECONDS,
+)
+from . import ClipCandidate
+from .helpers import (
+    parse_transcript,
+    _get_field,
+    _to_float,
+    _merge_adjacent_candidates,
+    _enforce_non_overlap,
+    snap_start_to_dialog_start,
+    snap_end_to_dialog_end,
+    _snap_start_to_sentence_start,
+    _snap_end_to_sentence_end,
+)
+from ..silence import snap_start_to_silence, snap_end_to_silence
+from .prompts import INSPIRING_PROMPT_DESC, build_window_prompt
+
+
+def _window_items(
+    items: List[Tuple[float, float, str]],
+    window: float = WINDOW_SIZE_SECONDS,
+    overlap: float = WINDOW_OVERLAP_SECONDS,
+) -> List[Tuple[float, float, List[Tuple[float, float, str]]]]:
+    if not items:
+        return []
+    start = items[0][0]
+    end = items[-1][1]
+    step = window - overlap
+    windows: List[Tuple[float, float, List[Tuple[float, float, str]]]] = []
+    t = start
+    while t < end:
+        w_end = t + window
+        win = [it for it in items if it[1] > t and it[0] < w_end]
+        if win:
+            windows.append((t, w_end, win))
+        t += step
+    return windows
 
 
 def find_inspiring_timestamps_batched(
@@ -14,36 +57,77 @@ def find_inspiring_timestamps_batched(
     min_rating: float = INSPIRING_MIN_RATING,
     min_words: int = INSPIRING_MIN_WORDS,
     return_all_stages: bool = False,
-    **kwargs,
-) -> List[ClipCandidate]:
-    """Find inspiring clip candidates using batched processing."""
-    return find_clip_timestamps_batched(
-        transcript_path,
-        prompt_desc=INSPIRING_PROMPT_DESC,
+    segments: Any | None = None,
+    dialog_ranges: Any | None = None,
+    silences: Any | None = None,
+    **kwargs: Any,
+) -> List[ClipCandidate] | tuple[List[ClipCandidate], List[ClipCandidate], List[ClipCandidate]]:
+    items = parse_transcript(transcript_path)
+    windows = _window_items(items)
+    all_candidates: List[ClipCandidate] = []
+    for win_start, win_end, win_items in windows:
+        ctx_items = [
+            it
+            for it in items
+            if it[1] > win_start - WINDOW_CONTEXT_SECONDS and it[0] < win_end + WINDOW_CONTEXT_SECONDS
+        ]
+        text = "\n".join(f"[{s:.2f}-{e:.2f}] {t}" for s, e, t in ctx_items)
+        prompt = build_window_prompt(INSPIRING_PROMPT_DESC, text)
+        try:
+            arr = local_llm_call_json(
+                model="google/gemma-3-4b",
+                prompt=prompt,
+                options={"temperature": 0.2},
+            )
+        except Exception as e:
+            print(f"[Finder] window {win_start:.2f}-{win_end:.2f} failed: {e}")
+            continue
+        for it in arr:
+            start = _to_float(_get_field(it, "start"))
+            end = _to_float(_get_field(it, "end"))
+            rating = _to_float(_get_field(it, "rating"))
+            reason = str(_get_field(it, "reason", ""))
+            quote = str(_get_field(it, "quote", ""))
+            if start is None or end is None or rating is None:
+                continue
+            start = float(start)
+            end = float(end)
+            rating = round(float(rating), 1)
+            if not (RATING_MIN <= rating <= RATING_MAX):
+                continue
+            if segments is not None:
+                start = _snap_start_to_sentence_start(start, segments)
+                end = _snap_end_to_sentence_end(end, segments)
+            if dialog_ranges is not None:
+                start = snap_start_to_dialog_start(start, dialog_ranges)
+                end = snap_end_to_dialog_end(end, dialog_ranges)
+            if silences is not None:
+                start = snap_start_to_silence(start, silences)
+                end = snap_end_to_silence(end, silences)
+            all_candidates.append(
+                ClipCandidate(
+                    start=start, end=end, rating=rating, reason=reason, quote=quote
+                )
+            )
+    filtered = [c for c in all_candidates if c.rating >= min_rating]
+    merged = _merge_adjacent_candidates(filtered, items, silences=silences)
+    top = _enforce_non_overlap(
+        merged,
+        items,
+        silences=silences,
+        min_duration_seconds=MIN_DURATION_SECONDS,
         min_rating=min_rating,
-        min_words=min_words,
-        return_all_stages=return_all_stages,
-        **kwargs,
     )
+    if return_all_stages:
+        return top, merged, all_candidates
+    return top
 
 
 def find_inspiring_timestamps(
     transcript_path: str | Path,
-    *,
-    min_rating: float = INSPIRING_MIN_RATING,
-    min_words: int = INSPIRING_MIN_WORDS,
-    return_all_stages: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> List[ClipCandidate]:
-    """Find inspiring clip candidates."""
-    return find_clip_timestamps(
-        transcript_path,
-        prompt_desc=INSPIRING_PROMPT_DESC,
-        min_rating=min_rating,
-        min_words=min_words,
-        return_all_stages=return_all_stages,
-        **kwargs,
-    )
+    return find_inspiring_timestamps_batched(transcript_path, **kwargs)
 
 
 __all__ = ["find_inspiring_timestamps_batched", "find_inspiring_timestamps"]

--- a/server/steps/candidates/prompts.py
+++ b/server/steps/candidates/prompts.py
@@ -7,6 +7,11 @@ from config import (
     MIN_DURATION_SECONDS,
     SWEET_SPOT_MAX_SECONDS,
     SWEET_SPOT_MIN_SECONDS,
+    RATING_MIN,
+    RATING_MAX,
+    WINDOW_SIZE_SECONDS,
+    WINDOW_OVERLAP_SECONDS,
+    WINDOW_CONTEXT_SECONDS,
 )
 
 FUNNY_PROMPT_DESC = (
@@ -80,7 +85,7 @@ def _build_system_instructions(
         "- Boundaries: never start mid-word; begin at a natural lead-in and end just after the key beat lands (leave ~0.2–0.6s of tail room); prefer entering at the hook when possible. Always end at the end of a full sentence, not mid-thought.\n"
         "- Hook priority: the first 1–2 seconds must contain a clear hook (surprising line, bold claim, sharp question, or punchy setup). Trim silence/filler; avoid slow ramps. Prefer entering on the hook rather than several seconds of preamble.\n"
         "- Intro music: if there is intro music or a theme song at the start, begin the clip after the intro; never include music-only intros.\n"
-        "- Valid values: start < end; start ≥ 0; rating is a number 0.0–10.0 with one decimal place (e.g., 5.2, 6.7, 9.1). Do not restrict to .0 endings — use fractional decimals for nuance. No NaN/Infinity.\n"
+        f"- Valid values: start < end; start ≥ 0; rating is a number {RATING_MIN:.1f}–{RATING_MAX:.1f} with one decimal place (e.g., 5.2, 6.7, 9.1). Do not restrict to .0 endings — use fractional decimals for nuance. No NaN/Infinity.\n"
         "- Quote fidelity: `quote` must appear within [start, end] and capture the core line.\n"
         "- Tags: include 1–5 short, lowercase tags describing the moment (topic or device).\n"
         "- Structure: every clip should present a setup, brief escalation, and a clear payoff.\n"
@@ -105,6 +110,18 @@ def _build_system_instructions(
     )
 
 
+
+
+def build_window_prompt(prompt_desc: str, text: str) -> str:
+    """Construct a complete prompt for a transcript window."""
+    system_instructions = _build_system_instructions(prompt_desc)
+    return (
+        f"{system_instructions}\n\n"
+        f"TRANSCRIPT WINDOW (≈{WINDOW_SIZE_SECONDS:.0f}s, overlap {WINDOW_OVERLAP_SECONDS:.0f}s, context {WINDOW_CONTEXT_SECONDS:.0f}s):\n{text}\n\n"
+        "Return JSON now."
+    )
+
+
 __all__ = [
     "FUNNY_PROMPT_DESC",
     "INSPIRING_PROMPT_DESC",
@@ -112,4 +129,5 @@ __all__ = [
     "GENERAL_RATING_DESCRIPTIONS",
     "FUNNY_RATING_DESCRIPTIONS",
     "_build_system_instructions",
+    "build_window_prompt",
 ]


### PR DESCRIPTION
## Summary
- centralize duration, batching, and rating constants in config
- use shared prompt builder and config-driven windowing in candidate finders
- enforce post-snap duration limits via config values

## Testing
- `pytest` *(fails: ffmpeg missing, WHISPER_MODEL mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8a6b24788323a8a4679b79ea2a64