### PR TITLE
Gate LLM segment refinement on transcript size

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -21,10 +21,12 @@ SNAP_TO_SILENCE = True
 SNAP_TO_DIALOG = True
 SNAP_TO_SENTENCE = True
 
-# Toggle LLM-based refinement of transcript segments
-REFINE_SEGMENTS_WITH_LLM = True
+# Toggle LLM usage for transcript segmentation
+USE_LLM_FOR_SEGMENTS = False
+# Maximum transcript length to allow LLM segment refinement
+SEG_LLM_MAX_CHARS = 12_000
 # Toggle LLM-based detection of dialog ranges
-DETECT_DIALOG_WITH_LLM = True
+DETECT_DIALOG_WITH_LLM = False
 MAX_LLM_CHARS = 48_000
 LLM_API_TIMEOUT = 12000
 
@@ -105,7 +107,8 @@ __all__ = [
     "SNAP_TO_SILENCE",
     "SNAP_TO_DIALOG",
     "SNAP_TO_SENTENCE",
-    "REFINE_SEGMENTS_WITH_LLM",
+    "USE_LLM_FOR_SEGMENTS",
+    "SEG_LLM_MAX_CHARS",
     "DETECT_DIALOG_WITH_LLM",
     "EXPORT_RAW_CLIPS",
     "RAW_LIMIT",

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -64,6 +64,8 @@ from config import (
     FORCE_REBUILD_SEGMENTS,
     FORCE_REBUILD_DIALOG,
     MIN_EXTENSION_MARGIN,
+    USE_LLM_FOR_SEGMENTS,
+    SEG_LLM_MAX_CHARS,
 )
 
 import sys
@@ -297,7 +299,9 @@ def process_video(yt_url: str, niche: str | None = None) -> None:
         def step_segments() -> list[tuple[float, float, str]]:
             items = parse_transcript(transcript_output_path)
             segs = segment_transcript_items(items)
-            segs = maybe_refine_segments_with_llm(segs)
+            text = transcript_output_path.read_text(encoding="utf-8")
+            if USE_LLM_FOR_SEGMENTS and len(text) < SEG_LLM_MAX_CHARS:
+                segs = maybe_refine_segments_with_llm(segs)
             write_segments_json(segs, segments_path)
             return segs
 

--- a/server/steps/segment.py
+++ b/server/steps/segment.py
@@ -143,7 +143,7 @@ def maybe_refine_segments_with_llm(
     segments: List[Tuple[float, float, str]], **kwargs
 ) -> List[Tuple[float, float, str]]:
     """Refine segments with an LLM if enabled in configuration."""
-    if not config.REFINE_SEGMENTS_WITH_LLM:
+    if not config.USE_LLM_FOR_SEGMENTS:
         return segments
     return refine_segments_with_llm(segments, **kwargs)
 

--- a/tests/test_segment_llm.py
+++ b/tests/test_segment_llm.py
@@ -63,7 +63,7 @@ def test_maybe_refine_segments_with_llm_respects_config(monkeypatch) -> None:
         raise AssertionError("refine_segments_with_llm should not be called")
 
     monkeypatch.setattr(seg_pkg, "refine_segments_with_llm", fake_refine)
-    monkeypatch.setattr(seg_pkg.config, "REFINE_SEGMENTS_WITH_LLM", False)
+    monkeypatch.setattr(seg_pkg.config, "USE_LLM_FOR_SEGMENTS", False)
 
     refined = maybe_refine_segments_with_llm(segments)
     assert refined == segments


### PR DESCRIPTION
## Summary
- add `USE_LLM_FOR_SEGMENTS` and size threshold to config and disable LLM dialog detection by default
- only invoke `maybe_refine_segments_with_llm` when explicitly enabled and transcript is small
- adjust tests for new segment refinement flag

## Testing
- `pytest` *(fails: ffmpeg missing; config assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9a1e442c832382aa948b941d3123