### PR TITLE
Add optional project cleanup after pipeline

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -83,6 +83,12 @@ RATING_MAX = 10.0
 MIN_EXTENSION_MARGIN = 0.3
 
 # ---------------------------------------
+# Post-pipeline cleanup
+# ---------------------------------------
+# Remove all non-short artifacts after pipeline run
+CLEANUP_NON_SHORTS = False
+
+# ---------------------------------------
 # Multi-platform upload settings
 # ---------------------------------------
 TOKENS_DIR = Path(__file__).with_name("tokens")
@@ -137,6 +143,7 @@ __all__ = [
     "RATING_MIN",
     "RATING_MAX",
     "MIN_EXTENSION_MARGIN",
+    "CLEANUP_NON_SHORTS",
     "TOKENS_DIR",
     "YOUTUBE_PRIVACY",
     "YOUTUBE_CATEGORY_ID",

--- a/server/helpers/cleanup.py
+++ b/server/helpers/cleanup.py
@@ -1,0 +1,26 @@
+"""Helper utilities for cleaning up pipeline project directories."""
+
+from pathlib import Path
+import shutil
+
+
+def cleanup_project_dir(project_dir: Path, keep: str = "shorts") -> None:
+    """Remove all files and folders in *project_dir* except *keep* directory.
+
+    Parameters
+    ----------
+    project_dir:
+        Path to the project directory produced by the pipeline.
+    keep:
+        Name of the subdirectory that should be preserved. Defaults to "shorts".
+    """
+    for child in project_dir.iterdir():
+        if child.name == keep:
+            continue
+        if child.is_dir():
+            shutil.rmtree(child, ignore_errors=True)
+        else:
+            try:
+                child.unlink()
+            except FileNotFoundError:
+                pass

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -66,6 +66,7 @@ from config import (
     MIN_EXTENSION_MARGIN,
     USE_LLM_FOR_SEGMENTS,
     SEG_LLM_MAX_CHARS,
+    CLEANUP_NON_SHORTS,
 )
 
 import sys
@@ -87,6 +88,7 @@ from helpers.notifications import send_failure_email
 from helpers.ai import local_llm_call_json
 from helpers.description import maybe_append_website_link
 from steps.candidates import ClipCandidate
+from helpers.cleanup import cleanup_project_dir
 
 
 
@@ -578,6 +580,8 @@ def process_video(yt_url: str, niche: str | None = None) -> None:
     print(
         f"{Fore.MAGENTA}Full pipeline completed in {total_elapsed:.2f}s{Style.RESET_ALL}"
     )
+    if CLEANUP_NON_SHORTS:
+        cleanup_project_dir(project_dir)
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_cleanup.py
+++ b/tests/test_pipeline_cleanup.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from server.helpers.cleanup import cleanup_project_dir
+from server import config
+
+
+def test_cleanup_project_dir_removes_non_shorts(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    shorts = project / "shorts"
+    shorts.mkdir(parents=True)
+    (project / "keep.mp4").write_text("v")
+    (project / "clips").mkdir()
+    (project / "clips" / "extra.txt").write_text("x")
+    (shorts / "final.mp4").write_text("f")
+
+    cleanup_project_dir(project)
+
+    assert shorts.exists()
+    assert (shorts / "final.mp4").exists()
+    assert not (project / "keep.mp4").exists()
+    assert not (project / "clips").exists()
+
+
+def test_config_exposes_cleanup_flag() -> None:
+    assert config.CLEANUP_NON_SHORTS is False


### PR DESCRIPTION
## Summary
- add `CLEANUP_NON_SHORTS` config flag to enable deleting non-short artifacts
- provide `cleanup_project_dir` helper
- invoke cleanup at pipeline completion
- add tests for cleanup behavior and config exposure

## Testing
- `pytest` *(fails: FileNotFoundError: 'ffmpeg')*
- `PYTHONPATH=. pytest tests/test_pipeline_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc3541138083238a134dfce1d1ee48