### PR TITLE
feat: add configurable local llm provider and model

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -4,6 +4,7 @@ Sections are grouped by feature for easier editing.
 """
 
 import os
+import platform
 from pathlib import Path
 
 # ---------------------------------------
@@ -29,6 +30,13 @@ SEG_LLM_MAX_CHARS = 12_000
 DETECT_DIALOG_WITH_LLM = False
 MAX_LLM_CHARS = 24_000
 LLM_API_TIMEOUT = 12000
+
+# Choose local LLM provider and model
+LOCAL_LLM_PROVIDER = os.environ.get(
+    "LOCAL_LLM_PROVIDER",
+    "lmstudio" if platform.system() == "Darwin" else "ollama",
+)
+LOCAL_LLM_MODEL = os.environ.get("LOCAL_LLM_MODEL", "google/gemma-3-4b")
 
 # Export silence-only "raw" clips for debugging comparisons
 EXPORT_RAW_CLIPS = False
@@ -116,6 +124,8 @@ __all__ = [
     "USE_LLM_FOR_SEGMENTS",
     "SEG_LLM_MAX_CHARS",
     "DETECT_DIALOG_WITH_LLM",
+    "LOCAL_LLM_PROVIDER",
+    "LOCAL_LLM_MODEL",
     "EXPORT_RAW_CLIPS",
     "RAW_LIMIT",
     "SILENCE_DETECTION_NOISE",

--- a/server/helpers/ai.py
+++ b/server/helpers/ai.py
@@ -1,6 +1,5 @@
 import json
 import os
-import platform
 import re
 import time
 from typing import Any, Callable, Dict, List, Optional
@@ -8,7 +7,7 @@ from typing import Any, Callable, Dict, List, Optional
 import requests
 from requests.exceptions import HTTPError, RequestException
 
-from config import LLM_API_TIMEOUT
+from config import LLM_API_TIMEOUT, LOCAL_LLM_PROVIDER
 
 # Default URLs for local model servers. Can be overridden via environment.
 OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
@@ -16,12 +15,6 @@ LMSTUDIO_URL = os.environ.get("LMSTUDIO_URL", "http://127.0.0.1:1234")
 
 # Regex to salvage the first JSON array from a response.
 DEFAULT_JSON_EXTRACT = re.compile(r"\[(?:.|\n)*\]")
-
-# Determine which local LLM provider to use. Default to LM Studio on macOS.
-LOCAL_LLM_PROVIDER = os.environ.get(
-    "LOCAL_LLM_PROVIDER",
-    "lmstudio" if platform.system() == "Darwin" else "ollama",
-)
 
 
 # Some models occasionally emit stray control characters that break ``json.loads``.

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -2,6 +2,7 @@ from dotenv import load_dotenv
 load_dotenv(dotenv_path="../.env")
 
 import json
+import config
 
 from steps.transcribe import transcribe_audio
 from steps.download import (
@@ -530,7 +531,7 @@ def process_video(yt_url: str, niche: str | None = None) -> None:
                 prompt += f"Quote: {candidate.quote}"
             try:
                 tags = local_llm_call_json(
-                    model="google/gemma-3-4b",
+                    model=config.LOCAL_LLM_MODEL,
                     prompt=prompt,
                     options={"temperature": 0.0},
                 )

--- a/server/steps/candidates/__init__.py
+++ b/server/steps/candidates/__init__.py
@@ -13,6 +13,7 @@ from config import (
     MAX_DURATION_SECONDS,
     MAX_LLM_CHARS,
     MIN_DURATION_SECONDS,
+    LOCAL_LLM_MODEL,
 )
 
 from .helpers import (
@@ -194,7 +195,7 @@ def _verify_tone(
 
 
 # -----------------------------
-# LLM (Ollama / google/gemma-3-4b) utilities
+# LLM utilities
 # -----------------------------
 
 def find_clip_timestamps_batched(
@@ -204,7 +205,7 @@ def find_clip_timestamps_batched(
     min_rating: float = DEFAULT_MIN_RATING,
     rating_descriptions: Optional[Dict[str, str]] = None,
     min_words: int = DEFAULT_MIN_WORDS,
-    model: str = "google/gemma-3-4b",
+    model: str = LOCAL_LLM_MODEL,
     options: Optional[dict] = None,
     max_chars_per_chunk: int = MAX_LLM_CHARS,
     overlap_lines: int = 4,
@@ -343,7 +344,7 @@ def find_clip_timestamps(
     min_rating: float = DEFAULT_MIN_RATING,
     rating_descriptions: Optional[Dict[str, str]] = None,
     min_words: int = DEFAULT_MIN_WORDS,
-    model: str = "google/gemma-3-4b",
+    model: str = LOCAL_LLM_MODEL,
     options: Optional[dict] = None,
     silences: Optional[List[Tuple[float, float]]] = None,
     words: Optional[List[dict]] = None,
@@ -351,7 +352,7 @@ def find_clip_timestamps(
     merge_overlapping: bool = False,
     return_all_stages: bool = False,
 ) -> List[ClipCandidate] | tuple[List[ClipCandidate], List[ClipCandidate], List[ClipCandidate]]:
-    """Use a local Ollama model (google/gemma-3-4b) to score transcript lines and propose clip windows."""
+    """Use a local LLM model to score transcript lines and propose clip windows."""
     items = parse_transcript(transcript_path)
     if not items:
         return []

--- a/server/steps/candidates/educational.py
+++ b/server/steps/candidates/educational.py
@@ -13,6 +13,7 @@ from config import (
     WINDOW_SIZE_SECONDS,
     WINDOW_OVERLAP_SECONDS,
     WINDOW_CONTEXT_SECONDS,
+    LOCAL_LLM_MODEL,
 )
 from . import ClipCandidate
 from .helpers import (
@@ -78,7 +79,7 @@ def find_educational_timestamps_batched(
         )
         try:
             arr = local_llm_call_json(
-                model="google/gemma-3-4b",
+                model=LOCAL_LLM_MODEL,
                 prompt=prompt,
                 options={"temperature": 0.2},
             )

--- a/server/steps/candidates/funny.py
+++ b/server/steps/candidates/funny.py
@@ -13,6 +13,7 @@ from config import (
     WINDOW_SIZE_SECONDS,
     WINDOW_OVERLAP_SECONDS,
     WINDOW_CONTEXT_SECONDS,
+    LOCAL_LLM_MODEL,
 )
 from . import ClipCandidate
 from .helpers import (
@@ -80,7 +81,7 @@ def find_funny_timestamps_batched(
         )
         try:
             arr = local_llm_call_json(
-                model="google/gemma-3-4b",
+                model=LOCAL_LLM_MODEL,
                 prompt=prompt,
                 options={"temperature": 0.2},
             )

--- a/server/steps/candidates/inspiring.py
+++ b/server/steps/candidates/inspiring.py
@@ -13,6 +13,7 @@ from config import (
     WINDOW_SIZE_SECONDS,
     WINDOW_OVERLAP_SECONDS,
     WINDOW_CONTEXT_SECONDS,
+    LOCAL_LLM_MODEL,
 )
 from . import ClipCandidate
 from .helpers import (
@@ -78,7 +79,7 @@ def find_inspiring_timestamps_batched(
         )
         try:
             arr = local_llm_call_json(
-                model="google/gemma-3-4b",
+                model=LOCAL_LLM_MODEL,
                 prompt=prompt,
                 options={"temperature": 0.2},
             )

--- a/server/steps/dialog.py
+++ b/server/steps/dialog.py
@@ -85,7 +85,10 @@ def _merge_ranges(ranges: List[Tuple[float, float]]) -> List[Tuple[float, float]
 
 
 def _llm_dialog_ranges(
-    items: List[Tuple[float, float, str]], *, model: str = "google/gemma-3-4b", timeout: int = config.LLM_API_TIMEOUT
+    items: List[Tuple[float, float, str]],
+    *,
+    model: str = config.LOCAL_LLM_MODEL,
+    timeout: int = config.LLM_API_TIMEOUT,
 ) -> List[Tuple[float, float]]:
     """Detect dialog ranges using an LLM with chunked prompts."""
     chunks = _chunk_items(items, max_chars=config.MAX_LLM_CHARS)

--- a/server/steps/segment.py
+++ b/server/steps/segment.py
@@ -68,7 +68,7 @@ def _chunk_segments(
 def refine_segments_with_llm(
     segments: List[Tuple[float, float, str]],
     *,
-    model: str = "google/gemma-3-4b",
+    model: str = config.LOCAL_LLM_MODEL,
     timeout: int = config.LLM_API_TIMEOUT,
 ) -> List[Tuple[float, float, str]]:
     """Use an LLM to merge or split segments into complete sentences.


### PR DESCRIPTION
## Summary
- allow selecting local LLM provider (Ollama or LM Studio) via config
- make local LLM model name configurable
- replace hard-coded model references throughout pipeline and candidate steps

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg', AssertionError: assert 'tiny' == 'tiny-test')*


------
https://chatgpt.com/codex/tasks/task_e_68bc428b667c83238cf67f08e738aca8