### PR TITLE
Ensure cron uses LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docker/cron text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ COPY . .
 
 # Cron setup
 COPY docker/cron /etc/cron.d/uploader
-RUN chmod 0644 /etc/cron.d/uploader && crontab /etc/cron.d/uploader
+RUN sed -i 's/\r$//' /etc/cron.d/uploader \
+    && chmod 0644 /etc/cron.d/uploader \
+    && crontab /etc/cron.d/uploader
 RUN touch /var/log/cron.log
 
 CMD ["sh", "-c", "cron && tail -f /var/log/cron.log"]


### PR DESCRIPTION
## Summary
- Force docker/cron to use LF line endings via .gitattributes
- Strip CR characters from cron file in Dockerfile before installation

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ffmpeg not found, other assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc668c06d08323b7f39a8c4722f776