### PR TITLE
Clarify high score guidance in candidate prompts

### DIFF
--- a/server/steps/candidates/prompts.py
+++ b/server/steps/candidates/prompts.py
@@ -103,6 +103,8 @@ def _build_system_instructions(
         + "\n".join([f"{rating}: {desc}" for rating, desc in GENERAL_RATING_DESCRIPTIONS.items()])
         + ("\n\nTONE-SPECIFIC NOTES:\n" + "\n".join([f"{rating}: {desc}" for rating, desc in rating_descriptions.items()]) if rating_descriptions else "")
         + "\n\n"
+        "Scores above 8 are reserved for truly standout clips; when uncertain, "
+        "default to a lower score.\n\n"
         "INSTRUCTIONS SOURCE (for context, not a style target):\n"
         f"{prompt_desc}\n"
         "Return the JSON now.\n"


### PR DESCRIPTION
## Summary
- clarify SCORING GUIDE instructions to reserve scores above 8 for standout clips and default lower when uncertain

## Testing
- `pytest` *(fails: FileNotFoundError: ffmpeg and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd560f9a08323891022564e29670c