### PR TITLE
centralize chunk and thread pool utilities

### DIFF
--- a/server/common/chunk_utils.py
+++ b/server/common/chunk_utils.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+_END_PUNCT = {".", "!", "?"}
+
+
+def chunk_by_chars(
+    items: List[Tuple[float, float, str]],
+    *,
+    max_chars: int,
+    overlap_lines: int = 2,
+    max_items: int | None = None,
+) -> List[List[Tuple[float, float, str]]]:
+    """Chunk transcript items under ``max_chars`` and ``max_items`` with small overlaps."""
+    chunks: List[List[Tuple[float, float, str]]] = []
+    buf: List[Tuple[float, float, str]] = []
+    count = 0
+    for triplet in items:
+        s, e, t = triplet
+        line = f"[{s:.2f}-{e:.2f}] {t}"
+        ln = len(line) + 1
+        would_exceed_chars = buf and count + ln > max_chars
+        would_exceed_items = max_items is not None and buf and len(buf) >= max_items
+        if would_exceed_chars or would_exceed_items:
+            chunks.append(buf[:])
+            tail = buf[-overlap_lines:] if overlap_lines > 0 else []
+            buf = tail[:]
+            count = sum(len(f"[{a:.2f}-{b:.2f}] {c}") + 1 for a, b, c in buf)
+        buf.append(triplet)
+        count += ln
+    if buf:
+        chunks.append(buf)
+    return chunks
+
+
+def chunk_is_sentence_like(chunk: List[Tuple[float, float, str]]) -> bool:
+    """Return ``True`` if the chunk already looks like sentence-bounded text."""
+    if not chunk:
+        return True
+    ends_ok = sum(1 for _, _, t in chunk if t and t.strip()[-1:] in _END_PUNCT)
+    ratio = ends_ok / max(1, len(chunk))
+    avg_len = sum(len(t) for _, _, t in chunk) / max(1, len(chunk))
+    return ratio >= 0.7 and 24 <= avg_len <= 240
+
+
+__all__ = ["chunk_by_chars", "chunk_is_sentence_like"]

--- a/server/common/llm_utils.py
+++ b/server/common/llm_utils.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Sequence, Tuple
+
+
+def format_transcript_lines(chunk: Sequence[Tuple[float, float, str]]) -> List[str]:
+    """Format transcript triplets into ``"[start-end] text"`` lines."""
+    return [f"[{s:.2f}-{e:.2f}] {t}" for s, e, t in chunk]
+
+
+def default_llm_options(num_predict: int) -> dict:
+    """Return standard LLM call options with configurable prediction length."""
+    return {"temperature": 0.0, "top_p": 0.9, "num_predict": num_predict}
+
+
+def chunk_span(chunk: Iterable[Tuple[float, float, str]]) -> Tuple[float, float]:
+    """Return ``(min_start, max_end)`` for ``chunk``."""
+    starts = [s for s, _, _ in chunk]
+    ends = [e for _, e, _ in chunk]
+    return (min(starts), max(ends)) if starts and ends else (0.0, 0.0)
+
+
+def parse_llm_spans(out, *, with_text: bool = False):
+    """Parse a list of span dicts from LLM output.
+
+    Parameters
+    ----------
+    out:
+        LLM JSON response, expected to be a list of objects with ``start`` and
+        ``end`` keys, and optionally ``text`` when ``with_text`` is ``True``.
+    with_text:
+        Include the ``text`` field in returned tuples when ``True``.
+    """
+    spans = []
+    if isinstance(out, list):
+        for obj in out:
+            try:
+                s = float(obj.get("start"))
+                e = float(obj.get("end"))
+            except Exception:
+                continue
+            if e < s:
+                continue
+            if with_text:
+                t = str(obj.get("text", "")).strip()
+                if not t:
+                    continue
+                spans.append((s, e, t))
+            else:
+                spans.append((s, e))
+    return spans
+
+
+__all__ = [
+    "format_transcript_lines",
+    "default_llm_options",
+    "chunk_span",
+    "parse_llm_spans",
+]

--- a/server/common/thread_pool.py
+++ b/server/common/thread_pool.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeout
+from typing import Callable, List, Sequence, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def process_with_thread_pool(
+    chunks: Sequence[T],
+    func: Callable[[int, T], R],
+    *,
+    max_workers: int,
+    timeout: int | float | None,
+    on_error: Callable[[int, T, Exception], R],
+) -> List[R]:
+    """Process ``chunks`` in parallel with a thread pool.
+
+    Parameters
+    ----------
+    chunks:
+        Sequence of items to process.
+    func:
+        Callable invoked as ``func(index, chunk)`` returning a result.
+    max_workers:
+        Maximum number of worker threads.
+    timeout:
+        Per-chunk timeout in seconds. ``None`` or ``0`` waits indefinitely.
+    on_error:
+        Fallback invoked as ``on_error(index, chunk, exc)`` on timeout or other
+        exceptions.
+    """
+    results: List[R] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+        futures = [ex.submit(func, i + 1, ch) for i, ch in enumerate(chunks)]
+        for i, fut in enumerate(futures, 1):
+            try:
+                if timeout in (0, None):
+                    res = fut.result()
+                else:
+                    res = fut.result(timeout=timeout)
+            except FuturesTimeout as e:
+                res = on_error(i, chunks[i - 1], e)
+            except Exception as e:  # pragma: no cover - passthrough to handler
+                res = on_error(i, chunks[i - 1], e)
+            results.append(res)
+    return results
+
+
+__all__ = ["process_with_thread_pool"]

--- a/server/steps/segment.py
+++ b/server/steps/segment.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 import json
 import re
-import time
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeout
+from concurrent.futures import TimeoutError as FuturesTimeout
 from pathlib import Path
 from typing import List, Tuple
 
 import config
 from helpers.ai import local_llm_call_json
+from common.chunk_utils import chunk_by_chars, chunk_is_sentence_like
+from common.thread_pool import process_with_thread_pool
+from common.llm_utils import (
+    format_transcript_lines,
+    default_llm_options,
+    parse_llm_spans,
+)
 
 _SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
 
@@ -43,42 +49,6 @@ def segment_transcript_items(
     return segments
 
 
-def _chunk_segments(
-    segments: List[Tuple[float, float, str]], *, max_chars: int, overlap_lines: int = 2, max_items: int | None = None
-) -> List[List[Tuple[float, float, str]]]:
-    """Chunk segments under ``max_chars`` and optional ``max_items`` with small overlaps."""
-    chunks: List[List[Tuple[float, float, str]]] = []
-    buf: List[Tuple[float, float, str]] = []
-    count = 0
-    for triplet in segments:
-        s, e, t = triplet
-        line = f"[{s:.2f}-{e:.2f}] {t}"
-        ln = len(line) + 1
-        would_exceed_chars = buf and count + ln > max_chars
-        would_exceed_items = max_items is not None and buf and len(buf) >= max_items
-        if would_exceed_chars or would_exceed_items:
-            chunks.append(buf[:])
-            tail = buf[-overlap_lines:] if overlap_lines > 0 else []
-            buf = tail[:]
-            count = sum(len(f"[{a:.2f}-{b:.2f}] {c}") + 1 for a, b, c in buf)
-        buf.append(triplet)
-        count += ln
-    if buf:
-        chunks.append(buf)
-    return chunks
-
-
-_END_PUNCT = set(".!?")
-def _chunk_is_sentence_like(chunk: List[Tuple[float, float, str]]) -> bool:
-    if not chunk:
-        return True
-    ends_ok = sum(1 for _, _, t in chunk if t and t.strip()[-1:] in _END_PUNCT)
-    ratio = ends_ok / max(1, len(chunk))
-    avg_len = sum(len(t) for _, _, t in chunk) / max(1, len(chunk))
-    # Skip LLM if ≥70% already end with sentence punctuation and avg length is reasonable
-    return ratio >= 0.7 and 24 <= avg_len <= 240
-
-
 def refine_segments_with_llm(
     segments: List[Tuple[float, float, str]],
     *,
@@ -89,7 +59,7 @@ def refine_segments_with_llm(
 
     Returns adjusted segments or the original segments on failure/timeout.
     """
-    chunks = _chunk_segments(
+    chunks = chunk_by_chars(
         segments, max_chars=config.MAX_LLM_CHARS, overlap_lines=2, max_items=config.SEGMENT_OR_DIALOG_CHUNK_MAX_ITEMS
     )
 
@@ -109,12 +79,12 @@ def refine_segments_with_llm(
             "",
             "Segments:",
         ]
-        lines.extend(f"[{s:.2f}-{e:.2f}] {t}" for s, e, t in chunk)
+        lines.extend(format_transcript_lines(chunk))
         return "\n".join(lines)
 
     def _process_chunk(idx: int, chunk: List[Tuple[float, float, str]]):
         # Skip LLM if chunk already looks good
-        if _chunk_is_sentence_like(chunk):
+        if chunk_is_sentence_like(chunk):
             print(f"[segments] Chunk {idx}: skipping LLM, looks sentence-like.")
             return chunk
 
@@ -124,28 +94,14 @@ def refine_segments_with_llm(
             out = local_llm_call_json(
                 model=model,
                 prompt=prompt,
-                options={
-                    "temperature": 0.0,
-                    "top_p": 0.9,
-                    "num_predict": 512,
-                },
+                options=default_llm_options(512),
                 timeout=min(timeout, config.LLM_PER_CHUNK_TIMEOUT),
             )
         except Exception as e:
             print(f"[segments] Chunk {idx}: LLM exception -> {e}")
             return chunk
 
-        refined: List[Tuple[float, float, str]] = []
-        if isinstance(out, list):
-            for obj in out:
-                try:
-                    s = float(obj.get("start"))
-                    e = float(obj.get("end"))
-                    t = str(obj.get("text", "")).strip()
-                except Exception:
-                    continue
-                if t and e >= s:
-                    refined.append((s, e, t))
+        refined = parse_llm_spans(out, with_text=True)
         print(f"[segments] Chunk {idx}: LLM returned {len(refined)} refined sentences (original {len(chunk)}).")
         return refined or chunk
 
@@ -154,30 +110,28 @@ def refine_segments_with_llm(
 
     if config.LLM_PER_CHUNK_TIMEOUT in (0, None):
         print("[segments] Per-chunk timeout is disabled; waiting indefinitely for each chunk.")
-    with ThreadPoolExecutor(max_workers=config.LLM_MAX_WORKERS) as ex:
-        futures = []
-        for i, chunk in enumerate(chunks):
-            futures.append(ex.submit(_process_chunk, i + 1, chunk))
 
-        for i, fut in enumerate(futures, 1):
-            try:
-                timeout_val = config.LLM_PER_CHUNK_TIMEOUT
-                if timeout_val in (0, None):
-                    chunk_out = fut.result()
-                else:
-                    chunk_out = fut.result(timeout=timeout_val)
-            except FuturesTimeout:
-                print(f"[segments] Chunk {i}: timeout; using original.")
-                chunk_out = chunks[i - 1]
-            except Exception as e:
-                print(f"[segments] Chunk {i}: error {e}; using original.")
-                chunk_out = chunks[i - 1]
+    def _on_error(idx: int, chunk: List[Tuple[float, float, str]], exc: Exception):
+        if isinstance(exc, FuturesTimeout):
+            print(f"[segments] Chunk {idx}: timeout; using original.")
+        else:
+            print(f"[segments] Chunk {idx}: error {exc}; using original.")
+        return chunk
 
-            for s, e, t in chunk_out:
-                key = (s, e, t)
-                if key not in seen:
-                    all_refined.append((s, e, t))
-                    seen.add(key)
+    results = process_with_thread_pool(
+        chunks,
+        _process_chunk,
+        max_workers=config.LLM_MAX_WORKERS,
+        timeout=config.LLM_PER_CHUNK_TIMEOUT,
+        on_error=_on_error,
+    )
+
+    for chunk_out in results:
+        for s, e, t in chunk_out:
+            key = (s, e, t)
+            if key not in seen:
+                all_refined.append((s, e, t))
+                seen.add(key)
 
     print(f"[segments] Refinement complete: total {len(all_refined)} final segments.")
     return all_refined or segments


### PR DESCRIPTION
## Summary
- move transcript chunk helpers into shared common module
- add generic thread pool processor for reused parallelism
- refactor segment and dialog steps to use shared utilities and reduce duplication
- introduce shared LLM helpers for prompt formatting, options, span parsing

## Testing
- `pytest` *(fails: ffmpeg missing, config assertions, dialog range expectations, LLM dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd620171c8323b2d7374166fc3d63