### PR TITLE
Refactor tone handling into ToneSpec enum

### DIFF
--- a/server/common/tone.py
+++ b/server/common/tone.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Tuple, List
+
+from config import (
+    FUNNY_MIN_RATING,
+    INSPIRING_MIN_RATING,
+    EDUCATIONAL_MIN_RATING,
+)
+from interfaces.clip_candidate import ClipCandidate
+from steps.candidates.funny import find_funny_timestamps_batched
+from steps.candidates.inspiring import find_inspiring_timestamps_batched
+from steps.candidates.educational import find_educational_timestamps_batched
+
+
+Finder = Callable[
+    ..., Tuple[List[ClipCandidate], List[ClipCandidate], List[ClipCandidate]]
+]
+
+
+@dataclass(frozen=True)
+class ToneSpec:
+    """Configuration for a particular clip tone."""
+
+    finder: Finder
+    min_rating: float
+
+
+class Tone(Enum):
+    FUNNY = ToneSpec(find_funny_timestamps_batched, FUNNY_MIN_RATING)
+    INSPIRING = ToneSpec(find_inspiring_timestamps_batched, INSPIRING_MIN_RATING)
+    EDUCATIONAL = ToneSpec(find_educational_timestamps_batched, EDUCATIONAL_MIN_RATING)
+


### PR DESCRIPTION
## Summary
- add `ToneSpec` dataclass and `Tone` enum bundling finder and minimum rating
- update `process_video` to use `ToneSpec` instead of separate finder/min-rating maps
- remove obsolete clip type dictionaries

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68bd073ca4dc8323a26c5668c84710ae