### PR TITLE
feat: include credit in YouTube titles

### DIFF
--- a/server/integrations/youtube/upload.py
+++ b/server/integrations/youtube/upload.py
@@ -44,11 +44,20 @@ def read_description(path: Path) -> tuple[str, str]:
     hashtag_pattern = r"(?:^|\s)(#\w+)"
     hashtags = [tag.strip() for tag in re.findall(hashtag_pattern, desc_text)]
     title_hashtags = hashtags[:4]
-    title_clean = "Made by Atropos "
-    if title_hashtags:
-        title_clean += " ".join(title_hashtags)
 
-    title_clean = title_clean.strip()[:100]
+    credit_line = ""
+    for line in desc_text.splitlines():
+        if line.lower().startswith("credit:"):
+            credit_line = line.strip()
+            break
+
+    title_parts: list[str] = []
+    if credit_line:
+        title_parts.append(credit_line)
+    if title_hashtags:
+        title_parts.append(" ".join(title_hashtags))
+
+    title_clean = " ".join(title_parts).strip()[:100]
 
     desc_text = desc_text[:YOUTUBE_DESC_LIMIT]
     return title_clean, desc_text

--- a/tests/test_description_link.py
+++ b/tests/test_description_link.py
@@ -35,11 +35,16 @@ def test_read_description_appends_link_to_description_only(monkeypatch, tmp_path
     )
     desc_file = tmp_path / "desc.txt"
     desc_file.write_text(
-        "Full video line\nCredit line\n#funny #cool #wow #amazing #extra",
+        (
+            "Full video line\nCredit: line\nMade by Atropos\n"
+            "#funny #cool #wow #amazing #extra"
+        ),
         encoding="utf-8",
     )
     title, description = read_description(desc_file)
-    assert title == "#funny #cool #wow #amazing"
+    assert title == "Credit: line #funny #cool #wow #amazing"
     assert "https://atropos-video.com" not in title
+    assert "Made by Atropos" in description
+    assert "Made by Atropos" not in title
     assert description.endswith("https://atropos-video.com")
 


### PR DESCRIPTION
## Summary
- prepend video credit to YouTube upload title and drop "Made by Atropos" prefix
- expand description parsing test to include credit and ensure "Made by Atropos" only in description

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg'; AssertionError: assert 'large-v3-turbo' == 'tiny-test')*

------
https://chatgpt.com/codex/tasks/task_e_68bd7d83044c8323b21ef7a528d89163