### PR TITLE
Skip private videos and notify

### DIFF
--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -109,12 +109,8 @@ def process_video(yt_url: str, niche: str | None = None) -> None:
     video_info = get_video_info(yt_url)
 
     if not video_info:
-        send_failure_email(
-            "Video info retrieval failed",
-            f"Failed to retrieve video information for {yt_url}",
-        )
         print(f"{Fore.RED}Failed to retrieve video information.{Style.RESET_ALL}")
-        sys.exit()
+        return
 
     upload_date = video_info["upload_date"]
     sanitized_title = sanitize_filename(video_info["title"])

--- a/tests/test_private_video.py
+++ b/tests/test_private_video.py
@@ -1,0 +1,32 @@
+from unittest.mock import MagicMock, patch
+
+import yt_dlp
+
+from server.steps.download import get_video_info, get_video_urls
+
+
+def test_get_video_urls_private_video():
+    """Private videos should trigger an email and be skipped."""
+    ydl = MagicMock()
+    ydl.__enter__.return_value = ydl
+    ydl.extract_info.side_effect = yt_dlp.utils.DownloadError("Private video")
+    with patch("server.steps.download.yt_dlp.YoutubeDL", return_value=ydl), patch(
+        "server.steps.download.send_failure_email"
+    ) as email:
+        urls = get_video_urls("https://www.youtube.com/watch?v=abc")
+    assert urls == []
+    email.assert_called_once()
+
+
+def test_get_video_info_private_video():
+    """Private videos should trigger an email and return None."""
+    ydl = MagicMock()
+    ydl.__enter__.return_value = ydl
+    ydl.extract_info.side_effect = yt_dlp.utils.DownloadError("Private video")
+    with patch("server.steps.download.yt_dlp.YoutubeDL", return_value=ydl), patch(
+        "server.steps.download.send_failure_email"
+    ) as email:
+        info = get_video_info("https://www.youtube.com/watch?v=abc")
+    assert info is None
+    email.assert_called_once()
+


### PR DESCRIPTION
## Summary
- skip private or unlisted YouTube videos and send an email notification
- avoid stopping the pipeline when video info is unavailable
- cover private video handling with unit tests

## Testing
- `pytest` *(fails: tests/test_funny_filter.py::test_batched_min_rating_inclusive, tests/test_pipeline_cleanup.py::test_config_exposes_cleanup_flag, tests/test_schedule_upload.py::test_project_not_deleted_until_last_short, tests/test_transcribe.py::test_transcribe_audio_handles_generator, tests/test_transcribe.py::test_whisper_model_env_override)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc0bc56288323bc7c579e6dc1a718