### PR TITLE
Make caption colors configurable

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -14,6 +14,11 @@ from pathlib import Path
 CAPTION_FONT_SCALE = 2.0
 # Maximum number of lines per caption before splitting
 CAPTION_MAX_LINES: int = 2
+# Toggle whether rendered captions use custom colors
+CAPTION_USE_COLORS = True
+# Default caption fill and outline colors in BGR (blue-green-red) order
+CAPTION_FILL_BGR = (255, 187, 28)  # hex 1cbbff -> RGB(28,187,255) -> BGR(255,187,28)
+CAPTION_OUTLINE_BGR = (236, 236, 236)  # hex ececec
 # Constant frame-rate to avoid VFR issues on platforms like TikTok/Reels
 OUTPUT_FPS: float = 30.0
 
@@ -133,6 +138,9 @@ TIKTOK_DESC_LIMIT = 2000
 __all__ = [
     "CAPTION_FONT_SCALE",
     "CAPTION_MAX_LINES",
+    "CAPTION_USE_COLORS",
+    "CAPTION_FILL_BGR",
+    "CAPTION_OUTLINE_BGR",
     "SNAP_TO_SILENCE",
     "SNAP_TO_DIALOG",
     "SNAP_TO_SENTENCE",

--- a/server/steps/render.py
+++ b/server/steps/render.py
@@ -37,7 +37,14 @@ try:
 except Exception:
     pass
 
-from config import CAPTION_FONT_SCALE, CAPTION_MAX_LINES, OUTPUT_FPS
+from config import (
+    CAPTION_FONT_SCALE,
+    CAPTION_MAX_LINES,
+    CAPTION_FILL_BGR,
+    CAPTION_OUTLINE_BGR,
+    CAPTION_USE_COLORS,
+    OUTPUT_FPS,
+)
 
 def _open_writer(path, fps, size):
     w, h = size
@@ -82,8 +89,9 @@ def render_vertical_with_captions(
     max_lines: int = CAPTION_MAX_LINES,
     wrap_width_px_ratio: float = 0.86,  # caption max width as ratio of frame_width
     blur_ksize: int = 31,               # must be odd; background blur amount
-    fill_bgr: Tuple[int, int, int] = (255, 187, 28),   # hex 1cbbff -> RGB(28,187,255) -> BGR(255,187,28)
-    outline_bgr: Tuple[int, int, int] = (236, 236, 236),  # hex ececec
+    use_caption_colors: bool = CAPTION_USE_COLORS,
+    fill_bgr: Tuple[int, int, int] = CAPTION_FILL_BGR,
+    outline_bgr: Tuple[int, int, int] = CAPTION_OUTLINE_BGR,
     # NEW performance toggles
     use_cuda: bool = True,
     use_opencl: bool = True,
@@ -100,6 +108,9 @@ def render_vertical_with_captions(
     output.parent.mkdir(parents=True, exist_ok=True)
 
     temp_video = output.with_suffix('.temp.mp4')
+
+    fill_color = fill_bgr if use_caption_colors else (255, 255, 255)
+    outline_color = outline_bgr if use_caption_colors else (0, 0, 0)
 
     # --- HW accel probes ---
     if use_opencl:
@@ -420,12 +431,21 @@ def render_vertical_with_captions(
                             (x_text + dx, y_text + th + dy),
                             font,
                             fs,
-                            outline_bgr,
+                            outline_color,
                             thickness + outline,
                             line_type,
                         )
                 # fill
-                cv2.putText(canvas, ln, (x_text, y_text + th), font, fs, fill_bgr, thickness, line_type)
+                cv2.putText(
+                    canvas,
+                    ln,
+                    (x_text, y_text + th),
+                    font,
+                    fs,
+                    fill_color,
+                    thickness,
+                    line_type,
+                )
                 y_text += th + spacing
 
         writer.write(canvas)

--- a/tests/test_render_fps.py
+++ b/tests/test_render_fps.py
@@ -37,3 +37,30 @@ def test_render_preserves_fps(tmp_path: Path) -> None:
     cap.release()
 
     assert abs(out_fps - fps) < 0.1
+
+
+def test_render_without_caption_colors(tmp_path: Path) -> None:
+    src_path = tmp_path / "src.mp4"
+    fps = 10.0
+    size = (64, 64)
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(src_path), fourcc, fps, size)
+    black = np.zeros((size[1], size[0], 3), dtype=np.uint8)
+    for _ in range(3):
+        writer.write(black)
+    writer.release()
+
+    out_path = tmp_path / "out.mp4"
+    render_vertical_with_captions(
+        src_path,
+        captions=[(0.0, 1.0, "test")],
+        output_path=out_path,
+        frame_width=160,
+        frame_height=280,
+        mux_audio=False,
+        use_cuda=False,
+        use_opencl=False,
+        use_caption_colors=False,
+    )
+
+    assert out_path.exists()


### PR DESCRIPTION
## Summary
- allow caption colors to be toggled and customized via `CAPTION_USE_COLORS`, `CAPTION_FILL_BGR`, and `CAPTION_OUTLINE_BGR`
- render captions in default white/black when colors are disabled
- add regression test covering caption color toggle

## Testing
- `pytest` *(fails: test_batched_min_rating_inclusive, test_config_exposes_cleanup_flag, test_transcribe_audio_handles_generator, test_whisper_model_env_override)*

------
https://chatgpt.com/codex/tasks/task_e_68be18fcb14c832385af71698b86bfd1