### PR TITLE
Include tone-specific rating guides in prompts

### DIFF
--- a/server/custom_types/tone.py
+++ b/server/custom_types/tone.py
@@ -17,6 +17,7 @@ class Tone(Enum):
 @dataclass
 class ToneStrategy:
     prompt_desc: str
+    rating_descriptions: dict[str, str] | None = None
     min_rating: float = DEFAULT_MIN_RATING
     min_words: int = DEFAULT_MIN_WORDS
     snap_to_sentence: bool = True

--- a/server/steps/candidates/prompts.py
+++ b/server/steps/candidates/prompts.py
@@ -160,7 +160,6 @@ HEALTH_RATING_DESCRIPTIONS = {
     "0":  "reject; dangerous misinformation",
 }
 
-
 def _build_system_instructions(
     prompt_desc: str, rating_descriptions: Optional[Dict[str, str]] = None
 ) -> str:
@@ -206,9 +205,15 @@ def _build_system_instructions(
 
 
 
-def build_window_prompt(prompt_desc: str, text: str) -> str:
+def build_window_prompt(
+    prompt_desc: str,
+    text: str,
+    rating_descriptions: Optional[Dict[str, str]] = None,
+) -> str:
     """Construct a complete prompt for a transcript window."""
-    system_instructions = _build_system_instructions(prompt_desc)
+    system_instructions = _build_system_instructions(
+        prompt_desc, rating_descriptions
+    )
     return (
         f"{system_instructions}\n\n"
         f"TRANSCRIPT WINDOW (≈{WINDOW_SIZE_SECONDS:.0f}s, overlap {WINDOW_OVERLAP_SECONDS:.0f}s, context {WINDOW_CONTEXT_SECONDS:.0f}s):\n{text}\n\n"

--- a/server/steps/candidates/tone.py
+++ b/server/steps/candidates/tone.py
@@ -14,7 +14,7 @@ from config import (
     FUNNY_MIN_WORDS,
 )
 
-from custom_types.tone import Tone, ToneStrategy
+from server.custom_types.tone import Tone, ToneStrategy
 
 from . import ClipCandidate, _filter_promotional_candidates
 from .helpers import (
@@ -35,6 +35,11 @@ from .prompts import (
     HISTORY_PROMPT_DESC,
     TECH_PROMPT_DESC,
     HEALTH_PROMPT_DESC,
+    FUNNY_RATING_DESCRIPTIONS,
+    SPACE_RATING_DESCRIPTIONS,
+    HISTORY_RATING_DESCRIPTIONS,
+    TECH_RATING_DESCRIPTIONS,
+    HEALTH_RATING_DESCRIPTIONS,
     build_window_prompt,
 )
 
@@ -42,13 +47,26 @@ from .prompts import (
 STRATEGY_REGISTRY: dict[Tone, ToneStrategy] = {
     Tone.FUNNY: ToneStrategy(
         prompt_desc=FUNNY_PROMPT_DESC,
+        rating_descriptions=FUNNY_RATING_DESCRIPTIONS,
         min_rating=FUNNY_MIN_RATING,
         min_words=FUNNY_MIN_WORDS,
     ),
-    Tone.SPACE: ToneStrategy(prompt_desc=SPACE_PROMPT_DESC),
-    Tone.HISTORY: ToneStrategy(prompt_desc=HISTORY_PROMPT_DESC),
-    Tone.TECH: ToneStrategy(prompt_desc=TECH_PROMPT_DESC),
-    Tone.HEALTH: ToneStrategy(prompt_desc=HEALTH_PROMPT_DESC),
+    Tone.SPACE: ToneStrategy(
+        prompt_desc=SPACE_PROMPT_DESC,
+        rating_descriptions=SPACE_RATING_DESCRIPTIONS,
+    ),
+    Tone.HISTORY: ToneStrategy(
+        prompt_desc=HISTORY_PROMPT_DESC,
+        rating_descriptions=HISTORY_RATING_DESCRIPTIONS,
+    ),
+    Tone.TECH: ToneStrategy(
+        prompt_desc=TECH_PROMPT_DESC,
+        rating_descriptions=TECH_RATING_DESCRIPTIONS,
+    ),
+    Tone.HEALTH: ToneStrategy(
+        prompt_desc=HEALTH_PROMPT_DESC,
+        rating_descriptions=HEALTH_RATING_DESCRIPTIONS,
+    ),
 }
 
 
@@ -105,7 +123,11 @@ def find_candidates_by_tone(
             if it[1] > win_start - WINDOW_CONTEXT_SECONDS and it[0] < win_end + WINDOW_CONTEXT_SECONDS
         ]
         text = "\n".join(f"[{s:.2f}-{e:.2f}] {t}" for s, e, t in ctx_items)
-        prompt = build_window_prompt(strategy.prompt_desc, text)
+        prompt = build_window_prompt(
+            strategy.prompt_desc,
+            text,
+            strategy.rating_descriptions,
+        )
         print(f"[Tone] window {win_start:.2f}-{win_end:.2f}")
         start_t = time.perf_counter()
         try:

--- a/tests/test_prompt_ratings.py
+++ b/tests/test_prompt_ratings.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from server.steps.candidates.prompts import (
     _build_system_instructions,
     FUNNY_PROMPT_DESC,
-    FUNNY_RATING_DESCRIPTIONS,
 )
+from server.custom_types.tone import Tone
+from server.steps.candidates.tone import STRATEGY_REGISTRY
 
 
 def test_default_rating_descriptions_present() -> None:
@@ -28,12 +29,19 @@ def test_custom_rating_descriptions_included() -> None:
 
 
 def test_funny_rating_descriptions_included() -> None:
+    strategy = STRATEGY_REGISTRY[Tone.FUNNY]
     instructions = _build_system_instructions(
-        "desc", rating_descriptions=FUNNY_RATING_DESCRIPTIONS
+        strategy.prompt_desc, strategy.rating_descriptions
     )
-    assert "10: can't stop laughing" in instructions
-    assert "5: weak humor; raunchy or crude without payoff" in instructions
-    assert "0: reject; hateful or non-consensual content without comedic value" in instructions
+    assert (
+        f"10: {strategy.rating_descriptions['10']}" in instructions
+    )
+    assert (
+        f"5: {strategy.rating_descriptions['5']}" in instructions
+    )
+    assert (
+        f"0: {strategy.rating_descriptions['0']}" in instructions
+    )
 
 
 def test_funny_prompt_mentions_raunch() -> None:


### PR DESCRIPTION
## Summary
- Store rating descriptions on each `ToneStrategy`
- Include tone-specific rating scales when building prompts
- Update tests to use strategy rating descriptions

## Testing
- `pytest` *(fails: tests/test_private_video.py::test_get_video_urls_private_video, tests/test_schedule_upload.py::test_batch_processes_all_niches)*

------
https://chatgpt.com/codex/tasks/task_e_68be32abdb908323982ed9a653e3c46a