### PR TITLE
Add browser-based TikTok uploader with feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository includes a minimal framework for bulk uploading short videos
 with captions to multiple social platforms. The orchestrator script scans a
-folder for video files and paired caption text files, normalises captions, and
+folder for video files and paired caption text files, normalizes captions, and
 then uploads the pairs to each enabled platform.
 All core modules now live under the `server/` directory. For example:
 
@@ -60,3 +60,11 @@ per platform.
 
 To view logs after upping with -d
 `docker compose logs -f uploader`
+
+## TikTok backend
+
+TikTok uploads use a browser automation path by default. Set
+`TIKTOK_UPLOAD_BACKEND=api` to use the official API instead. Browser uploads rely
+on persisted cookies stored in `server/tokens/tiktok_cookies.json` and are
+controlled via additional `TIKTOK_AUTO_*` environment variables (see
+`server/config.py` for defaults).

--- a/cspell.json
+++ b/cspell.json
@@ -13,7 +13,14 @@
     "madebyatropos",
     "ndarray",
     "opencl",
-    "wtok"
+    "wtok",
+    "pytest",
+    "docstrings",
+    "fernet",
+    "FERNET",
+    "Autouploader",
+    "autouploader",
+    "tiktokautouploader"
   ],
   "ignorePaths": [
     "node_modules",

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,3 +57,4 @@ uritemplate==4.2.0
 urllib3==2.5.0
 youtube-transcript-api==1.2.2
 yt-dlp==2025.8.22
+tiktokautouploader==4.5

--- a/server/config.py
+++ b/server/config.py
@@ -125,6 +125,27 @@ YOUTUBE_CATEGORY_ID = "23"
 TIKTOK_PRIVACY_LEVEL = "SELF_ONLY"
 TIKTOK_CHUNK_SIZE = 10_000_000  # bytes
 
+# Upload backend can be "api" or "autouploader"
+TIKTOK_UPLOAD_BACKEND = os.environ.get("TIKTOK_UPLOAD_BACKEND", "autouploader")
+
+# Settings for the browser-based uploader
+TIKTOK_AUTO_HEADLESS = (
+    os.environ.get("TIKTOK_AUTO_HEADLESS", "false").lower() == "true"
+)
+TIKTOK_AUTO_BROWSER = os.environ.get("TIKTOK_AUTO_BROWSER", "chromium")
+TIKTOK_AUTO_COOKIES_PATH = Path(
+    os.environ.get(
+        "TIKTOK_AUTO_COOKIES_PATH", TOKENS_DIR / "tiktok_cookies.json"
+    )
+)
+TIKTOK_AUTO_TIMEOUT_SEC = int(os.environ.get("TIKTOK_AUTO_TIMEOUT_SEC", "180"))
+TIKTOK_AUTO_MAX_RETRIES = int(os.environ.get("TIKTOK_AUTO_MAX_RETRIES", "2"))
+TIKTOK_AUTO_RETRY_BACKOFF_SEC = int(
+    os.environ.get("TIKTOK_AUTO_RETRY_BACKOFF_SEC", "8")
+)
+TIKTOK_AUTO_PROXY = os.environ.get("TIKTOK_AUTO_PROXY", "")
+TIKTOK_AUTO_UPLOAD_URL = os.environ.get("TIKTOK_AUTO_UPLOAD_URL", "")
+
 # Optional website link to append to video descriptions
 INCLUDE_WEBSITE_LINK = True
 WEBSITE_URL = "https://atropos-video.com"
@@ -181,6 +202,15 @@ __all__ = [
     "YOUTUBE_CATEGORY_ID",
     "TIKTOK_PRIVACY_LEVEL",
     "TIKTOK_CHUNK_SIZE",
+    "TIKTOK_UPLOAD_BACKEND",
+    "TIKTOK_AUTO_HEADLESS",
+    "TIKTOK_AUTO_BROWSER",
+    "TIKTOK_AUTO_COOKIES_PATH",
+    "TIKTOK_AUTO_TIMEOUT_SEC",
+    "TIKTOK_AUTO_MAX_RETRIES",
+    "TIKTOK_AUTO_RETRY_BACKOFF_SEC",
+    "TIKTOK_AUTO_PROXY",
+    "TIKTOK_AUTO_UPLOAD_URL",
     "INCLUDE_WEBSITE_LINK",
     "WEBSITE_URL",
     "YOUTUBE_DESC_LIMIT",

--- a/server/integrations/tiktok/__init__.py
+++ b/server/integrations/tiktok/__init__.py
@@ -1,2 +1,6 @@
-"""TikTok integration package."""
+"""TikTok integration package.
+
+Deprecated path: set ``TIKTOK_UPLOAD_BACKEND='api'`` to re-enable. Default is
+``'autouploader'`` until TikTok app is approved.
+"""
 

--- a/server/integrations/tiktok/auth.py
+++ b/server/integrations/tiktok/auth.py
@@ -1,4 +1,7 @@
 # tiktok_desktop_pkce_demo.py
+# Deprecated path: set TIKTOK_UPLOAD_BACKEND='api' to re-enable. Default is
+# 'autouploader' until TikTok app is approved. TODO: remove when feature flag is
+# dropped.
 import os
 from pathlib import Path
 # Constants you edit once:

--- a/server/integrations/tiktok/post.py
+++ b/server/integrations/tiktok/post.py
@@ -1,0 +1,48 @@
+"""Facade for posting videos to TikTok via multiple backends."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+from config import (
+    TIKTOK_CHUNK_SIZE,
+    TIKTOK_PRIVACY_LEVEL,
+    TIKTOK_UPLOAD_BACKEND,
+)
+from . import upload as api_upload
+from integrations.tiktok_autouploader.uploader import (
+    upload_video_with_autouploader,
+)
+
+
+def _post_via_api(
+    video_path: str, caption: str, cover_timestamp_ms: Optional[int]
+) -> Dict[str, Any]:  # pragma: no cover - exercised via facade tests
+    """Upload using the official TikTok API."""
+
+    path = Path(video_path)
+    size = path.stat().st_size
+    publish_id, upload_url = api_upload.init_direct_post(
+        size, TIKTOK_CHUNK_SIZE, caption, TIKTOK_PRIVACY_LEVEL
+    )
+    api_upload.upload_video(upload_url, path, TIKTOK_CHUNK_SIZE)
+    data = api_upload.poll_status(publish_id)
+    status = data.get("status", "")
+    result_status = "posted" if status == "PUBLISH_COMPLETE" else status.lower()
+    return {"status": result_status, "post_url": None, "debug": data}
+
+
+def post_to_tiktok(
+    video_path: str, caption: str, cover_timestamp_ms: Optional[int] = None
+) -> Dict[str, Any]:
+    """Post ``video_path`` with ``caption`` to TikTok.
+
+    The backend is selected via :data:`TIKTOK_UPLOAD_BACKEND`. The function
+    prints the backend used for observability.
+    """
+
+    print(f"TikTok backend = {TIKTOK_UPLOAD_BACKEND}")
+    if TIKTOK_UPLOAD_BACKEND == "api":
+        return _post_via_api(video_path, caption, cover_timestamp_ms)
+    return upload_video_with_autouploader(video_path, caption, cover_timestamp_ms)

--- a/server/integrations/tiktok/upload.py
+++ b/server/integrations/tiktok/upload.py
@@ -1,3 +1,10 @@
+"""TikTok API uploader (deprecated).
+
+Deprecated path: set ``TIKTOK_UPLOAD_BACKEND='api'`` to re-enable. Default is
+``'autouploader'`` until TikTok app is approved. TODO: remove when feature flag
+is dropped.
+"""
+
 import os
 import time
 import math

--- a/server/integrations/tiktok_autouploader/README.md
+++ b/server/integrations/tiktok_autouploader/README.md
@@ -1,0 +1,25 @@
+# TikTok Autouploader
+
+> **Warning**: This integration uses headless browser automation to post to
+> TikTok. It may violate TikTok's platform terms and is provided only for local
+> desktop use. Do not expose this feature in a multi-tenant or commercial SaaS
+> setting.
+
+This module wraps the [`tiktokautouploader`](https://pypi.org/project/tiktokautouploader/)
+package so uploads can continue while our official API application is under
+review.
+
+## Usage
+
+1. Install browser binaries supported by the library (Chromium, Chrome or Edge).
+2. Set `TIKTOK_UPLOAD_BACKEND=autouploader` (default) and run the uploader as
+   usual.
+3. On first run the script will open a browser window and prompt you to log in.
+   Cookies are saved to `server/tokens/tiktok_cookies.json` for future runs.
+
+## Caveats
+
+- The session relies on persisted cookies; if they expire you must log in again.
+- CAPTCHA challenges require manual resolution.
+- The first login is easiest on a local machine with a display; copy the cookies
+  file into the mounted tokens directory when running in Docker.

--- a/server/integrations/tiktok_autouploader/__init__.py
+++ b/server/integrations/tiktok_autouploader/__init__.py
@@ -1,0 +1,4 @@
+"""Browser-based TikTok uploader using `tiktokautouploader`.
+
+This module provides a fallback uploader that automates a local browser to
+publish videos to TikTok while the official API is unavailable."""

--- a/server/integrations/tiktok_autouploader/auth.py
+++ b/server/integrations/tiktok_autouploader/auth.py
@@ -1,0 +1,55 @@
+"""Authentication helpers for the TikTok browser uploader."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, List
+
+from config import TIKTOK_AUTO_COOKIES_PATH
+
+
+def _read_cookies(path: Path) -> List[dict[str, Any]] | None:
+    """Return cookies from ``path`` if it exists."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:  # pragma: no cover - fallback when file missing
+        return None
+
+
+def _write_cookies(path: Path, cookies: List[dict[str, Any]]) -> None:
+    """Persist ``cookies`` atomically with restrictive permissions."""
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(cookies), encoding="utf-8")
+    os.replace(tmp, path)
+    path.chmod(0o600)
+
+
+def ensure_cookies(uploader: Any) -> List[dict[str, Any]]:
+    """Load cookies for ``uploader`` or guide the user through login.
+
+    The function tries to reuse persisted cookies. When they are missing or
+    rejected by TikTok, a headful browser window is opened to let the user log
+    in manually. Cookies from the successful session are then stored at
+    :data:`TIKTOK_AUTO_COOKIES_PATH` for reuse on subsequent runs.
+    """
+
+    path = Path(TIKTOK_AUTO_COOKIES_PATH)
+    cookies = _read_cookies(path)
+    if cookies:
+        try:
+            uploader.set_cookies(cookies)
+            return cookies
+        except Exception:  # pragma: no cover - library handles validation
+            pass
+
+    print(
+        "Please complete TikTok login in the opened window. Close the window or "
+        "press Enter here when you see your profile avatar."
+    )
+    uploader.launch_login()
+    input()
+    cookies = uploader.get_cookies()
+    _write_cookies(path, cookies)
+    return cookies

--- a/server/integrations/tiktok_autouploader/uploader.py
+++ b/server/integrations/tiktok_autouploader/uploader.py
@@ -1,0 +1,76 @@
+"""Video uploader using the `tiktokautouploader` package."""
+
+from __future__ import annotations
+
+import time
+from typing import Optional, Dict, Any
+
+from config import (
+    TIKTOK_AUTO_BROWSER,
+    TIKTOK_AUTO_HEADLESS,
+    TIKTOK_AUTO_MAX_RETRIES,
+    TIKTOK_AUTO_PROXY,
+    TIKTOK_AUTO_RETRY_BACKOFF_SEC,
+    TIKTOK_AUTO_TIMEOUT_SEC,
+    TIKTOK_AUTO_UPLOAD_URL,
+)
+from helpers.logging import log_timing
+
+from . import auth
+
+
+class UploadError(Exception):
+    """Error raised when the autouploader fails."""
+
+    def __init__(self, code: str, details: Any | None = None) -> None:
+        super().__init__(code)
+        self.code = code
+        self.details = details
+
+
+def _build_client():  # pragma: no cover - depends on external library
+    from tiktokautouploader import TikTokUploader
+
+    return TikTokUploader(
+        headless=TIKTOK_AUTO_HEADLESS,
+        browser=TIKTOK_AUTO_BROWSER,
+        proxy=TIKTOK_AUTO_PROXY or None,
+        upload_url=TIKTOK_AUTO_UPLOAD_URL or None,
+        timeout=TIKTOK_AUTO_TIMEOUT_SEC,
+    )
+
+
+def upload_video_with_autouploader(
+    video_path: str, caption: str, cover_timestamp_ms: Optional[int]
+) -> Dict[str, Any]:
+    """Upload ``video_path`` with ``caption`` via browser automation."""
+
+    last_error: UploadError | None = None
+    for attempt in range(1, TIKTOK_AUTO_MAX_RETRIES + 2):
+        try:
+            with log_timing(f"[TikTok][Auto] attempt {attempt}"):
+                client = _build_client()
+                auth.ensure_cookies(client)
+                print("[TikTok][Auto] Launching browser…")
+                client.open_upload()
+                print("[TikTok][Auto] Cookies found: yes")
+                client.select_video(video_path)
+                print("[TikTok][Auto] File selected")
+                client.set_caption(caption)
+                print("[TikTok][Auto] Caption applied")
+                if cover_timestamp_ms is not None:
+                    client.set_cover(cover_timestamp_ms)
+                client.publish()
+                print("[TikTok][Auto] Publish clicked")
+                url = client.wait_for_post_url()
+                print(f"[TikTok][Auto] Success URL: {url}")
+                return {"status": "posted", "post_url": url, "debug": {"attempt": attempt}}
+        except UploadError as exc:
+            last_error = exc
+        except Exception as exc:  # pragma: no cover - defensive
+            last_error = UploadError("exception", str(exc))
+        if attempt <= TIKTOK_AUTO_MAX_RETRIES:
+            backoff = TIKTOK_AUTO_RETRY_BACKOFF_SEC * (2 ** (attempt - 1))
+            print(f"[TikTok][Auto] retrying in {backoff}s…")
+            time.sleep(backoff)
+    raise last_error or UploadError("unknown")

--- a/server/schedule_upload.py
+++ b/server/schedule_upload.py
@@ -16,6 +16,7 @@ import os
 import shutil
 
 from upload_all import run
+from integrations.tiktok.post import post_to_tiktok  # noqa: F401
 
 # Root directory that contains sub-folders for each niche. The default niche
 # uses this directory directly, e.g. ``out/<project>``. Other niches place their

--- a/server/upload_all.py
+++ b/server/upload_all.py
@@ -17,6 +17,7 @@ load_dotenv(dotenv_path="../.env")
 from config import (
     TIKTOK_CHUNK_SIZE,
     TIKTOK_PRIVACY_LEVEL,
+    TIKTOK_UPLOAD_BACKEND,
     TOKENS_DIR,
     YOUTUBE_CATEGORY_ID,
     YOUTUBE_PRIVACY,
@@ -24,6 +25,7 @@ from config import (
 from helpers.notifications import send_failure_email
 
 from integrations.tiktok import upload as tt_upload
+from integrations.tiktok.post import post_to_tiktok
 from integrations.youtube.auth import ensure_creds, refresh_creds
 from integrations.tiktok.auth import (
     run as run_tiktok_auth,
@@ -77,14 +79,10 @@ def _upload_tiktok(
     privacy_level: str,
     tokens_file: Path,
 ) -> None:
-    _ensure_tiktok_tokens(tokens_file)
     caption = tt_upload.read_caption(desc)
-    size = video.stat().st_size
-    publish_id, upload_url = tt_upload.init_direct_post(
-        size, chunk_size, caption, privacy_level
-    )
-    tt_upload.upload_video(upload_url, video, chunk_size)
-    result = tt_upload.poll_status(publish_id)
+    if TIKTOK_UPLOAD_BACKEND == "api":
+        _ensure_tiktok_tokens(tokens_file)
+    result = post_to_tiktok(str(video), caption)
     print("TikTok upload:", result)
 
 

--- a/tests/test_tiktok_post.py
+++ b/tests/test_tiktok_post.py
@@ -1,0 +1,25 @@
+from server.integrations.tiktok import post as tiktok_post
+
+
+def test_post_to_tiktok_switch(monkeypatch):
+    calls: list[str] = []
+
+    def fake_api(video_path, caption, cover_timestamp_ms=None):
+        calls.append("api")
+        return {"status": "posted", "post_url": None, "debug": {}}
+
+    def fake_auto(video_path, caption, cover_timestamp_ms=None):
+        calls.append("auto")
+        return {"status": "posted", "post_url": None, "debug": {}}
+
+    monkeypatch.setattr(tiktok_post, "_post_via_api", fake_api)
+    monkeypatch.setattr(tiktok_post, "upload_video_with_autouploader", fake_auto)
+
+    monkeypatch.setattr(tiktok_post, "TIKTOK_UPLOAD_BACKEND", "autouploader")
+    tiktok_post.post_to_tiktok("v.mp4", "caption")
+    assert calls == ["auto"]
+
+    calls.clear()
+    monkeypatch.setattr(tiktok_post, "TIKTOK_UPLOAD_BACKEND", "api")
+    tiktok_post.post_to_tiktok("v.mp4", "caption")
+    assert calls == ["api"]


### PR DESCRIPTION
## Summary
- add feature flag to swap between official API and browser autouploader
- implement new `tiktok_autouploader` module with cookie-based auth
- route existing uploads through new `post_to_tiktok` facade

## Testing
- `npx cspell --config cspell.json "**/*.md"`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68beba7b06548323b2769cd197cec5bb