### PR TITLE
Improve upload failure notifications with context

### DIFF
--- a/server/schedule_upload.py
+++ b/server/schedule_upload.py
@@ -136,7 +136,7 @@ def batch(
     """
 
     if niches is None:
-        niches = list_niches()
+        niches = list_niches(OUT_ROOT)
 
     for niche in niches:
         main(kind=niche, platforms=platforms)

--- a/server/steps/download.py
+++ b/server/steps/download.py
@@ -54,7 +54,11 @@ def get_video_urls(url: str) -> list[str]:
     try:
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info = ydl.extract_info(url, download=False)
-    except DownloadError:
+    except DownloadError as exc:
+        send_failure_email(
+            "Playlist retrieval failed",
+            f"Skipping {url}: {exc}",
+        )
         return []
 
     if not info:

--- a/tests/test_auth_refreshers.py
+++ b/tests/test_auth_refreshers.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from server import upload_all
 
 
@@ -14,7 +16,7 @@ def test_youtube_refresh_then_full(monkeypatch):
     monkeypatch.setattr(upload_all, "refresh_creds", mock_refresh)
     monkeypatch.setattr(upload_all, "ensure_creds", mock_full)
 
-    refreshers = upload_all._get_auth_refreshers("u", "p")
+    refreshers = upload_all._get_auth_refreshers("u", "p", Path("v.mp4"), "fun")
     refreshers["youtube"]()
 
     assert calls == ["refresh", "full"]
@@ -33,7 +35,7 @@ def test_youtube_refresh_success(monkeypatch):
     monkeypatch.setattr(upload_all, "refresh_creds", mock_refresh)
     monkeypatch.setattr(upload_all, "ensure_creds", mock_full)
 
-    refreshers = upload_all._get_auth_refreshers("u", "p")
+    refreshers = upload_all._get_auth_refreshers("u", "p", Path("v.mp4"), "fun")
     refreshers["youtube"]()
 
     assert calls == ["refresh"]
@@ -52,7 +54,7 @@ def test_tiktok_refresh_then_full(monkeypatch):
     monkeypatch.setattr(upload_all, "refresh_tiktok_tokens", mock_refresh)
     monkeypatch.setattr(upload_all, "run_tiktok_auth", mock_full)
 
-    refreshers = upload_all._get_auth_refreshers("u", "p")
+    refreshers = upload_all._get_auth_refreshers("u", "p", Path("v.mp4"), "fun")
     refreshers["tiktok"]()
 
     assert calls == ["refresh", "full"]
@@ -71,7 +73,7 @@ def test_tiktok_refresh_success(monkeypatch):
     monkeypatch.setattr(upload_all, "refresh_tiktok_tokens", mock_refresh)
     monkeypatch.setattr(upload_all, "run_tiktok_auth", mock_full)
 
-    refreshers = upload_all._get_auth_refreshers("u", "p")
+    refreshers = upload_all._get_auth_refreshers("u", "p", Path("v.mp4"), "fun")
     refreshers["tiktok"]()
 
     assert calls == ["refresh"]

--- a/tests/test_upload_failure_email.py
+++ b/tests/test_upload_failure_email.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from server import upload_all
+
+
+def test_failure_email_contains_context(monkeypatch, tmp_path):
+    def fail_upload(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(upload_all, "_upload_youtube", fail_upload)
+    monkeypatch.setattr(upload_all, "_upload_instagram", lambda *a, **k: None)
+    monkeypatch.setattr(upload_all, "_upload_tiktok", lambda *a, **k: None)
+    monkeypatch.setattr(
+        upload_all, "_get_auth_refreshers", lambda u, p, v, n: {}
+    )
+
+    emails: list[tuple[str, str]] = []
+
+    def fake_email(subject: str, body: str) -> None:
+        emails.append((subject, body))
+
+    monkeypatch.setattr(upload_all, "send_failure_email", fake_email)
+
+    video = Path("vid.mp4")
+    upload_all.upload_all(
+        video,
+        Path("d.txt"),
+        yt_privacy="public",
+        yt_category_id="22",
+        tt_chunk_size=1,
+        tt_privacy="PRIVATE",
+        tokens_file=tmp_path / "t.json",
+        ig_username="u",
+        ig_password="p",
+        niche="fun",
+    )
+
+    assert len(emails) == 1
+    subject, body = emails[0]
+    assert "youtube" in subject.lower()
+    assert "fun" in body
+    assert str(video) in body
+    assert "youtube" in body.lower()
+    assert "boom" in body
+    assert "Time:" in body

--- a/tests/test_upload_platforms.py
+++ b/tests/test_upload_platforms.py
@@ -14,7 +14,9 @@ def test_upload_all_platform_subset(monkeypatch, tmp_path):
     monkeypatch.setattr(upload_all, "_upload_youtube", mock_upload("youtube"))
     monkeypatch.setattr(upload_all, "_upload_instagram", mock_upload("instagram"))
     monkeypatch.setattr(upload_all, "_upload_tiktok", mock_upload("tiktok"))
-    monkeypatch.setattr(upload_all, "_get_auth_refreshers", lambda u, p: {})
+    monkeypatch.setattr(
+        upload_all, "_get_auth_refreshers", lambda u, p, v, n: {}
+    )
 
     upload_all.upload_all(
         Path("v.mp4"),
@@ -26,6 +28,7 @@ def test_upload_all_platform_subset(monkeypatch, tmp_path):
         tokens_file=tmp_path / "t.json",
         ig_username="u",
         ig_password="p",
+        niche="fun",
         platforms=["youtube", "tiktok"],
     )
 

--- a/tests/test_upload_retry.py
+++ b/tests/test_upload_retry.py
@@ -20,7 +20,9 @@ def test_retry_auth_on_failure(monkeypatch, tmp_path):
         upload_all, "_upload_tiktok", lambda v, d, cs, p, tf: None
     )
     monkeypatch.setattr(
-        upload_all, "_get_auth_refreshers", lambda u, p: {"youtube": mock_auth}
+        upload_all,
+        "_get_auth_refreshers",
+        lambda u, p, v, n: {"youtube": mock_auth},
     )
 
     upload_all.upload_all(
@@ -33,6 +35,7 @@ def test_retry_auth_on_failure(monkeypatch, tmp_path):
         tokens_file=tmp_path / "t.json",
         ig_username="u",
         ig_password="p",
+        niche="fun",
     )
 
     assert calls == {"upload": 2, "auth": 1}

--- a/tests/test_upload_run_cleanup.py
+++ b/tests/test_upload_run_cleanup.py
@@ -28,6 +28,8 @@ def test_run_folder_deletes_files(tmp_path, monkeypatch) -> None:
         tokens_file: Path,
         ig_username: str,
         ig_password: str,
+        *,
+        niche: str | None = None,
         platforms: Sequence[str] | None = None,
     ) -> None:
         calls.append((video, desc))


### PR DESCRIPTION
## Summary
- add `_failure_details` to include niche, video, platform, timestamp, and error in upload failure emails
- pass niche/video to auth refreshers and `upload_all` so emails carry proper context
- notify on playlist retrieval failures and fix batch niche discovery
- cover failure email context with new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bed1c64c348323871967d16d9705d3