### PR TITLE
refactor: namespace uploads by account

### DIFF
--- a/tests/test_schedule_upload.py
+++ b/tests/test_schedule_upload.py
@@ -53,8 +53,8 @@ def test_main_cleans_and_deletes(tmp_path: Path, monkeypatch) -> None:
 
     calls: list[tuple[Path, Path, str | None]] = []
 
-    def fake_run(*, video: Path, desc: Path, niche=None, **kwargs) -> None:
-        calls.append((video, desc, niche))
+    def fake_run(*, video: Path, desc: Path, account=None, **kwargs) -> None:
+        calls.append((video, desc, account))
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(schedule_upload, "run", fake_run)
@@ -95,8 +95,8 @@ def test_project_not_deleted_until_last_short(tmp_path: Path, monkeypatch) -> No
 
     calls: list[tuple[Path, Path, str | None]] = []
 
-    def fake_run(*, video: Path, desc: Path, niche=None, **kwargs) -> None:
-        calls.append((video, desc, niche))
+    def fake_run(*, video: Path, desc: Path, account=None, **kwargs) -> None:
+        calls.append((video, desc, account))
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(schedule_upload, "run", fake_run)
@@ -121,7 +121,7 @@ def test_project_not_deleted_until_last_short(tmp_path: Path, monkeypatch) -> No
     assert not project.exists()
 
 
-def test_main_respects_kind(tmp_path: Path, monkeypatch) -> None:
+def test_main_respects_account(tmp_path: Path, monkeypatch) -> None:
     out = tmp_path / "out" / "alt"
     project = out / "proj"
     shorts = project / "shorts"
@@ -133,14 +133,14 @@ def test_main_respects_kind(tmp_path: Path, monkeypatch) -> None:
 
     calls: list[tuple[Path, Path, str | None]] = []
 
-    def fake_run(*, video: Path, desc: Path, niche=None, **kwargs) -> None:
-        calls.append((video, desc, niche))
+    def fake_run(*, video: Path, desc: Path, account=None, **kwargs) -> None:
+        calls.append((video, desc, account))
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(schedule_upload, "run", fake_run)
     monkeypatch.setattr(schedule_upload, "OUT_ROOT", Path("out"))
 
-    schedule_upload.main(kind="alt")
+    schedule_upload.main(account="alt")
 
     assert len(calls) == 1
     assert calls[0] == (
@@ -164,7 +164,7 @@ def test_main_accepts_platforms(tmp_path: Path, monkeypatch) -> None:
 
     platforms_seen: list[Sequence[str] | None] = []
 
-    def fake_run(*, video: Path, desc: Path, niche=None, platforms=None, **kw) -> None:
+    def fake_run(*, video: Path, desc: Path, account=None, platforms=None, **kw) -> None:
         platforms_seen.append(platforms)
 
     monkeypatch.chdir(tmp_path)
@@ -176,15 +176,15 @@ def test_main_accepts_platforms(tmp_path: Path, monkeypatch) -> None:
     assert platforms_seen == [["youtube", "tiktok"]]
 
 
-def test_batch_processes_all_niches(tmp_path: Path, monkeypatch) -> None:
+def test_batch_processes_all_accounts(tmp_path: Path, monkeypatch) -> None:
     out = tmp_path / "out"
     (out / "proj" / "shorts").mkdir(parents=True)
     (out / "alt" / "proj" / "shorts").mkdir(parents=True)
 
-    kinds_seen: list[str | None] = []
+    accounts_seen: list[str | None] = []
 
-    def fake_main(*, kind=None, platforms=None):
-        kinds_seen.append(kind)
+    def fake_main(*, account=None, platforms=None):
+        accounts_seen.append(account)
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(schedule_upload, "main", fake_main)
@@ -192,22 +192,22 @@ def test_batch_processes_all_niches(tmp_path: Path, monkeypatch) -> None:
 
     schedule_upload.batch()
 
-    assert kinds_seen == [None, "alt"]
+    assert accounts_seen == [None, "alt"]
 
 
-def test_batch_respects_niches_argument(tmp_path: Path, monkeypatch) -> None:
+def test_batch_respects_accounts_argument(tmp_path: Path, monkeypatch) -> None:
     out = tmp_path / "out" / "alt" / "proj" / "shorts"
     out.mkdir(parents=True)
 
-    kinds_seen: list[str | None] = []
+    accounts_seen: list[str | None] = []
 
-    def fake_main(*, kind=None, platforms=None):
-        kinds_seen.append(kind)
+    def fake_main(*, account=None, platforms=None):
+        accounts_seen.append(account)
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(schedule_upload, "main", fake_main)
     monkeypatch.setattr(schedule_upload, "OUT_ROOT", Path("out"))
 
-    schedule_upload.batch(niches=["alt"])
+    schedule_upload.batch(accounts=["alt"])
 
-    assert kinds_seen == ["alt"]
+    assert accounts_seen == ["alt"]

--- a/tests/test_upload_failure_email.py
+++ b/tests/test_upload_failure_email.py
@@ -11,7 +11,7 @@ def test_failure_email_contains_context(monkeypatch, tmp_path):
     monkeypatch.setattr(upload_all, "_upload_instagram", lambda *a, **k: None)
     monkeypatch.setattr(upload_all, "_upload_tiktok", lambda *a, **k: None)
     monkeypatch.setattr(
-        upload_all, "_get_auth_refreshers", lambda u, p, v, n: {}
+        upload_all, "_get_auth_refreshers", lambda u, p, v, a: {}
     )
 
     emails: list[tuple[str, str]] = []
@@ -32,7 +32,7 @@ def test_failure_email_contains_context(monkeypatch, tmp_path):
         tokens_file=tmp_path / "t.json",
         ig_username="u",
         ig_password="p",
-        niche="fun",
+        account="fun",
     )
 
     assert len(emails) == 1

--- a/tests/test_upload_platforms.py
+++ b/tests/test_upload_platforms.py
@@ -15,7 +15,7 @@ def test_upload_all_platform_subset(monkeypatch, tmp_path):
     monkeypatch.setattr(upload_all, "_upload_instagram", mock_upload("instagram"))
     monkeypatch.setattr(upload_all, "_upload_tiktok", mock_upload("tiktok"))
     monkeypatch.setattr(
-        upload_all, "_get_auth_refreshers", lambda u, p, v, n: {}
+        upload_all, "_get_auth_refreshers", lambda u, p, v, a: {}
     )
 
     upload_all.upload_all(
@@ -28,7 +28,7 @@ def test_upload_all_platform_subset(monkeypatch, tmp_path):
         tokens_file=tmp_path / "t.json",
         ig_username="u",
         ig_password="p",
-        niche="fun",
+        account="fun",
         platforms=["youtube", "tiktok"],
     )
 

--- a/tests/test_upload_retry.py
+++ b/tests/test_upload_retry.py
@@ -22,7 +22,7 @@ def test_retry_auth_on_failure(monkeypatch, tmp_path):
     monkeypatch.setattr(
         upload_all,
         "_get_auth_refreshers",
-        lambda u, p, v, n: {"youtube": mock_auth},
+        lambda u, p, v, a: {"youtube": mock_auth},
     )
 
     upload_all.upload_all(
@@ -35,7 +35,7 @@ def test_retry_auth_on_failure(monkeypatch, tmp_path):
         tokens_file=tmp_path / "t.json",
         ig_username="u",
         ig_password="p",
-        niche="fun",
+        account="fun",
     )
 
     assert calls == {"upload": 2, "auth": 1}

--- a/tests/test_upload_run_cleanup.py
+++ b/tests/test_upload_run_cleanup.py
@@ -29,7 +29,7 @@ def test_run_folder_deletes_files(tmp_path, monkeypatch) -> None:
         ig_username: str,
         ig_password: str,
         *,
-        niche: str | None = None,
+        account: str | None = None,
         platforms: Sequence[str] | None = None,
     ) -> None:
         calls.append((video, desc))


### PR DESCRIPTION
## Summary
- decouple accounts from tones so multiple accounts can share a tone
- namespace upload tokens and output folders by account
- update scheduling and tests for account-based operations

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `npx -y cspell --config cspell.json "**/*.md"` *(issues found: 6 in 2 files)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5ae5b3548323b9ab9b9053a7bf67