### PR TITLE
Preserve highest rating when resolving clip overlaps

### DIFF
--- a/server/steps/candidates/helpers.py
+++ b/server/steps/candidates/helpers.py
@@ -462,9 +462,12 @@ def _enforce_non_overlap(
         return not (a.end + min_gap <= b.start or b.end + min_gap <= a.start)
 
     for cand in adjusted:
-        if any(overlaps(cand, s) for s in selected):
-            continue
-        selected.append(cand)
+        for sel in selected:
+            if overlaps(cand, sel):
+                sel.rating = max(sel.rating, cand.rating)
+                break
+        else:
+            selected.append(cand)
 
     selected.sort(key=lambda x: x.start)
     return selected

--- a/tests/test_candidate_ranking.py
+++ b/tests/test_candidate_ranking.py
@@ -21,7 +21,7 @@ def test_tone_aligned_prioritized() -> None:
     result = _enforce_non_overlap([bad, good], items)
     assert len(result) == 1
     chosen = result[0]
-    assert chosen.rating == good.rating
+    assert chosen.rating == max(good.rating, bad.rating)
     assert chosen.start == 0.0 and chosen.end == 12.0
 
 

--- a/tests/test_merge_optional.py
+++ b/tests/test_merge_optional.py
@@ -17,3 +17,4 @@ def test_merge_overlaps_flag_controls_behavior():
     )
     assert len(with_merge) == 1
     assert with_merge[0].start == 0.0 and with_merge[0].end == 2.0
+    assert with_merge[0].rating == 6


### PR DESCRIPTION
## Summary
- Keep the maximum rating among overlapping clip candidates during non-overlap enforcement
- Verify merged candidates retain the highest rating
- Adjust tests to expect highest rating propagation

## Testing
- `/usr/bin/python3 -m pytest tests/test_candidate_ranking.py::test_tone_aligned_prioritized -q` *(fails: No module named pytest)*
- `/usr/bin/npx cspell --config cspell.json "**/*.md"` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c03f26445483238db3535473f25c1b