### PR TITLE
Resnap merged clips after merging

### DIFF
--- a/server/steps/candidates/helpers.py
+++ b/server/steps/candidates/helpers.py
@@ -365,23 +365,36 @@ def _merge_adjacent_candidates(
             new_start = min(cur.start, nxt.start)
             new_end = max(cur.end, nxt.end)
             if (new_end - new_start) <= max_duration_seconds:
+                merged_rating = max(cur.rating, nxt.rating)
+                merged_reason = (
+                    cur.reason
+                    + (" | " if cur.reason and nxt.reason else "")
+                    + nxt.reason
+                ).strip()
+                merged_quote = (
+                    cur.quote
+                    + (" | " if cur.quote and nxt.quote else "")
+                    + nxt.quote
+                ).strip()
+                s, e = refine_clip_window(
+                    new_start,
+                    new_end,
+                    items,
+                    words=words,
+                    silences=silences,
+                    max_extension=max_duration_seconds,
+                )
+                if e - s > max_duration_seconds:
+                    e = s + max_duration_seconds
                 print(
-                    f"[Merge] ({cur.start:.2f}-{cur.end:.2f}) + ({nxt.start:.2f}-{nxt.end:.2f}) -> ({new_start:.2f}-{new_end:.2f})"
+                    f"[Merge] ({cur.start:.2f}-{cur.end:.2f}) + ({nxt.start:.2f}-{nxt.end:.2f}) -> ({s:.2f}-{e:.2f})"
                 )
                 cur = ClipCandidate(
-                    start=new_start,
-                    end=new_end,
-                    rating=max(cur.rating, nxt.rating),
-                    reason=(
-                        cur.reason
-                        + (" | " if cur.reason and nxt.reason else "")
-                        + nxt.reason
-                    ).strip(),
-                    quote=(
-                        cur.quote
-                        + (" | " if cur.quote and nxt.quote else "")
-                        + nxt.quote
-                    ).strip(),
+                    start=s,
+                    end=e,
+                    rating=merged_rating,
+                    reason=merged_reason,
+                    quote=merged_quote,
                 )
                 continue
         merged.append(cur)

--- a/tests/test_merge_optional.py
+++ b/tests/test_merge_optional.py
@@ -18,3 +18,18 @@ def test_merge_overlaps_flag_controls_behavior():
     assert len(with_merge) == 1
     assert with_merge[0].start == 0.0 and with_merge[0].end == 2.0
     assert with_merge[0].rating == 6
+
+
+def test_merged_clip_gets_resnapped():
+    items = [
+        (0.0, 1.0, "Hello"),
+        (1.0, 2.0, "there"),
+        (2.0, 3.0, "friend"),
+    ]
+    c1 = ClipCandidate(start=0.1, end=0.9, rating=5, reason="", quote="")
+    c2 = ClipCandidate(start=1.1, end=1.9, rating=6, reason="", quote="")
+
+    merged = _merge_adjacent_candidates([c1, c2], items, merge_overlaps=True)
+    assert len(merged) == 1
+    assert merged[0].start == 0.0
+    assert merged[0].end == 3.0


### PR DESCRIPTION
## Summary
- Resnap merged clip candidates to natural boundaries after merging
- Add regression test ensuring merged clips expand to adjacent sentence

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `npx --yes cspell --config cspell.json "**/*.md"`

------
https://chatgpt.com/codex/tasks/task_e_68c052240e8083238df8c3751c15fc66