### PR TITLE
Merge overlapping candidates before duration clamp

### DIFF
--- a/server/steps/candidates/helpers.py
+++ b/server/steps/candidates/helpers.py
@@ -360,41 +360,40 @@ def _merge_adjacent_candidates(
         if overlap or tiny_gap:
             new_orig_start = min(cur_orig_start, nxt_orig_start)
             new_orig_end = max(cur_orig_end, nxt_orig_end)
-            if (new_orig_end - new_orig_start) <= max_duration_seconds:
-                merged_rating = max(cur.rating, nxt.rating)
-                merged_reason = (
-                    cur.reason
-                    + (" | " if cur.reason and nxt.reason else "")
-                    + nxt.reason
-                ).strip()
-                merged_quote = (
-                    cur.quote
-                    + (" | " if cur.quote and nxt.quote else "")
-                    + nxt.quote
-                ).strip()
-                s, e = refine_clip_window(
-                    new_orig_start,
-                    new_orig_end,
-                    items,
-                    words=words,
-                    silences=silences,
-                    max_extension=max_duration_seconds,
-                )
-                if e - s > max_duration_seconds:
-                    e = s + max_duration_seconds
-                print(
-                    f"[Merge] ({cur.start:.2f}-{cur.end:.2f}) + ({nxt.start:.2f}-{nxt.end:.2f}) -> ({s:.2f}-{e:.2f})"
-                )
-                cur_orig_start = new_orig_start
-                cur_orig_end = new_orig_end
-                cur = ClipCandidate(
-                    start=s,
-                    end=e,
-                    rating=merged_rating,
-                    reason=merged_reason,
-                    quote=merged_quote,
-                )
-                continue
+            merged_rating = max(cur.rating, nxt.rating)
+            merged_reason = (
+                cur.reason
+                + (" | " if cur.reason and nxt.reason else "")
+                + nxt.reason
+            ).strip()
+            merged_quote = (
+                cur.quote
+                + (" | " if cur.quote and nxt.quote else "")
+                + nxt.quote
+            ).strip()
+            s, e = refine_clip_window(
+                new_orig_start,
+                new_orig_end,
+                items,
+                words=words,
+                silences=silences,
+                max_extension=max_duration_seconds,
+            )
+            if e - s > max_duration_seconds:
+                e = s + max_duration_seconds
+            print(
+                f"[Merge] ({cur.start:.2f}-{cur.end:.2f}) + ({nxt.start:.2f}-{nxt.end:.2f}) -> ({s:.2f}-{e:.2f})"
+            )
+            cur_orig_start = new_orig_start
+            cur_orig_end = e
+            cur = ClipCandidate(
+                start=s,
+                end=e,
+                rating=merged_rating,
+                reason=merged_reason,
+                quote=merged_quote,
+            )
+            continue
         merged.append(cur)
         cur_orig_start, cur_orig_end, cur = nxt_orig_start, nxt_orig_end, nxt
 

--- a/tests/test_merge_optional.py
+++ b/tests/test_merge_optional.py
@@ -49,3 +49,20 @@ def test_merge_uses_unsnapped_duration_check():
     assert len(merged) == 1
     assert merged[0].start == 0.0
     assert merged[0].end == 5.0
+
+
+def test_merge_exceeding_max_duration_clamps():
+    items = [
+        (0.0, 4.0, "A"),
+        (4.0, 8.0, "B"),
+    ]
+    c1 = ClipCandidate(start=0.0, end=4.0, rating=5, reason="", quote="")
+    c2 = ClipCandidate(start=4.1, end=8.0, rating=6, reason="", quote="")
+
+    merged = _merge_adjacent_candidates(
+        [c1, c2], items, merge_overlaps=True, max_duration_seconds=5.0
+    )
+    assert len(merged) == 1
+    assert merged[0].start == 0.0
+    assert merged[0].end == 5.0
+    assert merged[0].rating == 6


### PR DESCRIPTION
## Summary
- Merge overlapping or adjacent clip candidates using original timestamps and clamp after snapping
- Truncate merged clips to `max_duration_seconds` and update merge window
- Add regression tests for merging when combined span exceeds `max_duration_seconds`

## Testing
- `npx --yes cspell --config cspell.json "**/*.md"` *(fails: unknown words in AGENTS.md, README.md)*
- `pytest` *(fails: missing FFmpeg and tone config; KeyError/ FileNotFoundError)*


------
https://chatgpt.com/codex/tasks/task_e_68c0650b6e4c83238f231a71d17b8e62