### PR TITLE
Coalesce snapped intervals before final merge

### DIFF
--- a/server/steps/candidates/tone.py
+++ b/server/steps/candidates/tone.py
@@ -12,8 +12,8 @@ from config import (
     LOCAL_LLM_MODEL,
 )
 
-from custom_types.tone import ToneStrategy
-from custom_types.ETone import Tone
+from server.custom_types.tone import ToneStrategy
+from server.custom_types.ETone import Tone
 
 from . import ClipCandidate, _filter_promotional_candidates
 from .helpers import (
@@ -47,6 +47,7 @@ STRATEGY_REGISTRY: dict[Tone, ToneStrategy] = {
     Tone.FUNNY: ToneStrategy(
         prompt_desc=FUNNY_PROMPT_DESC,
         rating_descriptions=FUNNY_RATING_DESCRIPTIONS,
+        min_rating=8.0,
     ),
     Tone.SPACE: ToneStrategy(
         prompt_desc=SPACE_PROMPT_DESC,

--- a/tests/test_coalesce_snapped_intervals.py
+++ b/tests/test_coalesce_snapped_intervals.py
@@ -1,0 +1,34 @@
+from server.interfaces.clip_candidate import ClipCandidate
+from server.steps.candidates.helpers import _coalesce_snapped_intervals
+
+
+def test_coalesce_merges_touching():
+    c1 = ClipCandidate(start=0.27, end=12.62, rating=9.5, reason="r1", quote="q1")
+    c2 = ClipCandidate(start=12.62, end=60.29, rating=9.2, reason="r2", quote="q2")
+    out = _coalesce_snapped_intervals([c1, c2])
+    assert len(out) == 1
+    merged = out[0]
+    assert merged.start == 0.27 and merged.end == 60.29
+    assert merged.rating == 9.5
+    assert merged.reason == "r1"
+    assert merged.quote == "q1"
+
+
+def test_coalesce_gap_over_eps_not_merged():
+    c1 = ClipCandidate(start=10.0, end=15.0, rating=5.0, reason="", quote="")
+    c2 = ClipCandidate(start=15.001, end=20.0, rating=6.0, reason="", quote="")
+    out = _coalesce_snapped_intervals([c1, c2])
+    assert len(out) == 2
+
+
+def test_coalesce_merges_within_eps():
+    c1 = ClipCandidate(start=30.0, end=40.0, rating=5.0, reason="", quote="")
+    c2 = ClipCandidate(start=40.0005, end=50.0, rating=6.0, reason="", quote="")
+    out = _coalesce_snapped_intervals([c1, c2])
+    assert len(out) == 1
+    merged = out[0]
+    assert merged.start == 30.0 and merged.end == 50.0
+    assert merged.rating == 6.0
+
+    out2 = _coalesce_snapped_intervals([c1, c2], eps=4e-4)
+    assert len(out2) == 2


### PR DESCRIPTION
## Summary
- add `_coalesce_snapped_intervals` to merge overlapping or touching clip candidates and keep the best metadata
- integrate interval coalescing into the final merge/resnap pipeline with debug logs
- ensure FUNNY tone strategy uses server imports and explicit rating threshold

## Testing
- `pytest`
- `npx cspell --config cspell.json "**/*.md"` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b081ec6c832385e30930f0b0af8c