### PR TITLE
feat: coalesce snapped clip intervals

### DIFF
--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -23,6 +23,7 @@ from steps.candidates.helpers import (
     snap_start_to_dialog_start,
     snap_end_to_dialog_end,
     dedupe_candidates,
+    _coalesce_snapped_intervals,
 )
 from steps.segment import (
     segment_transcript_items,
@@ -542,6 +543,8 @@ def process_video(yt_url: str, account: str | None = None, tone: Tone | None = N
         print(
             f"{Fore.YELLOW}Skipping STEP 6: using {len(refined_candidates)} existing candidates{Style.RESET_ALL}"
         )
+
+    refined_candidates = _coalesce_snapped_intervals(refined_candidates)
 
     for idx, candidate in enumerate(refined_candidates, start=1):
         def step_cut() -> Path | None:

--- a/server/steps/candidates/__init__.py
+++ b/server/steps/candidates/__init__.py
@@ -20,7 +20,7 @@ from .helpers import (
     _get_field,
     _to_float,
     parse_transcript,
-    _final_merge_and_resnap,
+    _merge_adjacent_candidates,
     _enforce_non_overlap,
 )
 from .prompts import _build_system_instructions, FUNNY_PROMPT_DESC
@@ -295,7 +295,7 @@ def find_clip_timestamps_batched(
     print(
         f"[Batch] Collected {len(all_candidates)} raw candidates across all chunks. Merging and enforcing non-overlap..."
     )
-    filtered_candidates = _final_merge_and_resnap(
+    filtered_candidates = _merge_adjacent_candidates(
         filtered_candidates,
         items,
         merge_gap_seconds=1.0,
@@ -407,7 +407,7 @@ def find_clip_timestamps(
 
     candidates = _filter_promotional_candidates(candidates, items)
 
-    merged_candidates = _final_merge_and_resnap(
+    merged_candidates = _merge_adjacent_candidates(
         candidates,
         items,
         merge_gap_seconds=1.0,

--- a/server/steps/candidates/__init__.py
+++ b/server/steps/candidates/__init__.py
@@ -20,7 +20,7 @@ from .helpers import (
     _get_field,
     _to_float,
     parse_transcript,
-    _merge_adjacent_candidates,
+    _final_merge_and_resnap,
     _enforce_non_overlap,
 )
 from .prompts import _build_system_instructions, FUNNY_PROMPT_DESC
@@ -295,7 +295,7 @@ def find_clip_timestamps_batched(
     print(
         f"[Batch] Collected {len(all_candidates)} raw candidates across all chunks. Merging and enforcing non-overlap..."
     )
-    filtered_candidates = _merge_adjacent_candidates(
+    filtered_candidates = _final_merge_and_resnap(
         filtered_candidates,
         items,
         merge_gap_seconds=1.0,
@@ -407,7 +407,7 @@ def find_clip_timestamps(
 
     candidates = _filter_promotional_candidates(candidates, items)
 
-    merged_candidates = _merge_adjacent_candidates(
+    merged_candidates = _final_merge_and_resnap(
         candidates,
         items,
         merge_gap_seconds=1.0,

--- a/tests/test_coalesce_snapped_intervals.py
+++ b/tests/test_coalesce_snapped_intervals.py
@@ -1,0 +1,28 @@
+from server.interfaces.clip_candidate import ClipCandidate
+from server.steps.candidates.helpers import _coalesce_snapped_intervals
+
+
+def test_coalesce_merges_touching():
+    c1 = ClipCandidate(start=0.27, end=12.62, rating=9.5, reason="a", quote="q1")
+    c2 = ClipCandidate(start=12.62, end=60.29, rating=9.2, reason="b", quote="q2")
+    merged = _coalesce_snapped_intervals([c1, c2])
+    assert len(merged) == 1
+    m = merged[0]
+    assert m.start == 0.27 and m.end == 60.29
+    assert m.rating == 9.5 and m.reason == "a" and m.quote == "q1"
+
+
+def test_coalesce_keeps_gap_over_eps():
+    c1 = ClipCandidate(start=10.0, end=15.0, rating=5.0, reason="", quote="")
+    c2 = ClipCandidate(start=15.002, end=20.0, rating=4.0, reason="", quote="")
+    merged = _coalesce_snapped_intervals([c1, c2])
+    assert len(merged) == 2
+
+
+def test_coalesce_merges_within_eps():
+    c1 = ClipCandidate(start=30.0, end=40.0, rating=5.0, reason="", quote="")
+    c2 = ClipCandidate(start=39.9995, end=50.0, rating=6.0, reason="", quote="")
+    merged = _coalesce_snapped_intervals([c1, c2])
+    assert len(merged) == 1
+    m = merged[0]
+    assert m.start == 30.0 and m.end == 50.0 and m.rating == 6.0


### PR DESCRIPTION
## Summary
- add `_coalesce_snapped_intervals` to merge touching or overlapping clip candidates while preserving the highest rated metadata
- expose `_final_merge_and_resnap` wrapper that coalesces before and after group merging
- wire `_final_merge_and_resnap` into batch and single timestamp flows
- cover coalescing helper with unit tests

## Testing
- `apt-get update`
- `apt-get install -y libgl1 ffmpeg`
- `pytest` *(fails: KeyError: <Tone.FUNNY: 'funny'>)*
- `PYTHONPATH=.:server pytest tests/test_coalesce_snapped_intervals.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0d0b71ac88323a609ceb1511f36bd