### PR TITLE
feat: refine hashtag generation

### DIFF
--- a/tests/test_hashtag_generation.py
+++ b/tests/test_hashtag_generation.py
@@ -1,0 +1,21 @@
+
+from common.caption_utils import build_hashtag_prompt, prepare_hashtags
+
+
+def test_prepare_hashtags_sanitizes_and_sorts():
+    tags = ["Long Tag", "short", "punctuation!"]
+    result = prepare_hashtags(tags, "The Show")
+    assert result == ["#short", "#LongTag", "#TheShow", "#punctuation"]
+
+
+def test_prepare_hashtags_dedupes_and_adds_show():
+    tags = ["repeat", "repeat", "Another"]
+    result = prepare_hashtags(tags, "repeat")
+    assert result == ["#repeat", "#Another"]
+
+
+def test_build_hashtag_prompt_includes_guidelines():
+    prompt = build_hashtag_prompt("Title", quote="Quote", show="Show")
+    assert "Favor short hashtags" in prompt
+    assert "avoid punctuation" in prompt
+    assert "Show: Show" in prompt


### PR DESCRIPTION
## Summary
- sanitize and rank hashtags, favoring shorter tags and removing punctuation
- ensure show name becomes a hashtag and avoid always tagging the title
- cover hashtag preparation with unit tests
- pass explicit hashtag guidelines to the LLM prompt

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c16a2dffdc83238309cce9f2754cad