### PR TITLE
Expand hashtag generation with generic defaults

### DIFF
--- a/server/common/caption_utils.py
+++ b/server/common/caption_utils.py
@@ -91,15 +91,16 @@ def build_hashtag_prompt(
     """Create an instruction prompt for hashtag generation."""
 
     prompt = (
-        "Generate as many relevant hashtags for a short form video based on the "
-        "video's title"
+        "Generate many relevant hashtags for a short form video based on the video's "
+        "title"
     )
     if quote:
         prompt += " and a quote from the clip"
     prompt += (
-        ". Favor short hashtags, avoid punctuation, and the title does not always "
-        "need to be a hashtag. Include the show name if provided. Respond with a "
-        "JSON array of strings without the # symbol.\n"
+        ". Include a mix of broad, generic hashtags and ones specific to the video's "
+        "content. Favor short hashtags, avoid punctuation, and the title does not "
+        "always need to be a hashtag. Include the show name if provided. Respond with "
+        "a JSON array of strings without the # symbol.\n"
         f"Title: {title}\n"
     )
     if quote:

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -89,6 +89,7 @@ from helpers.cleanup import cleanup_project_dir
 from common.caption_utils import build_hashtag_prompt, prepare_hashtags
 
 
+GENERIC_HASHTAGS = ["foryou", "fyp", "viral", "trending"]
 
 
 def process_video(yt_url: str, account: str | None = None, tone: Tone | None = None) -> None:
@@ -645,7 +646,10 @@ def process_video(yt_url: str, account: str | None = None, tone: Tone | None = N
                     for w in video_info["title"].split()
                     if re.sub(r"[^0-9A-Za-z]", "", w)
                 ][:3]
-            hashtags = prepare_hashtags(tags + fallback_words, video_info.get("uploader"))
+            hashtags = prepare_hashtags(
+                tags + fallback_words + GENERIC_HASHTAGS,
+                video_info.get("uploader"),
+            )
             hashtags.extend(["#shorts", "#madebyatropos"])
             full_video_link = youtube_timestamp_url(yt_url, candidate.start)
             description = (

--- a/tests/test_hashtag_generation.py
+++ b/tests/test_hashtag_generation.py
@@ -14,8 +14,18 @@ def test_prepare_hashtags_dedupes_and_adds_show():
     assert result == ["#repeat", "#Another"]
 
 
+def test_prepare_hashtags_handles_generic_tags():
+    tags = ["Specific"]
+    generics = ["foryou", "fyp", "viral", "trending"]
+    result = prepare_hashtags(tags + generics, None)
+    for expected in ["#foryou", "#fyp", "#viral", "#trending", "#Specific"]:
+        assert expected in result
+
+
 def test_build_hashtag_prompt_includes_guidelines():
     prompt = build_hashtag_prompt("Title", quote="Quote", show="Show")
     assert "Favor short hashtags" in prompt
     assert "avoid punctuation" in prompt
     assert "Show: Show" in prompt
+    assert "generic hashtags" in prompt
+    assert "specific to the video's" in prompt


### PR DESCRIPTION
## Summary
- Encourage generic and content-specific hashtags in the generation prompt
- Always append popular generic hashtags to each clip's hashtag list
- Add tests for generic hashtag handling and updated prompt wording

## Testing
- `pytest` *(fails: KeyError: <Tone.FUNNY: 'funny'>)*

------
https://chatgpt.com/codex/tasks/task_e_68c180d36e348323825a8a68dcbbb65a