### PR TITLE
Handle control characters in LLM JSON responses

### DIFF
--- a/server/helpers/ai.py
+++ b/server/helpers/ai.py
@@ -18,8 +18,8 @@ DEFAULT_JSON_EXTRACT = re.compile(r"\[(?:.|\n)*\]")
 
 
 # Some models occasionally emit stray control characters that break ``json.loads``.
-# Strip everything except standard whitespace before attempting to parse.
-_CTRL_RE = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F]")
+# Strip all ASCII control characters before attempting to parse.
+_CTRL_RE = re.compile(r"[\x00-\x1F]")
 
 
 def _strip_control_chars(text: str) -> str:

--- a/tests/test_ai_json_parse.py
+++ b/tests/test_ai_json_parse.py
@@ -45,3 +45,15 @@ def test_ollama_generate_handles_dict_response(monkeypatch) -> None:
     out = ai.ollama_generate(model="m", prompt="p")
     assert out == json.dumps({"foo": [1, 2]})
 
+
+def test_ollama_call_json_strips_control_chars(monkeypatch) -> None:
+    raw = '["alpha", "br\navo", "char\ttlie"]'
+
+    def fake_generate(*args, **kwargs):
+        return raw
+
+    monkeypatch.setattr(ai, "ollama_generate", fake_generate)
+
+    result = ai.ollama_call_json(model="m", prompt="p")
+    assert result == ["alpha", "bravo", "chartlie"]
+


### PR DESCRIPTION
## Summary
- Strip all ASCII control characters from LLM responses before JSON parsing
- Add regression test ensuring hashtag generation tolerates control chars

## Testing
- `pytest` *(fails: KeyError: <Tone.FUNNY: 'funny'>, FileNotFoundError: 'ffmpeg')*
- `npx -y cspell --config cspell.json "**/*.md"` *(issues found: 6 in 2 files)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fb3d15648323b775fa5b783d08e3