### PR TITLE
Merge short clip candidates to reach sweet spot

### DIFF
--- a/tests/test_merge_optional.py
+++ b/tests/test_merge_optional.py
@@ -20,3 +20,37 @@ def test_merge_overlaps_flag_controls_behavior():
     assert merged.start == 0.0 and merged.end == 2.0
     assert merged.rating == 5.5
     assert merged.count == 2
+
+
+def test_merge_short_clips_reaches_sweet_spot() -> None:
+    c1 = ClipCandidate(start=0.0, end=4.0, rating=5, reason="", quote="")
+    c2 = ClipCandidate(start=4.0, end=8.0, rating=6, reason="", quote="")
+    c3 = ClipCandidate(start=8.0, end=12.0, rating=7, reason="", quote="")
+    merged = _merge_adjacent_candidates(
+        [c1, c2, c3],
+        merge_overlaps=True,
+        min_duration_seconds=5.0,
+        sweet_spot_min_seconds=10.0,
+        sweet_spot_max_seconds=15.0,
+    )
+    assert len(merged) == 1
+    m = merged[0]
+    assert m.start == 0.0 and m.end == 12.0
+
+
+def test_stop_merging_after_sweet_spot() -> None:
+    c1 = ClipCandidate(start=0.0, end=4.0, rating=5, reason="", quote="")
+    c2 = ClipCandidate(start=4.0, end=8.0, rating=6, reason="", quote="")
+    c3 = ClipCandidate(start=8.0, end=12.0, rating=7, reason="", quote="")
+    c4 = ClipCandidate(start=12.0, end=16.0, rating=8, reason="", quote="")
+    merged = _merge_adjacent_candidates(
+        [c1, c2, c3, c4],
+        merge_overlaps=True,
+        min_duration_seconds=5.0,
+        sweet_spot_min_seconds=10.0,
+        sweet_spot_max_seconds=15.0,
+    )
+    assert len(merged) == 2
+    first, second = merged
+    assert first.start == 0.0 and first.end == 12.0
+    assert second.start == 12.0 and second.end == 16.0


### PR DESCRIPTION
## Summary
- extend candidate merging to combine short adjacent clips until they reach the configured sweet spot
- add tests covering sweet spot merging boundaries

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg'; 19 failed, 77 passed)*
- `npx cspell --config cspell.json "**/*.md"` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b51df69483239283bdb704af6fa9