### PR TITLE
Greedy chaining pass for candidate sweet spot

### DIFF
--- a/server/steps/candidates/prompts.py
+++ b/server/steps/candidates/prompts.py
@@ -21,35 +21,6 @@ TONE-SPECIFIC:
 """
 
 
-GENERAL_RATING_DESCRIPTIONS: Dict[str, str] = {
-    "10": "rare, exceptional clip; perfect fit; instantly gripping and highly shareable",
-    "9":  "rare, exceptional clip; excellent fit; strong hook and clear payoff",
-    "8":  "very good; engaging and on-target (common; most clips fall here or below)",
-    "7":  "good; include if few stronger options exist",
-    "6":  "borderline; some issues with clarity or impact",
-    "5":  "weak; limited relevance or momentum",
-    "4":  "poor; off-target or confusing",
-    "3":  "poor; off-target or confusing",
-    "2":  "not usable; unclear or irrelevant",
-    "1":  "not usable; unclear or irrelevant",
-    "0":  "reject; misleading or inappropriate",
-}
-
-
-FUNNY_RATING_DESCRIPTIONS: Dict[str, str] = {
-    "10": "can't stop laughing; universal hysterics",
-    "9":  "guaranteed laugh; laugh-out-loud every time",
-    "8":  "big laugh for most; very funny",
-    "7":  "solid laugh; clearly funny",
-    "6":  "lightly amusing; smile more than laugh",
-    "5":  "weak humor; raunchy or crude without payoff",
-    "4":  "poor joke; muddy setup or payoff",
-    "3":  "barely humorous; off-tone or confusing",
-    "2":  "not funny; flat or irrelevant",
-    "1":  "not funny at all; offensive or crude with no humor",
-    "0":  "reject; hateful or non-consensual content without comedic value",
-}
-
 SCIENCE_PROMPT_DESC = """
 TONE-SPECIFIC:
 - Select moments that spark scientific awe or curiosity: clear explanations, surprising discoveries, elegant analogies, or milestone findings across any scientific field (space/astronomy, biology, chemistry, physics, or other disciplines).
@@ -98,92 +69,8 @@ TONE-SPECIFIC:
 - Exclude campaign slogans, personal attacks, horse‑race chatter, or unverified claims; flag uncertainty if the speaker speculates.
 """
 
-SCIENCE_RATING_DESCRIPTIONS = {
-    "10": "jaw-dropping breakthrough or explanation; unforgettable sense of clarity or wonder",
-    "9":  "profound and memorable; crisp explanation or striking discovery with clear insight",
-    "8":  "very strong; sparks curiosity and delivers a clear, engaging scientific takeaway",
-    "7":  "good; informative and relevant with a decent hook",
-    "6":  "borderline; needs tighter framing, clearer takeaway, or better grounding",
-    "5":  "weak; facts or data points with little context or no clear point",
-    "4":  "poor; meandering jargon, unclear framing, or partial claims",
-    "3":  "confusing or unfocused; audience left without a clear idea",
-    "2":  "not usable; speculative or off-topic without evidence",
-    "1":  "not usable; misleading, trivial, or shoddy science",
-    "0":  "reject; unsafe misinformation, pseudoscience, or sensational claims without evidence",
-}
-
-HISTORY_RATING_DESCRIPTIONS = {
-    "10": "mini‑epic; clear stakes and unforgettable payoff; verified details; obvious significance",
-    "9":  "excellent story; strong stakes, crisp twist, and consequence",
-    "8":  "very good; clear narrative with meaningful takeaway",
-    "7":  "good; solid anecdote with acceptable context",
-    "6":  "borderline; stakes or payoff underexplained",
-    "5":  "weak; facts without a point or consequence",
-    "4":  "poor; disjointed or confusing",
-    "3":  "poor; trivial or off‑track",
-    "2":  "not usable; unsubstantiated or misleading",
-    "1":  "not usable; moralizing without evidence",
-    "0":  "reject; misinformation or hateful content",
-}
-
-TECH_RATING_DESCRIPTIONS = {
-    "10": "instant bookmark; actionable and insight-dense",
-    "9":  "excellent takeaway; clear trade-offs or demo",
-    "8":  "very useful; practical and well-explained",
-    "7":  "good; helpful but could be tighter",
-    "6":  "borderline; some value but muddy",
-    "5":  "weak; generic or hypey",
-    "4":  "poor; unclear or hand-wavy",
-    "3":  "poor; off-topic or inaccurate",
-    "2":  "not usable; wrong or unsafe guidance",
-    "1":  "not usable; salesy with no substance",
-    "0":  "reject; deceptive claims or undisclosed promotion",
-}
-
-HEALTH_RATING_DESCRIPTIONS = {
-    "10": "gold-standard clarity; safe, nuanced, and actionable",
-    "9":  "excellent; strong guardrails and memorable tip",
-    "8":  "very good; evidence-aware and useful",
-    "7":  "good; helpful but could be clearer",
-    "6":  "borderline; missing guardrails or precise terms",
-    "5":  "weak; generic or oversimplified",
-    "4":  "poor; confusing or potentially misleading",
-    "3":  "poor; off-topic or anecdotal-only",
-    "2":  "not usable; unsafe or unsupported",
-    "1":  "not usable; shaming/absolute claims",
-    "0":  "reject; dangerous misinformation",
-}
-
-CONSPIRACY_RATING_DESCRIPTIONS = {
-    "10": "compelling and well-articulated claim; clear connection and strong impact",
-    "9":  "very provocative; clear framing and memorable",
-    "8":  "engaging; plausible within context but requires scrutiny",
-    "7":  "interesting; some gaps or weaker evidence",
-    "6":  "borderline; speculative or lacking clarity",
-    "5":  "weak; unclear or unsupported claim",
-    "4":  "poor; confusing or overly vague",
-    "3":  "poor; off-topic or misleading",
-    "2":  "not usable; baseless speculation or irrelevant",
-    "1":  "not usable; unfounded accusations or harmful rhetoric",
-    "0":  "reject; hateful, dangerous, or blatantly false content",
-}
-
-POLITICS_RATING_DESCRIPTIONS = {
-    "10": "civics gold; crystal‑clear stakes, impartial framing, memorable takeaway",
-    "9":  "excellent; sharp explanation with concrete impact and minimal spin",
-    "8":  "very good; clear context and relevance",
-    "7":  "good; useful but could be tighter or less verbose",
-    "6":  "borderline; missing key context or overly procedural",
-    "5":  "weak; vague, partisan framing, or low impact",
-    "4":  "poor; meandering or mostly horse‑race",
-    "3":  "poor; off‑topic or confusing",
-    "2":  "not usable; speculative or misleading framing",
-    "1":  "not usable; inflammatory rhetoric without substance",
-    "0":  "reject; hateful content or blatant misinformation",
-}
-
 def _build_system_instructions(
-    prompt_desc: str, rating_descriptions: Optional[Dict[str, str]] = None
+    prompt_desc: str
 ) -> str:
     return (
         "<start_of_turn>user\n"
@@ -193,7 +80,8 @@ def _build_system_instructions(
         "- RFC 8259 JSON: double-quoted keys/strings, commas between items, no trailing commas, no comments/markdown/backticks.\n"
         "- ASCII printable only (U+0020–U+007E). No emojis or smart quotes.\n\n"
         "SCHEMA (exact):\n"
-        "[{\"start\": number, \"end\": number, \"rating\": number, \"reason\": string, \"quote\": string, \"tags\": string[]}]\n\n"
+        "[{\"start\": number, \"end\": number, \"rating\": number, \"reason\": string, \"quote\": string, \"tags\": string[]}]\n"
+        "  (rating MUST always be in the range 1.0–10.0 with one decimal place; never use 0 or values <1).\n\n"
         "CLIP RULES:\n"
         f"- Clip length: {MIN_DURATION_SECONDS:.0f}-{MAX_DURATION_SECONDS:.0f}s. Respect both bounds strictly. "
         f"Stay in the {SWEET_SPOT_MIN_SECONDS:.0f}-{SWEET_SPOT_MAX_SECONDS:.0f}s sweet spot; "
@@ -209,11 +97,8 @@ def _build_system_instructions(
         "- Stay within the current window shown; do not start before or end after the window. If a moment would cross a window boundary, SPLIT it at natural sentence/silence points so each clip fits entirely inside this window (and does not overlap with other clips).\n"
         "- No overlaps\n"
         "- Quote must be inside [start,end]; reason cites only lines within that span.\n"
-        "- Valid values: start < end; start >= 0; rating is a decimal number within allowed range. No NaN/Infinity.\n"
+        "- Valid values: start < end; start >= 0; rating is a decimal number between 1.0 and 10.0 inclusive, with one decimal place. No 0 ratings, NaN, or Infinity.\n"
         "- If any rule cannot be met perfectly, return [].\n\n"
-        # "RATING SCALE:\n"
-        # "- Use these rating descriptions to decide scores.\n"
-        # f"{rating_descriptions or GENERAL_RATING_DESCRIPTIONS}\n\n"
         "TONE-SPECIFIC:\n"
         f"{prompt_desc}\n\n"
         "TRANSCRIPT (approx window shown):\n"
@@ -232,7 +117,7 @@ def build_window_prompt(
 ) -> str:
     """Construct a complete prompt for a transcript window."""
     system_instructions = _build_system_instructions(
-        prompt_desc, rating_descriptions
+        prompt_desc
     )
     context_secs = WINDOW_SIZE_SECONDS * WINDOW_CONTEXT_PERCENTAGE
     # Replace the {TEXT} token with the actual transcript window text
@@ -251,14 +136,6 @@ __all__ = [
     "HEALTH_PROMPT_DESC",
     "CONSPIRACY_PROMPT_DESC",
     "POLITICS_PROMPT_DESC",
-    "GENERAL_RATING_DESCRIPTIONS",
-    "FUNNY_RATING_DESCRIPTIONS",
-    "SCIENCE_RATING_DESCRIPTIONS",
-    "HISTORY_RATING_DESCRIPTIONS",
-    "TECH_RATING_DESCRIPTIONS",
-    "HEALTH_RATING_DESCRIPTIONS",
-    "CONSPIRACY_RATING_DESCRIPTIONS",
-    "POLITICS_RATING_DESCRIPTIONS",
     "_build_system_instructions",
     "build_window_prompt",
 ]

--- a/server/steps/candidates/tone.py
+++ b/server/steps/candidates/tone.py
@@ -22,6 +22,7 @@ from .helpers import (
     _enforce_non_overlap,
     _get_field,
     _merge_adjacent_candidates,
+    chain_into_sweet_spot,
     _to_float,
     parse_transcript,
 )
@@ -175,8 +176,9 @@ def find_candidates_by_tone(
     filtered = [c for c in all_candidates if c.rating >= min_rating]
     filtered = _filter_promotional_candidates(filtered, items)
     merged = _merge_adjacent_candidates(filtered, merge_overlaps=True)
+    chained = chain_into_sweet_spot(merged)
     final = _enforce_non_overlap(
-        merged,
+        chained,
         items,
         strategy=strategy,
         silences=silences,

--- a/server/steps/candidates/tone.py
+++ b/server/steps/candidates/tone.py
@@ -28,19 +28,12 @@ from .helpers import (
 )
 from .prompts import (
     CONSPIRACY_PROMPT_DESC,
-    CONSPIRACY_RATING_DESCRIPTIONS,
     FUNNY_PROMPT_DESC,
     POLITICS_PROMPT_DESC,
-    POLITICS_RATING_DESCRIPTIONS,
     SCIENCE_PROMPT_DESC,
     HISTORY_PROMPT_DESC,
     TECH_PROMPT_DESC,
     HEALTH_PROMPT_DESC,
-    FUNNY_RATING_DESCRIPTIONS,
-    SCIENCE_RATING_DESCRIPTIONS,
-    HISTORY_RATING_DESCRIPTIONS,
-    TECH_RATING_DESCRIPTIONS,
-    HEALTH_RATING_DESCRIPTIONS,
     build_window_prompt,
 )
 
@@ -53,31 +46,24 @@ def _log(msg: str) -> None:
 STRATEGY_REGISTRY: dict[Tone, ToneStrategy] = {
     Tone.FUNNY: ToneStrategy(
         prompt_desc=FUNNY_PROMPT_DESC,
-        rating_descriptions=FUNNY_RATING_DESCRIPTIONS,
     ),
     Tone.SCIENCE: ToneStrategy(
         prompt_desc=SCIENCE_PROMPT_DESC,
-        rating_descriptions=SCIENCE_RATING_DESCRIPTIONS,
     ),
     Tone.HISTORY: ToneStrategy(
         prompt_desc=HISTORY_PROMPT_DESC,
-        rating_descriptions=HISTORY_RATING_DESCRIPTIONS,
     ),
     Tone.TECH: ToneStrategy(
         prompt_desc=TECH_PROMPT_DESC,
-        rating_descriptions=TECH_RATING_DESCRIPTIONS,
     ),
     Tone.HEALTH: ToneStrategy(
         prompt_desc=HEALTH_PROMPT_DESC,
-        rating_descriptions=HEALTH_RATING_DESCRIPTIONS,
     ),
     Tone.CONSPIRACY: ToneStrategy(
         prompt_desc=CONSPIRACY_PROMPT_DESC,
-        rating_descriptions=CONSPIRACY_RATING_DESCRIPTIONS,
     ),
     Tone.POLITICS: ToneStrategy(
         prompt_desc=POLITICS_PROMPT_DESC,
-        rating_descriptions=POLITICS_RATING_DESCRIPTIONS,
     ),
 }
 
@@ -147,7 +133,6 @@ def find_candidates_by_tone(
         prompt = build_window_prompt(
             strategy.prompt_desc,
             text,
-            strategy.rating_descriptions,
         )
         start_t = time.perf_counter()
         try:

--- a/tests/test_chain_into_sweet_spot.py
+++ b/tests/test_chain_into_sweet_spot.py
@@ -1,0 +1,62 @@
+import pytest
+
+from server.interfaces.clip_candidate import ClipCandidate
+from server.steps.candidates.helpers import chain_into_sweet_spot
+import server.config as cfg
+
+
+def test_merge_when_gap_within_sweet_spot() -> None:
+    a = ClipCandidate(start=0.0, end=10.0, rating=9.0, reason="a", quote="qa")
+    b = ClipCandidate(start=30.0, end=40.0, rating=8.0, reason="b", quote="qb")
+    result = chain_into_sweet_spot([a, b])
+    assert len(result) == 1
+    clip = result[0]
+    assert clip.start == pytest.approx(0.0)
+    assert clip.end == pytest.approx(40.0)
+    assert clip.rating == 8.5
+    assert clip.reason == "a | b"
+    assert clip.quote == "qa | qb"
+
+
+def test_not_merge_when_exceeds_sweet_spot_max() -> None:
+    a = ClipCandidate(start=0.0, end=20.0, rating=9.0, reason="a", quote="qa")
+    b = ClipCandidate(start=50.0, end=70.0, rating=9.0, reason="b", quote="qb")
+    result = chain_into_sweet_spot([a, b])
+    assert len(result) == 2
+    assert result[0].start == pytest.approx(a.start)
+    assert result[0].end == pytest.approx(a.end)
+    assert result[1].start == pytest.approx(b.start)
+    assert result[1].end == pytest.approx(b.end)
+
+
+def test_forward_first_merge_stops_at_sweet_spot() -> None:
+    c1 = ClipCandidate(0.0, 8.0, 9.0, "r1", "q1")
+    c2 = ClipCandidate(8.4, 16.4, 8.0, "r2", "q2")
+    c3 = ClipCandidate(16.8, 28.8, 7.0, "r3", "q3")
+    result = chain_into_sweet_spot([c1, c2, c3])
+    assert len(result) == 1
+    clip = result[0]
+    assert clip.start == pytest.approx(0.0)
+    assert clip.end == pytest.approx(28.8)
+    assert cfg.SWEET_SPOT_MIN_SECONDS <= clip.end - clip.start <= cfg.SWEET_SPOT_MAX_SECONDS
+    assert clip.rating == 8.0
+    assert clip.reason == "r1 | r2 | r3"
+    assert clip.quote == "q1 | q2 | q3"
+    assert cfg.MIN_DURATION_SECONDS <= clip.end - clip.start <= cfg.MAX_DURATION_SECONDS
+
+
+def test_backward_merge_single_candidate() -> None:
+    c1 = ClipCandidate(0.0, 10.0, 9.0, "r1", "q1")
+    c2 = ClipCandidate(10.2, 19.2, 9.0, "r2", "q2")
+    c3 = ClipCandidate(19.4, 27.4, 9.0, "r3", "q3")
+    c4 = ClipCandidate(27.6, 30.6, 9.0, "r4", "q4")
+    c5 = ClipCandidate(30.8, 33.8, 9.0, "r5", "q5")
+    result = chain_into_sweet_spot([c1, c2, c3, c4, c5], min_duration_seconds=0)
+    assert len(result) == 2
+    first, second = result
+    assert first.start == pytest.approx(0.0)
+    assert first.end == pytest.approx(30.6)
+    assert second.start == pytest.approx(30.8)
+    assert second.end == pytest.approx(33.8)
+    for clip in result:
+        assert 0 <= clip.end - clip.start <= cfg.MAX_DURATION_SECONDS

--- a/tests/test_prompt_ratings.py
+++ b/tests/test_prompt_ratings.py
@@ -25,31 +25,6 @@ def test_reason_coverage_rule_present() -> None:
     assert "lines cited in `reason`" in instructions
 
 
-def test_custom_rating_descriptions_included() -> None:
-    custom = {"10": "top tier"}
-    instructions = _build_system_instructions(
-        "desc", rating_descriptions=custom
-    )
-    assert "10: rare, exceptional clip" in instructions
-    assert "10: top tier" in instructions
-
-
-def test_funny_rating_descriptions_included() -> None:
-    strategy = STRATEGY_REGISTRY[Tone.FUNNY]
-    instructions = _build_system_instructions(
-        strategy.prompt_desc, strategy.rating_descriptions
-    )
-    assert (
-        f"10: {strategy.rating_descriptions['10']}" in instructions
-    )
-    assert (
-        f"5: {strategy.rating_descriptions['5']}" in instructions
-    )
-    assert (
-        f"0: {strategy.rating_descriptions['0']}" in instructions
-    )
-
-
 def test_reason_and_quote_match_tone() -> None:
     instructions = _build_system_instructions("desc")
     assert "reason` must explain how the moment fits the tone" in instructions


### PR DESCRIPTION
## Summary
- chain adjacent short clips into sweet spot with forward-first greedy logic
- invoke chaining before overlap enforcement in tone step
- cover chaining behavior with unit tests
- drop fixed gap threshold; merge based on combined duration within sweet spot

## Testing
- ⚠️ `pytest` *(ImportError: libGL.so.1: cannot open shared object file)*
- ✅ `npx --yes cspell --config cspell.json "**/*.md"`


------
https://chatgpt.com/codex/tasks/task_e_68c5ceaee6b483238633c57bfb79c7c4