### PR TITLE
Add selectable render layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ now inferred from this folder structure and the matching tokens are loaded from
   options) now live at the bottom of `server/config.py` and are deprecated.
 - Candidate overlap enforcement can be toggled with `ENFORCE_NON_OVERLAP` in
   `server/config.py`.
+- The render layout for generated shorts can be selected via `RENDER_LAYOUT` in
+  `server/config.py`. Available options are `centered`, `no_zoom`, and
+  `left_aligned`.
 
 ## Git Reversion
 

--- a/server/config.py
+++ b/server/config.py
@@ -29,6 +29,9 @@ CAPTION_OUTLINE_BGR = (236, 236, 236)  # hex ececec
 # Constant frame-rate to avoid VFR issues on platforms like TikTok/Reels
 OUTPUT_FPS: float = 30.0
 
+# Name of the render layout to use. Options: "centered", "no_zoom", "left_aligned"
+RENDER_LAYOUT = os.environ.get("RENDER_LAYOUT", "centered")
+
 # Clip boundary snapping options
 SNAP_TO_SILENCE = False
 SNAP_TO_DIALOG = True

--- a/server/config.py
+++ b/server/config.py
@@ -30,7 +30,7 @@ CAPTION_OUTLINE_BGR = (236, 236, 236)  # hex ececec
 OUTPUT_FPS: float = 30.0
 
 # Name of the render layout to use. Options: "centered", "no_zoom", "left_aligned"
-RENDER_LAYOUT = os.environ.get("RENDER_LAYOUT", "centered")
+RENDER_LAYOUT = os.environ.get("RENDER_LAYOUT", "left_aligned")
 
 # Clip boundary snapping options
 SNAP_TO_SILENCE = False

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -29,6 +29,7 @@ from steps.segment import (
 from steps.cut import save_clip_from_candidate
 from steps.subtitle import build_srt_for_range
 from steps.render import render_vertical_with_captions
+from steps.render_layouts import get_layout
 from steps.silence import (
     detect_silences,
     write_silences_json,
@@ -54,6 +55,7 @@ from config import (
     USE_LLM_FOR_SEGMENTS,
     CLEANUP_NON_SHORTS,
     START_AT_STEP,
+    RENDER_LAYOUT,
 )
 
 import sys
@@ -549,6 +551,7 @@ def process_video(yt_url: str, account: str | None = None, tone: Tone | None = N
                 clip_path,
                 srt_path,
                 vertical_output,
+                layout=get_layout(RENDER_LAYOUT),
             )
 
         if should_run(8):

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -633,14 +633,14 @@ def process_video(yt_url: str, account: str | None = None, tone: Tone | None = N
 
 
 if __name__ == "__main__":
-    # tone = Tone.FUNNY 
-    # account = "funnykinda"
-    # # In Review Playlist (newest first)
-    # # yt_url = "https://www.youtube.com/playlist?list=PLy3mMHt2i7RKE9ba8rfL7_qnFcpbUaA8_"
-    # # KFAF Playlist(newest first)
-    # # last used [10:12]
-    # # nick yelling barrett like kevin did is index 8
-    # yt_url = "https://www.youtube.com/playlist?list=PLOlEpGVXWUVurPHlIotFyz-cIOXjV_cxx"
+    tone = Tone.FUNNY 
+    account = "funnykinda"
+    # In Review Playlist (newest first)
+    # yt_url = "https://www.youtube.com/playlist?list=PLy3mMHt2i7RKE9ba8rfL7_qnFcpbUaA8_"
+    # KFAF Playlist(newest first)
+    # last used [0:10]
+    # nick yelling barrett like kevin did is index 8
+    yt_url = "https://www.youtube.com/playlist?list=PLOlEpGVXWUVurPHlIotFyz-cIOXjV_cxx"
 
     
     # tone = Tone.HISTORY
@@ -651,12 +651,12 @@ if __name__ == "__main__":
     # # last used [3:5]
     # yt_url = "https://www.youtube.com/playlist?list=PL_gGGlaAre787Q8Wx6sCF5m9podjPcqfx"
     
-    tone = Tone.SCIENCE
-    account = "cosmos"
-    # Melodysheep: Life Beyond
-    # yt_url = "https://www.youtube.com/watch?v=dww8Hekngmg"
-    # Melodysheep: Water Worlds
-    yt_url = "https://www.youtube.com/watch?v=URyiCGZNjdI"
+    # tone = Tone.SCIENCE
+    # account = "cosmos"
+    # # Melodysheep: Life Beyond
+    # # yt_url = "https://www.youtube.com/watch?v=dww8Hekngmg"
+    # # Melodysheep: Water Worlds
+    # yt_url = "https://www.youtube.com/watch?v=URyiCGZNjdI"
     
     
     # tone = Tone.HEALTH
@@ -670,7 +670,8 @@ if __name__ == "__main__":
     # # last used [2:5]
     # yt_url = "https://www.youtube.com/playlist?list=PL8PPtxxTQjQu7fznaPSkk-WosHgPs5y4Z"
 
+
     urls = get_video_urls(yt_url)
-    # urls.reverse() # If the playlist is newest first, reverse to process oldest first
-    for url in urls[:]:
+    urls.reverse() # If the playlist is newest first, reverse to process oldest first
+    for url in urls[10:20]:
         process_video(url, account=account, tone=tone)

--- a/server/steps/render_layouts/__init__.py
+++ b/server/steps/render_layouts/__init__.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .base import RenderLayout
+from .centered_zoom import CenteredZoomLayout
+from .no_zoom import NoZoomLayout
+from .left_aligned_zoom import LeftAlignedZoomLayout
+
+__all__ = [
+    "RenderLayout",
+    "CenteredZoomLayout",
+    "NoZoomLayout",
+    "LeftAlignedZoomLayout",
+    "get_layout",
+]
+
+
+_LAYOUTS: Dict[str, RenderLayout] = {
+    "centered": CenteredZoomLayout(),
+    "no_zoom": NoZoomLayout(),
+    "left_aligned": LeftAlignedZoomLayout(),
+}
+
+
+def get_layout(name: str) -> RenderLayout:
+    """Return a render layout by name.
+
+    Falls back to the centered layout when the name is unknown.
+    """
+    return _LAYOUTS.get(name, _LAYOUTS["centered"])

--- a/server/steps/render_layouts/base.py
+++ b/server/steps/render_layouts/base.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class RenderLayout(ABC):
+    """Strategy for scaling and positioning the foreground clip."""
+
+    @abstractmethod
+    def scale_factor(
+        self,
+        width: int,
+        height: int,
+        frame_width: int,
+        frame_height: int,
+        fg_height_ratio: float,
+    ) -> float:
+        """Return scaling factor for the foreground clip."""
+
+    @abstractmethod
+    def x_position(self, fg_width: int, frame_width: int) -> int:
+        """Return the X coordinate where the foreground should be placed."""

--- a/server/steps/render_layouts/centered_zoom.py
+++ b/server/steps/render_layouts/centered_zoom.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from .base import RenderLayout
+
+
+class CenteredZoomLayout(RenderLayout):
+    """Default layout: zoom to a fraction of frame height and center."""
+
+    def scale_factor(
+        self,
+        width: int,
+        height: int,
+        frame_width: int,
+        frame_height: int,
+        fg_height_ratio: float,
+    ) -> float:
+        fg_target_h = max(100, int(frame_height * fg_height_ratio))
+        return fg_target_h / height
+
+    def x_position(self, fg_width: int, frame_width: int) -> int:
+        return (frame_width - fg_width) // 2

--- a/server/steps/render_layouts/left_aligned_zoom.py
+++ b/server/steps/render_layouts/left_aligned_zoom.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .centered_zoom import CenteredZoomLayout
+
+
+class LeftAlignedZoomLayout(CenteredZoomLayout):
+    """Like the default layout but aligned to the left edge."""
+
+    def x_position(self, fg_width: int, frame_width: int) -> int:
+        return 0

--- a/server/steps/render_layouts/no_zoom.py
+++ b/server/steps/render_layouts/no_zoom.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from .base import RenderLayout
+
+
+class NoZoomLayout(RenderLayout):
+    """Layout that preserves the original clip size."""
+
+    def scale_factor(
+        self,
+        width: int,
+        height: int,
+        frame_width: int,
+        frame_height: int,
+        fg_height_ratio: float,
+    ) -> float:
+        # Do not upscale; scale down only if clip exceeds frame
+        return min(1.0, frame_width / width, frame_height / height)
+
+    def x_position(self, fg_width: int, frame_width: int) -> int:
+        # Center the clip horizontally
+        return (frame_width - fg_width) // 2

--- a/tests/test_render_layouts.py
+++ b/tests/test_render_layouts.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "server"))
+
+from server.steps.render_layouts import (
+    CenteredZoomLayout,
+    NoZoomLayout,
+    LeftAlignedZoomLayout,
+)
+
+
+def test_no_zoom_scales_down() -> None:
+    layout = NoZoomLayout()
+    scale = layout.scale_factor(200, 100, 100, 200, 0.5)
+    assert abs(scale - 0.5) < 1e-6
+
+
+def test_left_aligned_position() -> None:
+    layout = LeftAlignedZoomLayout()
+    scale = layout.scale_factor(100, 100, 200, 400, 0.5)
+    fg_width = int(100 * scale)
+    assert layout.x_position(fg_width, 200) == 0
+
+
+def test_centered_position() -> None:
+    layout = CenteredZoomLayout()
+    scale = layout.scale_factor(100, 100, 300, 400, 0.5)
+    fg_width = int(100 * scale)
+    assert layout.x_position(fg_width, 300) == 50


### PR DESCRIPTION
## Summary
- add layout strategy classes for rendering: centered, no zoom, and left-aligned
- allow choosing layout via `RENDER_LAYOUT` config and pipeline
- document render layout options and add unit tests

## Testing
- `npx -y cspell --config cspell.json "**/*.md"`
- `pytest` *(fails: KeyError Tone.FUNNY, FileNotFoundError: ffmpeg)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fbb11f688323b2e700a83c904f85