### PR TITLE
Add centered-with-corners render layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ now inferred from this folder structure and the matching tokens are loaded from
 - Candidate overlap enforcement can be toggled with `ENFORCE_NON_OVERLAP` in
   `server/config.py`.
 - The render layout for generated shorts can be selected via `RENDER_LAYOUT` in
-  `server/config.py`. Available options are `centered`, `no_zoom`, and
-  `left_aligned`.
+  `server/config.py`. Available options are `centered`, `centered_with_corners`,
+  `no_zoom`, and `left_aligned`.
 
 ## Git Reversion
 

--- a/server/config.py
+++ b/server/config.py
@@ -29,7 +29,7 @@ CAPTION_OUTLINE_BGR = (236, 236, 236)  # hex ececec
 # Constant frame-rate to avoid VFR issues on platforms like TikTok/Reels
 OUTPUT_FPS: float = 30.0
 
-# Name of the render layout to use. Options: "centered", "no_zoom", "left_aligned"
+# Name of the render layout to use. Options: "centered", "centered_with_corners", "no_zoom", "left_aligned"
 RENDER_LAYOUT = os.environ.get("RENDER_LAYOUT", "left_aligned")
 
 # Clip boundary snapping options

--- a/server/steps/render.py
+++ b/server/steps/render.py
@@ -404,6 +404,9 @@ def render_vertical_with_captions(
             src_x2 = src_x1 + (x2 - x1); src_y2 = src_y1 + (y2 - y1)
             canvas[y1:y2, x1:x2] = fg[src_y1:src_y2, src_x1:src_x2]
 
+        # Allow layout to augment the composed frame (e.g., corner crops)
+        canvas = layout.augment_canvas(canvas, frame)
+
         # --- Captions under FG, wrapped, centered, with outline ---
         if current_text:
             fs = font_scale

--- a/server/steps/render_layouts/__init__.py
+++ b/server/steps/render_layouts/__init__.py
@@ -4,12 +4,14 @@ from typing import Dict
 
 from .base import RenderLayout
 from .centered_zoom import CenteredZoomLayout
+from .centered_with_corners import CenteredWithCornersLayout
 from .no_zoom import NoZoomLayout
 from .left_aligned_zoom import LeftAlignedZoomLayout
 
 __all__ = [
     "RenderLayout",
     "CenteredZoomLayout",
+    "CenteredWithCornersLayout",
     "NoZoomLayout",
     "LeftAlignedZoomLayout",
     "get_layout",
@@ -18,6 +20,7 @@ __all__ = [
 
 _LAYOUTS: Dict[str, RenderLayout] = {
     "centered": CenteredZoomLayout(),
+    "centered_with_corners": CenteredWithCornersLayout(),
     "no_zoom": NoZoomLayout(),
     "left_aligned": LeftAlignedZoomLayout(),
 }

--- a/server/steps/render_layouts/base.py
+++ b/server/steps/render_layouts/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+import numpy as np
 
 
 class RenderLayout(ABC):
@@ -20,3 +21,11 @@ class RenderLayout(ABC):
     @abstractmethod
     def x_position(self, fg_width: int, frame_width: int) -> int:
         """Return the X coordinate where the foreground should be placed."""
+
+    def augment_canvas(self, canvas: np.ndarray, frame: np.ndarray) -> np.ndarray:
+        """Allow layouts to add extra elements onto the composed frame.
+
+        By default this is a no-op and returns the canvas unchanged.
+        Subclasses may override to draw additional crops or overlays.
+        """
+        return canvas

--- a/server/steps/render_layouts/centered_with_corners.py
+++ b/server/steps/render_layouts/centered_with_corners.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from .centered_zoom import CenteredZoomLayout
+
+
+class CenteredWithCornersLayout(CenteredZoomLayout):
+    """Centered layout that also shows bottom corners above the main clip."""
+
+    def __init__(
+        self,
+        crop_ratio: float = 0.25,
+        target_width_ratio: float = 0.45,
+        margin_ratio: float = 0.02,
+    ) -> None:
+        self.crop_ratio = crop_ratio
+        self.target_width_ratio = target_width_ratio
+        self.margin_ratio = margin_ratio
+
+    def augment_canvas(self, canvas: np.ndarray, frame: np.ndarray) -> np.ndarray:
+        h, w = frame.shape[:2]
+        crop_w = int(w * self.crop_ratio)
+        crop_h = int(h * self.crop_ratio)
+        if crop_w == 0 or crop_h == 0:
+            return canvas
+
+        bottom_left = frame[h - crop_h : h, 0:crop_w]
+        bottom_right = frame[h - crop_h : h, w - crop_w : w]
+
+        target_w = int(canvas.shape[1] * self.target_width_ratio)
+        if target_w == 0:
+            return canvas
+        scale = target_w / crop_w
+        target_h = int(crop_h * scale)
+
+        bl_resized = cv2.resize(bottom_left, (target_w, target_h))
+        br_resized = cv2.resize(bottom_right, (target_w, target_h))
+
+        margin = int(canvas.shape[1] * self.margin_ratio)
+        y = margin
+        left_x = margin
+        right_x = canvas.shape[1] - target_w - margin
+
+        canvas[y : y + target_h, left_x : left_x + target_w] = bl_resized
+        canvas[y : y + target_h, right_x : right_x + target_w] = br_resized
+        return canvas


### PR DESCRIPTION
## Summary
- add `CenteredWithCornersLayout` to render bottom corner insets above main video
- allow layouts to augment canvas before captions
- document new `centered_with_corners` render option

## Testing
- `pytest` *(fails: KeyError <Tone.FUNNY>, assertion errors, see log)*
- `npx cspell --no-progress --config cspell.json "**/*.md"`


------
https://chatgpt.com/codex/tasks/task_e_68c6062ed4b8832380069b3b8a7425fc