### PR TITLE
Add centered-with-corners render layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ now inferred from this folder structure and the matching tokens are loaded from
 - Candidate overlap enforcement can be toggled with `ENFORCE_NON_OVERLAP` in
   `server/config.py`.
 - The render layout for generated shorts can be selected via `RENDER_LAYOUT` in
-  `server/config.py`. Available options are `centered`, `no_zoom`, and
-  `left_aligned`.
+  `server/config.py`. Available options are `centered`, `centered_with_corners`,
+  `no_zoom`, and `left_aligned`.
+- The `centered_with_corners` layout crops the source video’s bottom corners and
+  centers them above the main clip.
 
 ## Git Reversion
 

--- a/server/config.py
+++ b/server/config.py
@@ -29,7 +29,7 @@ CAPTION_OUTLINE_BGR = (236, 236, 236)  # hex ececec
 # Constant frame-rate to avoid VFR issues on platforms like TikTok/Reels
 OUTPUT_FPS: float = 30.0
 
-# Name of the render layout to use. Options: "centered", "no_zoom", "left_aligned"
+# Name of the render layout to use. Options: "centered", "centered_with_corners", "no_zoom", "left_aligned"
 RENDER_LAYOUT = os.environ.get("RENDER_LAYOUT", "left_aligned")
 
 # Clip boundary snapping options

--- a/server/steps/render.py
+++ b/server/steps/render.py
@@ -404,6 +404,9 @@ def render_vertical_with_captions(
             src_x2 = src_x1 + (x2 - x1); src_y2 = src_y1 + (y2 - y1)
             canvas[y1:y2, x1:x2] = fg[src_y1:src_y2, src_x1:src_x2]
 
+        # Allow layout to augment the composed frame (e.g., corner crops)
+        canvas = layout.augment_canvas(canvas, frame, (x_fg, y_fg, fg_w, fg_h))
+
         # --- Captions under FG, wrapped, centered, with outline ---
         if current_text:
             fs = font_scale

--- a/server/steps/render_layouts/__init__.py
+++ b/server/steps/render_layouts/__init__.py
@@ -4,12 +4,14 @@ from typing import Dict
 
 from .base import RenderLayout
 from .centered_zoom import CenteredZoomLayout
+from .centered_with_corners import CenteredWithCornersLayout
 from .no_zoom import NoZoomLayout
 from .left_aligned_zoom import LeftAlignedZoomLayout
 
 __all__ = [
     "RenderLayout",
     "CenteredZoomLayout",
+    "CenteredWithCornersLayout",
     "NoZoomLayout",
     "LeftAlignedZoomLayout",
     "get_layout",
@@ -18,6 +20,7 @@ __all__ = [
 
 _LAYOUTS: Dict[str, RenderLayout] = {
     "centered": CenteredZoomLayout(),
+    "centered_with_corners": CenteredWithCornersLayout(),
     "no_zoom": NoZoomLayout(),
     "left_aligned": LeftAlignedZoomLayout(),
 }

--- a/server/steps/render_layouts/base.py
+++ b/server/steps/render_layouts/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+import numpy as np
 
 
 class RenderLayout(ABC):
@@ -20,3 +21,22 @@ class RenderLayout(ABC):
     @abstractmethod
     def x_position(self, fg_width: int, frame_width: int) -> int:
         """Return the X coordinate where the foreground should be placed."""
+
+    def augment_canvas(
+        self,
+        canvas: np.ndarray,
+        frame: np.ndarray,
+        fg_box: tuple[int, int, int, int] | None = None,
+    ) -> np.ndarray:
+        """Allow layouts to add extra elements onto the composed frame.
+
+        Args:
+            canvas: The output frame with the foreground already placed.
+            frame: The original source frame.
+            fg_box: Optional ``(x, y, width, height)`` of the foreground clip on
+                the canvas. ``None`` if the foreground is not yet positioned.
+
+        By default this is a no-op and returns the canvas unchanged.
+        Subclasses may override to draw additional crops or overlays.
+        """
+        return canvas

--- a/server/steps/render_layouts/centered_with_corners.py
+++ b/server/steps/render_layouts/centered_with_corners.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from .centered_zoom import CenteredZoomLayout
+
+
+class CenteredWithCornersLayout(CenteredZoomLayout):
+    """Centered layout that also shows enlarged bottom corners above the clip."""
+
+    def __init__(
+        self,
+        crop_ratio: float = 0.4,
+        target_width_ratio: float = 0.5,
+        margin_ratio: float = 0.02,
+    ) -> None:
+        self.crop_ratio = crop_ratio
+        self.target_width_ratio = target_width_ratio
+        self.margin_ratio = margin_ratio
+
+    def augment_canvas(
+        self,
+        canvas: np.ndarray,
+        frame: np.ndarray,
+        fg_box: tuple[int, int, int, int] | None = None,
+    ) -> np.ndarray:
+        h, w = frame.shape[:2]
+        crop_w = int(w * self.crop_ratio)
+        crop_h = int(h * self.crop_ratio)
+        if crop_w == 0 or crop_h == 0:
+            return canvas
+
+        bottom_left = frame[h - crop_h : h, 0:crop_w]
+        bottom_right = frame[h - crop_h : h, w - crop_w : w]
+
+        target_w = int(canvas.shape[1] * self.target_width_ratio)
+        if target_w == 0:
+            return canvas
+        scale = target_w / crop_w
+        target_h = int(crop_h * scale)
+
+        bl_resized = cv2.resize(bottom_left, (target_w, target_h))
+        br_resized = cv2.resize(bottom_right, (target_w, target_h))
+
+        margin = int(canvas.shape[1] * self.margin_ratio)
+
+        if fg_box:
+            fg_top = fg_box[1]
+            y_center = fg_top / 2
+            y = int(y_center - target_h / 2)
+            y = max(margin, min(y, fg_top - target_h - margin))
+        else:
+            y = margin
+
+        left_x = margin
+        right_x = canvas.shape[1] - target_w - margin
+
+        canvas[y : y + target_h, left_x : left_x + target_w] = bl_resized
+        canvas[y : y + target_h, right_x : right_x + target_w] = br_resized
+        return canvas

--- a/tests/test_render_layouts.py
+++ b/tests/test_render_layouts.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import sys
+import numpy as np
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -7,6 +8,7 @@ sys.path.insert(0, str(ROOT / "server"))
 
 from server.steps.render_layouts import (
     CenteredZoomLayout,
+    CenteredWithCornersLayout,
     NoZoomLayout,
     LeftAlignedZoomLayout,
 )
@@ -30,3 +32,31 @@ def test_centered_position() -> None:
     scale = layout.scale_factor(100, 100, 300, 400, 0.5)
     fg_width = int(100 * scale)
     assert layout.x_position(fg_width, 300) == 50
+
+
+def test_corners_overlay() -> None:
+    layout = CenteredWithCornersLayout()
+    frame = np.zeros((100, 200, 3), dtype=np.uint8)
+    bl_color = (255, 0, 0)
+    br_color = (0, 255, 0)
+    crop_w = int(200 * layout.crop_ratio)
+    crop_h = int(100 * layout.crop_ratio)
+    frame[-crop_h:, :crop_w] = bl_color
+    frame[-crop_h:, -crop_w:] = br_color
+    canvas = np.zeros((200, 100, 3), dtype=np.uint8)
+    fg_top = 100
+    out = layout.augment_canvas(canvas, frame, (0, fg_top, 0, 0))
+    margin = int(100 * layout.margin_ratio)
+    target_w = int(100 * layout.target_width_ratio)
+    scale = target_w / crop_w
+    target_h = int(crop_h * scale)
+    expected_y_center = fg_top / 2
+    expected_y = int(expected_y_center - target_h / 2)
+    expected_y = max(margin, min(expected_y, fg_top - target_h - margin))
+    left_px = out[expected_y + target_h // 2, margin + target_w // 2]
+    right_px = out[
+        expected_y + target_h // 2,
+        100 - target_w - margin + target_w // 2,
+    ]
+    assert np.array_equal(left_px, bl_color)
+    assert np.array_equal(right_px, br_color)


### PR DESCRIPTION
## Summary
- center bottom-corner crops above the main video and enlarge capture area
- pass foreground bounds into layout augmentation
- document and test centered corner overlays

## Testing
- `pytest -q` *(fails: KeyError <Tone.FUNNY>, assertion errors)*
- `npx cspell --no-progress --config cspell.json "**/*.md"`


------
https://chatgpt.com/codex/tasks/task_e_68c6062ed4b8832380069b3b8a7425fc