### PR TITLE
Add helper to report video inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ per platform.
 To view logs after upping with -d
 `docker compose logs -f uploader`
 
+## Video Inventory
+
+Check how many prepared videos are available for each account and the number of
+days they will last given the current cron schedule:
+
+```bash
+python server/video_inventory.py
+```
+
 ### Multiple Accounts
 
 Place projects for different upload accounts under `out/<account>/<project>`.

--- a/server/video_inventory.py
+++ b/server/video_inventory.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Report ready videos and days of content per account."""
+
+from pathlib import Path
+import os
+
+from schedule_upload import get_out_root, list_accounts
+
+CRON_FILE = Path(__file__).resolve().parent.parent / "docker" / "cron"
+
+
+def uploads_per_day(cron_path: Path | None = None) -> int:
+    """Return the number of uploads scheduled per day.
+
+    The count is derived from the hour field of lines in ``cron_path`` that
+    execute ``schedule_upload.py``. Environment variable lines and comments are
+    ignored.
+    """
+
+    cron_path = cron_path or CRON_FILE
+    if not cron_path.exists():
+        return 0
+    uploads = 0
+    for line in cron_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" in line:
+            continue
+        if "schedule_upload.py" not in line:
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        hours_field = parts[1]
+        uploads += len([h for h in hours_field.split(",") if h])
+    return uploads
+
+
+def count_videos(account: str | None = None, base: Path | None = None) -> int:
+    """Count ready videos for ``account`` under ``base``.
+
+    A video is considered ready when an ``.mp4`` file has a matching ``.txt``
+    description in a ``shorts`` subdirectory.
+    """
+
+    base = base or get_out_root()
+    out_dir = base / account if account else base
+    if not out_dir.exists():
+        return 0
+    count = 0
+    for project in out_dir.iterdir():
+        shorts = project / "shorts"
+        if not shorts.is_dir():
+            continue
+        for video in shorts.glob("*.mp4"):
+            if video.with_suffix(".txt").exists():
+                count += 1
+    return count
+
+
+def main() -> None:
+    """Print the number of ready videos and days of content per account."""
+
+    uploads = uploads_per_day()
+    if uploads == 0:
+        print("No uploads scheduled.")
+        return
+
+    base = get_out_root()
+    accounts = list_accounts(base)
+    for account in accounts:
+        name = account if account is not None else "(default)"
+        videos = count_videos(account, base)
+        days = videos / uploads
+        print(f"{name}: {videos} videos, {days:.2f} days")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_video_inventory.py
+++ b/tests/test_video_inventory.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import server.video_inventory as inventory
+
+
+def test_uploads_per_day(tmp_path: Path) -> None:
+    cron = tmp_path / "cron"
+    cron.write_text(
+        "SHELL=/bin/sh\n0 1,7,12,20 * * * root cd /app/server && /usr/bin/python schedule_upload.py\n"
+    )
+    assert inventory.uploads_per_day(cron) == 4
+
+
+def test_count_videos(tmp_path: Path, monkeypatch) -> None:
+    out = tmp_path / "out"
+    default_short = out / "proj" / "shorts"
+    default_short.mkdir(parents=True)
+    (default_short / "a.mp4").write_bytes(b"a")
+    (default_short / "a.txt").write_text("desc")
+
+    alt_short = out / "alt" / "proj" / "shorts"
+    alt_short.mkdir(parents=True)
+    (alt_short / "b.mp4").write_bytes(b"b")
+    (alt_short / "b.txt").write_text("desc")
+
+    monkeypatch.setenv("OUT_ROOT", str(out))
+    assert inventory.count_videos() == 1
+    assert inventory.count_videos("alt") == 1
+
+
+def test_main_reports_days(tmp_path: Path, monkeypatch, capsys) -> None:
+    out = tmp_path / "out" / "proj" / "shorts"
+    out.mkdir(parents=True)
+    (out / "a.mp4").write_bytes(b"a")
+    (out / "a.txt").write_text("desc")
+
+    monkeypatch.setenv("OUT_ROOT", str(tmp_path / "out"))
+    monkeypatch.setattr(inventory, "uploads_per_day", lambda *a, **k: 2)
+
+    inventory.main()
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ["(default): 1 videos, 0.50 days"]


### PR DESCRIPTION
## Summary
- add `video_inventory.py` to count ready videos per account and estimate days of uploads based on cron schedule
- document inventory script in README
- cover inventory helper with tests

## Testing
- `npx cspell --config cspell.json "**/*.md"` *(fails: Unsupported NodeJS version (18.19.1); >=20 is required)*
- `pytest` *(fails: 21 failed, 92 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c70137a42883239be7771d9a0dfe01