### PR TITLE
Rename frontend to Atropos and type components

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,6 +1,6 @@
-# desktop
+# Atropos
 
-An Electron application with React and TypeScript
+Atropos is an Electron application with React and TypeScript.
 
 ## Recommended IDE Setup
 

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -1,5 +1,5 @@
-appId: com.electron.app
-productName: desktop
+appId: com.atropos.app
+productName: Atropos
 directories:
   buildResources: build
 files:
@@ -12,7 +12,7 @@ files:
 asarUnpack:
   - resources/**
 win:
-  executableName: desktop
+  executableName: atropos
 nsis:
   artifactName: ${name}-${version}-setup.${ext}
   shortcutName: ${productName}

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "desktop",
+  "name": "atropos",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "desktop",
+      "name": "atropos",
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "desktop",
+  "name": "atropos",
   "version": "1.0.0",
-  "description": "An Electron application with React and TypeScript",
+  "description": "Atropos – an Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",
   "homepage": "https://electron-vite.org",

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -10,6 +10,7 @@ function createWindow(): void {
     height: 670,
     show: false,
     autoHideMenuBar: true,
+    title: 'Atropos',
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
@@ -40,7 +41,8 @@ function createWindow(): void {
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(() => {
   // Set app user model id for windows
-  electronApp.setAppUserModelId('com.electron')
+  app.setName('Atropos')
+  electronApp.setAppUserModelId('com.atropos.app')
 
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.

--- a/desktop/src/renderer/index.html
+++ b/desktop/src/renderer/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Electron</title>
+    <title>Atropos</title>
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -1,20 +1,16 @@
-import { RefObject, useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import type { FC, RefObject } from 'react'
 import { Route, Routes } from 'react-router-dom'
 import Search from './components/Search'
 import ClipPage from './pages/Clip'
 import Home from './pages/Home'
-
-type SearchBridge = {
-  getQuery: () => string
-  onQueryChange: (value: string) => void
-  clear: () => void
-}
+import type { SearchBridge } from './types'
 
 type AppProps = {
   searchInputRef: RefObject<HTMLInputElement | null>
 }
 
-const App = ({ searchInputRef }: AppProps) => {
+const App: FC<AppProps> = ({ searchInputRef }) => {
   const [searchBridge, setSearchBridge] = useState<SearchBridge | null>(null)
   const [searchValue, setSearchValue] = useState('')
   const [isDark, setIsDark] = useState(() => {
@@ -33,6 +29,7 @@ const App = ({ searchInputRef }: AppProps) => {
       root.classList.add('dark')
     }
     setIsDark(root.classList.contains('dark'))
+    document.title = 'Atropos'
   }, [])
 
   const registerSearch = useCallback((bridge: SearchBridge | null) => {
@@ -67,7 +64,7 @@ const App = ({ searchInputRef }: AppProps) => {
       <header className="border-b border-white/10 bg-[color:color-mix(in_srgb,var(--card)_40%,transparent)]">
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 px-4 py-4">
           <div className="flex items-center justify-between gap-3">
-            <h1 className="text-2xl font-semibold tracking-tight">Clipit</h1>
+            <h1 className="text-2xl font-semibold tracking-tight">Atropos</h1>
             <button
               type="button"
               onClick={toggleTheme}

--- a/desktop/src/renderer/src/components/ClipCard.tsx
+++ b/desktop/src/renderer/src/components/ClipCard.tsx
@@ -1,5 +1,6 @@
-import { KeyboardEvent, memo } from 'react'
-import { Clip } from '../types'
+import { memo } from 'react'
+import type { FC, KeyboardEvent as ReactKeyboardEvent } from 'react'
+import type { Clip } from '../types'
 import { formatDuration, formatViews, timeAgo } from '../lib/format'
 
 type ClipCardProps = {
@@ -7,8 +8,8 @@ type ClipCardProps = {
   onClick: () => void
 }
 
-const ClipCard = ({ clip, onClick }: ClipCardProps) => {
-  const handleKeyDown = (event: KeyboardEvent<HTMLElement>): void => {
+const ClipCard: FC<ClipCardProps> = ({ clip, onClick }) => {
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>): void => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       onClick()

--- a/desktop/src/renderer/src/components/Versions.tsx
+++ b/desktop/src/renderer/src/components/Versions.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
+import type { FC } from 'react'
 
-function Versions(): React.JSX.Element {
+const Versions: FC = () => {
   const [versions] = useState(window.electron.process.versions)
 
   return (

--- a/desktop/src/renderer/src/main.tsx
+++ b/desktop/src/renderer/src/main.tsx
@@ -1,11 +1,12 @@
 import './index.css'
 
 import { StrictMode, useEffect, useRef } from 'react'
+import type { FC } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 
-const RootApp = () => {
+const RootApp: FC = () => {
   const searchRef = useRef<HTMLInputElement | null>(null)
 
   useEffect(() => {

--- a/desktop/src/renderer/src/pages/Clip.tsx
+++ b/desktop/src/renderer/src/pages/Clip.tsx
@@ -1,19 +1,15 @@
 import { useEffect, useMemo } from 'react'
+import type { FC } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { formatDuration, formatViews, timeAgo } from '../lib/format'
 import { CLIPS } from '../mock/clips'
-
-type SearchBridge = {
-  getQuery: () => string
-  onQueryChange: (value: string) => void
-  clear: () => void
-}
+import type { SearchBridge } from '../types'
 
 type ClipPageProps = {
   registerSearch: (bridge: SearchBridge | null) => void
 }
 
-const ClipPage = ({ registerSearch }: ClipPageProps) => {
+const ClipPage: FC<ClipPageProps> = ({ registerSearch }) => {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
 

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -1,21 +1,17 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { FC } from 'react'
 import { useNavigate } from 'react-router-dom'
 import ClipCard from '../components/ClipCard'
 import { CLIPS } from '../mock/clips'
+import type { SearchBridge } from '../types'
 
 const PAGE_SIZE = 12
-
-type SearchBridge = {
-  getQuery: () => string
-  onQueryChange: (value: string) => void
-  clear: () => void
-}
 
 type HomeProps = {
   registerSearch: (bridge: SearchBridge | null) => void
 }
 
-const Home = ({ registerSearch }: HomeProps) => {
+const Home: FC<HomeProps> = ({ registerSearch }) => {
   const [query, setQuery] = useState('')
   const [page, setPage] = useState(0)
   const [loading, setLoading] = useState(true)

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -1,9 +1,15 @@
 export interface Clip {
-  id: string;
-  title: string;
-  channel: string;
-  views: number;
-  createdAt: string;
-  durationSec: number;
-  thumbnail: string;
+  id: string
+  title: string
+  channel: string
+  views: number
+  createdAt: string
+  durationSec: number
+  thumbnail: string
+}
+
+export type SearchBridge = {
+  getQuery: () => string
+  onQueryChange: (value: string) => void
+  clear: () => void
 }


### PR DESCRIPTION
## Summary
- rename the desktop application to Atropos across product metadata, window title, and UI text
- update shared renderer types and annotate React components with FC typings

## Testing
- pytest *(fails: missing libGL.so.1 for cv2)*
- npm run typecheck *(fails: TypeScript cannot resolve react-router-dom and test utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68c9506b3430832381cdc9934ddc7010