### PR TITLE
Revamp desktop home pipeline interface

### DIFF
--- a/desktop/src/renderer/src/components/ClipDrawer.tsx
+++ b/desktop/src/renderer/src/components/ClipDrawer.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import type { FC, MouseEvent } from 'react'
+import { formatDuration, formatViews, timeAgo } from '../lib/format'
+import type { Clip } from '../types'
+
+type ClipDrawerProps = {
+  clips: Clip[]
+  selectedClipId: string | null
+  onSelect: (clipId: string) => void
+  onRemove: (clipId: string) => void
+  className?: string
+}
+
+const ClipDrawer: FC<ClipDrawerProps> = ({ clips, selectedClipId, onSelect, onRemove, className }) => {
+  const [isOpen, setIsOpen] = useState(true)
+
+  const handleRemove = (event: MouseEvent<HTMLButtonElement>, clipId: string): void => {
+    event.stopPropagation()
+    onRemove(clipId)
+  }
+
+  return (
+    <aside
+      className={`flex h-full flex-col rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] shadow-[0_10px_30px_-12px_rgba(15,23,42,0.45)] ${className ?? ''}`.trim()}
+    >
+      <button
+        type="button"
+        onClick={() => setIsOpen((current) => !current)}
+        className="flex items-center justify-between gap-3 px-4 py-3 text-left text-sm font-medium text-[var(--fg)] transition hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+      >
+        <span>Clip library</span>
+        <span className="flex items-center gap-2 text-xs text-[var(--muted)]">
+          {clips.length} {clips.length === 1 ? 'clip' : 'clips'}
+          <svg
+            viewBox="0 0 12 12"
+            aria-hidden="true"
+            className={`h-3 w-3 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+          >
+            <path
+              fill="currentColor"
+              d="M6 8.5a.75.75 0 0 1-.53-.22l-3-3a.75.75 0 0 1 1.06-1.06L6 6.69l2.47-2.47a.75.75 0 0 1 1.06 1.06l-3 3A.75.75 0 0 1 6 8.5"
+            />
+          </svg>
+        </span>
+      </button>
+      <div className="h-px w-full bg-white/10" aria-hidden="true" />
+
+      {isOpen ? (
+        clips.length > 0 ? (
+          <ul className="flex-1 space-y-3 overflow-y-auto px-4 py-3">
+            {clips.map((clip) => {
+              const isActive = clip.id === selectedClipId
+              return (
+                <li key={clip.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(clip.id)}
+                    className={`group flex w-full items-start gap-3 rounded-xl border border-white/5 bg-black/10 p-3 text-left transition hover:border-[var(--ring)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] ${
+                      isActive ? 'border-[var(--ring)] shadow-[0_0_0_1px_var(--ring)]' : ''
+                    }`}
+                  >
+                    <div className="h-16 w-24 flex-shrink-0 overflow-hidden rounded-lg bg-black/40">
+                      <img src={clip.thumbnail} alt="" className="h-full w-full object-cover" />
+                    </div>
+                    <div className="flex flex-1 flex-col">
+                      <span className="text-sm font-medium text-[var(--fg)] leading-snug">{clip.title}</span>
+                      <span className="mt-1 text-xs text-[var(--muted)]">
+                        {clip.channel} • {formatDuration(clip.durationSec)} • {formatViews(clip.views)} views
+                      </span>
+                      <span className="text-[10px] uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_70%,transparent)]">
+                        {timeAgo(clip.createdAt)}
+                      </span>
+                    </div>
+                    <button
+                      type="button"
+                      aria-label={`Remove ${clip.title}`}
+                      onClick={(event) => handleRemove(event, clip.id)}
+                      className="ml-2 rounded-md border border-transparent p-1 text-[var(--muted)] transition hover:border-white/10 hover:text-[var(--fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+                    >
+                      <svg viewBox="0 0 20 20" className="h-4 w-4" aria-hidden="true">
+                        <path
+                          fill="currentColor"
+                          d="M7.25 2A2.25 2.25 0 0 0 5 4.25V5H3.5a.75.75 0 0 0 0 1.5h.54l.63 8.32A2.75 2.75 0 0 0 7.41 17.5h5.18a2.75 2.75 0 0 0 2.74-2.68l.63-8.32h.54a.75.75 0 0 0 0-1.5H15v-.75A2.25 2.25 0 0 0 12.75 2zm.25 1.5h5a.75.75 0 0 1 .75.75V5H6.5v-.75a.75.75 0 0 1 .75-.75m-.49 11.47-.6-8.22h8.18l-.6 8.22a1.25 1.25 0 0 1-1.24 1.18H7.41a1.25 1.25 0 0 1-1.24-1.18M8.75 7.75a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0V8.5a.75.75 0 0 1 .75-.75m2.5 0a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0V8.5a.75.75 0 0 1 .75-.75"
+                        />
+                      </svg>
+                    </button>
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        ) : (
+          <div className="flex flex-1 flex-col items-center justify-center px-6 py-12 text-center text-sm text-[var(--muted)]">
+            No clips generated yet. Start the pipeline to create highlights.
+          </div>
+        )
+      ) : (
+        <div className="px-4 pb-4 text-xs text-[var(--muted)]">Drawer collapsed</div>
+      )}
+    </aside>
+  )
+}
+
+export default ClipDrawer

--- a/desktop/src/renderer/src/components/PipelineProgress.tsx
+++ b/desktop/src/renderer/src/components/PipelineProgress.tsx
@@ -1,0 +1,172 @@
+import { useMemo } from 'react'
+import type { FC } from 'react'
+import type { PipelineStep, PipelineStepStatus } from '../types'
+
+type PipelineProgressProps = {
+  steps: PipelineStep[]
+  className?: string
+}
+
+const statusLabels: Record<PipelineStepStatus, string> = {
+  pending: 'Queued',
+  running: 'In progress',
+  completed: 'Completed',
+  failed: 'Failed'
+}
+
+const segmentClasses: Record<PipelineStepStatus, string> = {
+  pending: 'bg-transparent',
+  running: 'bg-sky-400',
+  completed: 'bg-emerald-500',
+  failed: 'bg-rose-500'
+}
+
+const indicatorClasses: Record<PipelineStepStatus, string> = {
+  pending: 'border border-white/40 bg-transparent',
+  running: 'bg-sky-400 shadow-[0_0_0_2px_rgba(56,189,248,0.3)]',
+  completed: 'bg-emerald-500',
+  failed: 'bg-rose-500'
+}
+
+const clamp01 = (value: number): number => Math.min(1, Math.max(0, value))
+
+const PipelineProgress: FC<PipelineProgressProps> = ({ steps, className }) => {
+  const totalSteps = steps.length
+
+  const { completedCount, activeIndex, progressPercent, hasFailure } = useMemo(() => {
+    if (totalSteps === 0) {
+      return { completedCount: 0, activeIndex: -1, progressPercent: 0, hasFailure: false }
+    }
+
+    const completed = steps.filter((step) => step.status === 'completed').length
+    const active = steps.findIndex((step) => step.status === 'running')
+    const aggregate = steps.reduce((total, step) => {
+      if (step.status === 'completed') {
+        return total + 1
+      }
+      if (step.status === 'running') {
+        return total + clamp01(step.progress)
+      }
+      if (step.status === 'failed') {
+        return total + clamp01(step.progress)
+      }
+      return total
+    }, 0)
+
+    const percent = totalSteps === 0 ? 0 : (aggregate / totalSteps) * 100
+    const failure = steps.some((step) => step.status === 'failed')
+
+    return {
+      completedCount: completed,
+      activeIndex: active,
+      progressPercent: Math.round(percent),
+      hasFailure: failure
+    }
+  }, [steps, totalSteps])
+
+  const activeStep = activeIndex >= 0 ? steps[activeIndex] : null
+
+  const summaryLabel = useMemo(() => {
+    if (hasFailure) {
+      return 'Pipeline encountered an error'
+    }
+
+    if (activeStep) {
+      return `Running step ${activeIndex + 1} of ${totalSteps}`
+    }
+
+    if (totalSteps > 0 && completedCount === totalSteps) {
+      return 'All steps completed'
+    }
+
+    return 'Pipeline idle'
+  }, [activeIndex, activeStep, completedCount, hasFailure, totalSteps])
+
+  return (
+    <div
+      className={`flex flex-col gap-4 ${className ?? ''}`.trim()}
+      aria-label="Pipeline progress overview"
+    >
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-medium text-[var(--fg)]">Pipeline progress</p>
+          <p className="text-xs text-[var(--muted)]">{summaryLabel}</p>
+        </div>
+        <div className="text-xs text-[var(--muted)]">
+          {progressPercent}% complete • {completedCount}/{totalSteps} done
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={progressPercent}
+          className="flex h-2 w-full overflow-hidden rounded-full bg-white/10"
+        >
+          {steps.map((step, index) => {
+            const progress =
+              step.status === 'completed' || step.status === 'failed'
+                ? 1
+                : clamp01(step.progress)
+            return (
+              <div key={step.id} className="relative flex-1">
+                <div
+                  className={`absolute inset-0 transition-all duration-700 ease-out ${segmentClasses[step.status]}`}
+                  style={{ width: `${progress * 100}%` }}
+                />
+                {index < steps.length - 1 ? (
+                  <div className="absolute right-0 top-0 h-full w-px bg-white/10" aria-hidden="true" />
+                ) : null}
+              </div>
+            )
+          })}
+        </div>
+        <p className="text-xs text-[var(--muted)]">
+          {activeStep ? `${activeStep.title} — ${Math.round(clamp01(activeStep.progress) * 100)}%` : 'Waiting for next step'}
+        </p>
+      </div>
+
+      <ul className="space-y-3">
+        {steps.map((step, index) => (
+          <li
+            key={step.id}
+            className="rounded-xl border border-white/5 bg-[color:color-mix(in_srgb,var(--card)_65%,transparent)] p-3"
+          >
+            <div className="flex items-start gap-3">
+              <span
+                className={`mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full ${indicatorClasses[step.status]}`}
+                aria-hidden="true"
+              />
+              <div className="flex-1">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p className="text-sm font-medium text-[var(--fg)]">
+                    Step {index + 1}: {step.title}
+                  </p>
+                  <span className="text-xs text-[var(--muted)]">{statusLabels[step.status]}</span>
+                </div>
+                <p className="mt-1 text-xs text-[var(--muted)]">{step.description}</p>
+                {step.status === 'running' ? (
+                  <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+                    <div
+                      className="h-full rounded-full bg-sky-400 transition-all duration-500 ease-out"
+                      style={{ width: `${Math.round(clamp01(step.progress) * 100)}%` }}
+                    />
+                  </div>
+                ) : null}
+                {step.status === 'failed' ? (
+                  <p className="mt-2 text-xs font-medium text-rose-400">
+                    Check the server logs to resolve the failure before retrying.
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default PipelineProgress

--- a/desktop/src/renderer/src/mock/pipeline.ts
+++ b/desktop/src/renderer/src/mock/pipeline.ts
@@ -1,0 +1,58 @@
+import type { PipelineStepDefinition } from '../types'
+
+export const PIPELINE_STEP_DEFINITIONS: PipelineStepDefinition[] = [
+  {
+    id: 'download-video',
+    title: 'Download source video',
+    description: 'Retrieve the original YouTube or Twitch video file for processing.',
+    durationMs: 3200
+  },
+  {
+    id: 'acquire-audio',
+    title: 'Ensure audio track',
+    description: 'Extract or download the audio track so it can be analysed independently.',
+    durationMs: 2600
+  },
+  {
+    id: 'transcript',
+    title: 'Generate transcript',
+    description: 'Download the creator transcript or run Whisper transcription as a fallback.',
+    durationMs: 4800
+  },
+  {
+    id: 'silence-detection',
+    title: 'Detect silences',
+    description: 'Scan the audio track to find natural pauses that help with clip boundaries.',
+    durationMs: 2400
+  },
+  {
+    id: 'structure-transcript',
+    title: 'Build transcript structure',
+    description: 'Segment the transcript, refine dialogue ranges and prepare the project timeline.',
+    durationMs: 4200
+  },
+  {
+    id: 'find-candidates',
+    title: 'Select clip candidates',
+    description: 'Score potential clips, snap to silences and cut highlights for review.',
+    durationMs: 5200
+  },
+  {
+    id: 'subtitles',
+    title: 'Generate subtitles',
+    description: 'Create caption files for each candidate clip ready for rendering.',
+    durationMs: 2400
+  },
+  {
+    id: 'render',
+    title: 'Render vertical formats',
+    description: 'Render short-form vertical videos with the chosen layout and captions.',
+    durationMs: 4000
+  },
+  {
+    id: 'descriptions',
+    title: 'Write descriptions',
+    description: 'Assemble descriptions, hashtags and links that accompany the final clips.',
+    durationMs: 2200
+  }
+]

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -1,158 +1,317 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  ChangeEvent,
+  FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import type { FC } from 'react'
-import { useNavigate } from 'react-router-dom'
-import ClipCard from '../components/ClipCard'
+import ClipDrawer from '../components/ClipDrawer'
+import PipelineProgress from '../components/PipelineProgress'
 import { CLIPS } from '../mock/clips'
-import type { SearchBridge } from '../types'
+import { PIPELINE_STEP_DEFINITIONS } from '../mock/pipeline'
+import { formatDuration, formatViews, timeAgo } from '../lib/format'
+import type { Clip, PipelineStep, SearchBridge } from '../types'
 
-const PAGE_SIZE = 12
+const CLIP_PREVIEW_LIMIT = 6
+
+const SUPPORTED_HOSTS = ['youtube.com', 'youtu.be', 'twitch.tv'] as const
+
+const isValidVideoUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value.trim())
+    const host = url.hostname.toLowerCase()
+    return SUPPORTED_HOSTS.some((domain) => host === domain || host.endsWith(`.${domain}`))
+  } catch (error) {
+    return false
+  }
+}
+
+const clamp01 = (value: number): number => Math.min(1, Math.max(0, value))
+
+const buildInitialSteps = (): PipelineStep[] =>
+  PIPELINE_STEP_DEFINITIONS.map((definition) => ({
+    ...definition,
+    status: 'pending',
+    progress: 0
+  }))
 
 type HomeProps = {
   registerSearch: (bridge: SearchBridge | null) => void
 }
 
 const Home: FC<HomeProps> = ({ registerSearch }) => {
-  const [query, setQuery] = useState('')
-  const [page, setPage] = useState(0)
-  const [loading, setLoading] = useState(true)
-  const navigate = useNavigate()
+  const [videoUrl, setVideoUrl] = useState('')
+  const [urlError, setUrlError] = useState<string | null>(null)
+  const [steps, setSteps] = useState<PipelineStep[]>(() => buildInitialSteps())
+  const [isSimulating, setIsSimulating] = useState(false)
+  const [clips, setClips] = useState<Clip[]>([])
+  const [selectedClipId, setSelectedClipId] = useState<string | null>(null)
 
-  const handleQueryChange = useCallback(
-    (value: string) => {
-      setQuery(value)
-      setPage(0)
-    },
-    [setPage]
-  )
+  const timersRef = useRef<number[]>([])
+  const runStepRef = useRef<(index: number) => void>(() => {})
 
-  const bridge = useMemo<SearchBridge>(
-    () => ({
-      getQuery: () => query,
-      onQueryChange: handleQueryChange,
-      clear: () => handleQueryChange('')
-    }),
-    [handleQueryChange, query]
-  )
-
-  useEffect(() => {
-    registerSearch(bridge)
-    return () => registerSearch(null)
-  }, [bridge, registerSearch])
-
-  useEffect(() => {
-    setLoading(true)
-    const timer = window.setTimeout(() => setLoading(false), 300)
-    return () => window.clearTimeout(timer)
-  }, [query, page])
-
-  const filteredClips = useMemo(() => {
-    const normalized = query.trim().toLowerCase()
-    if (!normalized) {
-      return CLIPS
+  const clearTimers = useCallback(() => {
+    for (const id of timersRef.current) {
+      window.clearTimeout(id)
     }
-
-    return CLIPS.filter(
-      (clip) =>
-        clip.title.toLowerCase().includes(normalized) ||
-        clip.channel.toLowerCase().includes(normalized)
-    )
-  }, [query])
-
-  const totalPages = filteredClips.length === 0 ? 0 : Math.ceil(filteredClips.length / PAGE_SIZE)
+    timersRef.current = []
+  }, [])
 
   useEffect(() => {
-    if (totalPages === 0) {
-      if (page !== 0) {
-        setPage(0)
+    registerSearch(null)
+    return () => {
+      registerSearch(null)
+      clearTimers()
+    }
+  }, [clearTimers, registerSearch])
+
+  useEffect(() => {
+    runStepRef.current = (stepIndex: number) => {
+      if (stepIndex >= PIPELINE_STEP_DEFINITIONS.length) {
+        setIsSimulating(false)
+        return
+      }
+
+      const definition = PIPELINE_STEP_DEFINITIONS[stepIndex]
+      const increments = 5
+      const incrementDuration = Math.max(500, Math.round(definition.durationMs / increments))
+
+      setSteps((prev) =>
+        prev.map((step, index) => {
+          if (index < stepIndex) {
+            return { ...step, status: 'completed', progress: 1 }
+          }
+          if (index === stepIndex) {
+            return { ...step, status: 'running', progress: 0 }
+          }
+          return { ...step, status: 'pending', progress: 0 }
+        })
+      )
+
+      for (let i = 1; i <= increments; i += 1) {
+        const timeout = window.setTimeout(() => {
+          setSteps((prev) =>
+            prev.map((step, index) => {
+              if (index === stepIndex) {
+                const progress = clamp01(i / increments)
+                return {
+                  ...step,
+                  progress,
+                  status: progress >= 1 ? 'completed' : 'running'
+                }
+              }
+
+              if (index < stepIndex && (step.status !== 'completed' || step.progress !== 1)) {
+                return { ...step, status: 'completed', progress: 1 }
+              }
+
+              return step
+            })
+          )
+
+          if (i === increments) {
+            if (stepIndex === 5) {
+              setClips((current) => (current.length > 0 ? current : CLIPS.slice(0, CLIP_PREVIEW_LIMIT)))
+            }
+
+            if (stepIndex === PIPELINE_STEP_DEFINITIONS.length - 1) {
+              setIsSimulating(false)
+            } else {
+              const nextTimeout = window.setTimeout(() => runStepRef.current(stepIndex + 1), 500)
+              timersRef.current.push(nextTimeout)
+            }
+          }
+        }, incrementDuration * i)
+
+        timersRef.current.push(timeout)
+      }
+    }
+  }, [])
+
+  useEffect(() => () => clearTimers(), [clearTimers])
+
+  useEffect(() => {
+    if (clips.length === 0) {
+      if (selectedClipId !== null) {
+        setSelectedClipId(null)
       }
       return
     }
 
-    if (page > totalPages - 1) {
-      setPage(totalPages - 1)
+    if (!selectedClipId || !clips.some((clip) => clip.id === selectedClipId)) {
+      setSelectedClipId(clips[0].id)
     }
-  }, [page, totalPages])
+  }, [clips, selectedClipId])
 
-  const visibleClips = filteredClips.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE)
-  const skeletonCount = visibleClips.length > 0 ? visibleClips.length : Math.min(PAGE_SIZE, filteredClips.length || PAGE_SIZE)
-
-  const handleSelect = useCallback(
-    (id: string) => {
-      navigate(`/clip/${id}`)
+  const handleUrlChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setVideoUrl(event.target.value)
+      if (urlError) {
+        setUrlError(null)
+      }
     },
-    [navigate]
+    [urlError]
   )
 
-  const hasResults = filteredClips.length > 0
-  const hasPrev = page > 0
-  const hasNext = totalPages > 0 && page < totalPages - 1
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      const trimmed = videoUrl.trim()
+
+      if (!trimmed) {
+        setUrlError('Enter a video URL to start processing.')
+        return
+      }
+
+      if (!isValidVideoUrl(trimmed)) {
+        setUrlError('Enter a valid YouTube or Twitch URL.')
+        return
+      }
+
+      setUrlError(null)
+      clearTimers()
+      setClips([])
+      setSteps(buildInitialSteps())
+      setIsSimulating(true)
+
+      const startTimeout = window.setTimeout(() => runStepRef.current(0), 150)
+      timersRef.current.push(startTimeout)
+    },
+    [clearTimers, videoUrl]
+  )
+
+  const handleReset = useCallback(() => {
+    clearTimers()
+    setSteps(buildInitialSteps())
+    setIsSimulating(false)
+    setClips([])
+    setUrlError(null)
+  }, [clearTimers])
+
+  const handleClipRemove = useCallback((clipId: string) => {
+    setClips((current) => current.filter((clip) => clip.id !== clipId))
+  }, [])
+
+  const handleClipSelect = useCallback((clipId: string) => {
+    setSelectedClipId(clipId)
+  }, [])
+
+  const hasProgress = useMemo(
+    () => steps.some((step) => step.status !== 'pending' || step.progress > 0),
+    [steps]
+  )
+
+  const currentStep = useMemo(() => steps.find((step) => step.status === 'running') ?? null, [steps])
+  const selectedClip = useMemo(
+    () => clips.find((clip) => clip.id === selectedClipId) ?? null,
+    [clips, selectedClipId]
+  )
+
+  const pipelineMessage = useMemo(() => {
+    if (currentStep) {
+      return `Currently processing: ${currentStep.title}`
+    }
+    if (clips.length > 0 && !isSimulating) {
+      return 'Processing complete. Review the generated clips below.'
+    }
+    return 'Paste a supported link to kick off the Atropos pipeline.'
+  }, [clips.length, currentStep, isSimulating])
 
   return (
     <section className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-8">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <h2 className="text-lg font-semibold text-[var(--fg)]">Featured clips</h2>
-          <p className="text-sm text-[var(--muted)]">
-            {hasResults
-              ? `${filteredClips.length.toLocaleString()} clip${filteredClips.length === 1 ? '' : 's'} found`
-              : 'No clips match your search yet'}
-          </p>
-        </div>
-        {totalPages > 1 && hasResults ? (
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setPage((current) => Math.max(0, current - 1))}
-              disabled={!hasPrev}
-              className="rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-[var(--fg)] transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Previous
-            </button>
-            <span className="text-sm text-[var(--muted)]">
-              Page {page + 1} of {totalPages}
-            </span>
-            <button
-              type="button"
-              onClick={() => setPage((current) => Math.min(totalPages - 1, current + 1))}
-              disabled={!hasNext}
-              className="rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-[var(--fg)] transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Next
-            </button>
-          </div>
-        ) : null}
-      </div>
-
-      {loading ? (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {Array.from({ length: skeletonCount }).map((_, index) => (
-            <div
-              key={index}
-              className="flex h-full flex-col overflow-hidden rounded-xl bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)]"
-            >
-              <div className="aspect-video w-full animate-pulse bg-white/10" />
-              <div className="flex flex-1 flex-col gap-2 px-4 py-3">
-                <div className="h-4 w-3/4 animate-pulse rounded bg-white/10" />
-                <div className="h-3 w-1/2 animate-pulse rounded bg-white/10" />
-                <div className="h-3 w-2/3 animate-pulse rounded bg-white/10" />
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px] xl:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="flex flex-col gap-6">
+          <form
+            onSubmit={handleSubmit}
+            className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-6 shadow-[0_20px_40px_-24px_rgba(15,23,42,0.6)]"
+          >
+            <div className="flex flex-col gap-1">
+              <h2 className="text-lg font-semibold text-[var(--fg)]">Process a new video</h2>
+              <p className="text-sm text-[var(--muted)]">{pipelineMessage}</p>
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <label className="sr-only" htmlFor="video-url">
+                Video URL
+              </label>
+              <input
+                id="video-url"
+                type="url"
+                value={videoUrl}
+                onChange={handleUrlChange}
+                placeholder="https://www.youtube.com/watch?v=..."
+                className="flex-1 rounded-lg border border-white/10 bg-[var(--card)] px-4 py-2 text-sm text-[var(--fg)] shadow-sm placeholder:text-[var(--muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+              />
+              <div className="flex items-center gap-2">
+                <button
+                  type="submit"
+                  disabled={!videoUrl.trim() || isSimulating}
+                  className="rounded-lg border border-transparent bg-[var(--ring)] px-4 py-2 text-sm font-semibold text-white transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isSimulating ? 'Processing…' : 'Start processing'}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleReset}
+                  disabled={!hasProgress && clips.length === 0}
+                  className="rounded-lg border border-white/10 px-4 py-2 text-sm font-medium text-[var(--fg)] transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Reset
+                </button>
               </div>
             </div>
-          ))}
+            <div className="text-xs text-[var(--muted)]">
+              Supports YouTube and Twitch URLs. The pipeline runs locally; progress appears as the server completes each step.
+            </div>
+            {urlError ? <p className="text-xs font-medium text-rose-400">{urlError}</p> : null}
+          </form>
+
+          <div className="rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-6 shadow-[0_20px_40px_-24px_rgba(15,23,42,0.6)]">
+            <PipelineProgress steps={steps} />
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-6 shadow-[0_20px_40px_-24px_rgba(15,23,42,0.6)]">
+            <div className="flex flex-col gap-1">
+              <h3 className="text-lg font-semibold text-[var(--fg)]">Selected clip</h3>
+              <p className="text-sm text-[var(--muted)]">
+                {selectedClip ? 'Preview the highlight before exporting or sharing it.' : 'Generated clips will appear once the pipeline reaches the candidate stage.'}
+              </p>
+            </div>
+            {selectedClip ? (
+              <div className="mt-4 flex flex-col gap-4">
+                <div className="aspect-video w-full overflow-hidden rounded-xl bg-black/60">
+                  <img
+                    src={selectedClip.thumbnail}
+                    alt={selectedClip.title}
+                    className="h-full w-full object-cover"
+                  />
+                </div>
+                <div className="space-y-2 text-sm text-[var(--muted)]">
+                  <p className="text-base font-semibold text-[var(--fg)] leading-tight">{selectedClip.title}</p>
+                  <p>{selectedClip.channel} • {formatViews(selectedClip.views)} views</p>
+                  <p>
+                    Duration: {formatDuration(selectedClip.durationSec)} • Published {timeAgo(selectedClip.createdAt)}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="mt-6 rounded-xl border border-dashed border-white/10 bg-[color:color-mix(in_srgb,var(--card)_60%,transparent)] p-8 text-center text-sm text-[var(--muted)]">
+                No clips have been generated yet. Start processing a video to populate the clip drawer.
+              </div>
+            )}
+          </div>
         </div>
-      ) : hasResults ? (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {visibleClips.map((clip) => (
-            <ClipCard key={clip.id} clip={clip} onClick={() => handleSelect(clip.id)} />
-          ))}
-        </div>
-      ) : (
-        <div className="flex flex-1 flex-col items-center justify-center rounded-xl border border-dashed border-white/10 bg-[color:color-mix(in_srgb,var(--card)_60%,transparent)] p-10 text-center">
-          <h3 className="text-lg font-semibold text-[var(--fg)]">No clips found</h3>
-          <p className="mt-2 max-w-md text-sm text-[var(--muted)]">
-            Try a different keyword or explore trending creators to discover new highlights.
-          </p>
-        </div>
-      )}
+
+        <ClipDrawer
+          clips={clips}
+          selectedClipId={selectedClipId}
+          onSelect={handleClipSelect}
+          onRemove={handleClipRemove}
+          className="lg:sticky lg:top-6"
+        />
+      </div>
     </section>
   )
 }

--- a/desktop/src/renderer/src/tests/clipdrawer.test.tsx
+++ b/desktop/src/renderer/src/tests/clipdrawer.test.tsx
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom/vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import ClipDrawer from '../components/ClipDrawer'
+import type { Clip } from '../types'
+
+const sampleClips: Clip[] = [
+  {
+    id: 'clip-1',
+    title: 'First highlight',
+    channel: 'Channel One',
+    views: 12345,
+    createdAt: '2024-10-01T12:00:00Z',
+    durationSec: 42,
+    thumbnail: 'https://example.com/one.jpg'
+  },
+  {
+    id: 'clip-2',
+    title: 'Second highlight',
+    channel: 'Channel Two',
+    views: 6789,
+    createdAt: '2024-11-05T09:30:00Z',
+    durationSec: 58,
+    thumbnail: 'https://example.com/two.jpg'
+  }
+]
+
+describe('ClipDrawer', () => {
+  it('allows toggling and selecting clips', () => {
+    const onSelect = vi.fn()
+    const onRemove = vi.fn()
+
+    render(
+      <ClipDrawer clips={sampleClips} selectedClipId={sampleClips[0].id} onSelect={onSelect} onRemove={onRemove} />
+    )
+
+    expect(screen.getByRole('button', { name: /clip library/i })).toBeInTheDocument()
+    expect(screen.getByText(/first highlight/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText(/second highlight/i))
+    expect(onSelect).toHaveBeenCalledWith('clip-2')
+
+    fireEvent.click(screen.getByLabelText(/remove first highlight/i))
+    expect(onRemove).toHaveBeenCalledWith('clip-1')
+
+    fireEvent.click(screen.getByRole('button', { name: /clip library/i }))
+    expect(screen.getByText(/drawer collapsed/i)).toBeInTheDocument()
+  })
+})

--- a/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
+++ b/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import PipelineProgress from '../components/PipelineProgress'
+import type { PipelineStep } from '../types'
+
+const mockSteps: PipelineStep[] = [
+  {
+    id: 'download',
+    title: 'Download source video',
+    description: 'Retrieve the video file.',
+    durationMs: 1000,
+    status: 'completed',
+    progress: 1
+  },
+  {
+    id: 'audio',
+    title: 'Ensure audio track',
+    description: 'Acquire the audio track.',
+    durationMs: 1000,
+    status: 'running',
+    progress: 0.4
+  },
+  {
+    id: 'transcript',
+    title: 'Generate transcript',
+    description: 'Build the transcript file.',
+    durationMs: 1000,
+    status: 'pending',
+    progress: 0
+  }
+]
+
+describe('PipelineProgress', () => {
+  it('renders pipeline summary and step details', () => {
+    render(<PipelineProgress steps={mockSteps} />)
+
+    expect(screen.getByLabelText(/pipeline progress overview/i)).toBeInTheDocument()
+    expect(screen.getByText(/pipeline progress/i)).toBeInTheDocument()
+    expect(screen.getByText(/running step 2 of 3/i)).toBeInTheDocument()
+    expect(screen.getByText(/step 1: download source video/i)).toBeInTheDocument()
+    expect(screen.getByText(/ensure audio track — 40%/i)).toBeInTheDocument()
+
+    const progressbar = screen.getByRole('progressbar')
+    expect(progressbar).toHaveAttribute('aria-valuenow', '47')
+  })
+})

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -13,3 +13,17 @@ export type SearchBridge = {
   onQueryChange: (value: string) => void
   clear: () => void
 }
+
+export type PipelineStepStatus = 'pending' | 'running' | 'completed' | 'failed'
+
+export interface PipelineStepDefinition {
+  id: string
+  title: string
+  description: string
+  durationMs: number
+}
+
+export interface PipelineStep extends PipelineStepDefinition {
+  status: PipelineStepStatus
+  progress: number
+}


### PR DESCRIPTION
## Summary
- replace the desktop home screen with a video URL workflow and pipeline progress simulation
- add segmented pipeline progress and clip drawer components to preview and curate generated clips
- define pipeline step metadata and cover the new UI elements with focused tests

## Testing
- npm --prefix desktop test -- run
- pytest *(fails: ImportError: libGL.so.1 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c95b28bca883238a46fd913b336d1e