### PR TITLE
Add profile page showing account status and upcoming uploads

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { FC, RefObject } from 'react'
-import { Route, Routes } from 'react-router-dom'
+import { NavLink, Route, Routes } from 'react-router-dom'
 import Search from './components/Search'
 import ClipPage from './pages/Clip'
 import Home from './pages/Home'
+import Profile from './pages/Profile'
 import type { SearchBridge } from './types'
 
 type AppProps = {
@@ -59,16 +60,39 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
     }
   }, [])
 
+  const navLinkClassName = useCallback(
+    ({ isActive }: { isActive: boolean }) =>
+      `rounded-lg px-3 py-1.5 text-sm transition ${
+        isActive
+          ? 'bg-[color:color-mix(in_srgb,var(--card)_80%,transparent)] text-[var(--fg)] shadow-sm'
+          : 'text-[var(--muted)] hover:bg-white/10 hover:text-[var(--fg)]'
+      }`,
+    []
+  )
+
   return (
     <div className="flex min-h-full flex-col bg-[var(--bg)] text-[var(--fg)]">
       <header className="border-b border-white/10 bg-[color:color-mix(in_srgb,var(--card)_40%,transparent)]">
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 px-4 py-4">
-          <div className="flex items-center justify-between gap-3">
-            <h1 className="text-2xl font-semibold tracking-tight">Atropos</h1>
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-2xl font-semibold tracking-tight text-[var(--fg)]">Atropos</h1>
+              <nav
+                aria-label="Primary navigation"
+                className="flex items-center gap-2 rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_60%,transparent)] p-1"
+              >
+                <NavLink to="/" end className={navLinkClassName}>
+                  Library
+                </NavLink>
+                <NavLink to="/profile" className={navLinkClassName}>
+                  Profile
+                </NavLink>
+              </nav>
+            </div>
             <button
               type="button"
               onClick={toggleTheme}
-              className="rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-[var(--fg)] transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+              className="self-start rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-[var(--fg)] transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] md:self-auto"
               aria-label="Toggle theme"
             >
               {isDark ? 'Switch to light' : 'Switch to dark'}
@@ -86,6 +110,7 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
         <Routes>
           <Route path="/" element={<Home registerSearch={registerSearch} />} />
           <Route path="/clip/:id" element={<ClipPage registerSearch={registerSearch} />} />
+          <Route path="/profile" element={<Profile registerSearch={registerSearch} />} />
           <Route path="*" element={<Home registerSearch={registerSearch} />} />
         </Routes>
       </main>

--- a/desktop/src/renderer/src/mock/accounts.ts
+++ b/desktop/src/renderer/src/mock/accounts.ts
@@ -1,0 +1,86 @@
+import type { AccountProfile } from '../types'
+
+const SAMPLE_VIDEO_FLOWERS = 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4'
+const SAMPLE_VIDEO_OCEAN = 'https://samplelib.com/lib/preview/mp4/sample-5s.mp4'
+const SAMPLE_VIDEO_CITY = 'https://samplelib.com/lib/preview/mp4/sample-10s.mp4'
+
+export const PROFILE_ACCOUNTS: AccountProfile[] = [
+  {
+    id: 'account-youtube-main',
+    displayName: 'Main YouTube',
+    platform: 'YouTube Channel',
+    initials: 'YT',
+    status: 'active',
+    statusMessage: 'Token refreshed 2 hours ago',
+    dailyUploadTarget: 2,
+    readyVideos: 12,
+    upcomingUploads: [
+      {
+        id: 'yt-1',
+        title: 'Behind the Scenes: Editing Workflow',
+        videoUrl: SAMPLE_VIDEO_FLOWERS,
+        scheduledFor: '2025-05-04T14:00:00Z',
+        durationSec: 62
+      },
+      {
+        id: 'yt-2',
+        title: 'Creator Q&A: May Highlights',
+        videoUrl: SAMPLE_VIDEO_OCEAN,
+        scheduledFor: '2025-05-05T16:30:00Z',
+        durationSec: 75
+      },
+      {
+        id: 'yt-3',
+        title: 'Short Form Tips for YouTube',
+        videoUrl: SAMPLE_VIDEO_CITY,
+        scheduledFor: '2025-05-06T18:15:00Z',
+        durationSec: 48
+      }
+    ]
+  },
+  {
+    id: 'account-tiktok',
+    displayName: 'TikTok Highlights',
+    platform: 'TikTok',
+    initials: 'TT',
+    status: 'expiring',
+    statusMessage: 'Refresh recommended - expires in 3 days',
+    dailyUploadTarget: 1,
+    readyVideos: 5,
+    upcomingUploads: [
+      {
+        id: 'tt-1',
+        title: '60-Second Recap',
+        videoUrl: SAMPLE_VIDEO_OCEAN,
+        scheduledFor: '2025-05-04T20:00:00Z',
+        durationSec: 59
+      },
+      {
+        id: 'tt-2',
+        title: 'Creator Challenge Teaser',
+        videoUrl: SAMPLE_VIDEO_FLOWERS,
+        scheduledFor: '2025-05-05T18:00:00Z',
+        durationSec: 45
+      }
+    ]
+  },
+  {
+    id: 'account-instagram',
+    displayName: 'Instagram Reels',
+    platform: 'Instagram',
+    initials: 'IG',
+    status: 'disconnected',
+    statusMessage: 'Re-authentication required to publish',
+    dailyUploadTarget: 1,
+    readyVideos: 2,
+    upcomingUploads: [
+      {
+        id: 'ig-1',
+        title: 'Brand Story Reel',
+        videoUrl: SAMPLE_VIDEO_FLOWERS,
+        scheduledFor: '2025-05-07T15:45:00Z',
+        durationSec: 52
+      }
+    ]
+  }
+]

--- a/desktop/src/renderer/src/pages/Profile.tsx
+++ b/desktop/src/renderer/src/pages/Profile.tsx
@@ -1,0 +1,226 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { FC } from 'react'
+import { PROFILE_ACCOUNTS } from '../mock/accounts'
+import type { AccountProfile, AccountStatus, SearchBridge } from '../types'
+import { formatDuration } from '../lib/format'
+
+const STATUS_STYLES: Record<
+  AccountStatus,
+  { avatar: string; badge: string; label: string; helper: string }
+> = {
+  active: {
+    avatar: 'border-emerald-400 bg-emerald-400/10 text-emerald-200',
+    badge: 'border border-emerald-400/40 bg-emerald-400/10 text-emerald-200',
+    label: 'Authenticated',
+    helper: 'Connection is healthy and ready to publish.'
+  },
+  expiring: {
+    avatar: 'border-amber-400 bg-amber-400/10 text-amber-200',
+    badge: 'border border-amber-400/40 bg-amber-400/10 text-amber-200',
+    label: 'Expiring soon',
+    helper: 'Refresh authentication soon to avoid interruptions.'
+  },
+  disconnected: {
+    avatar: 'border-rose-500 bg-rose-500/10 text-rose-200',
+    badge: 'border border-rose-500/40 bg-rose-500/10 text-rose-200',
+    label: 'Not connected',
+    helper: 'Reconnect this account to resume scheduling uploads.'
+  }
+}
+
+const formatScheduleTime = (isoDate: string): string =>
+  new Date(isoDate).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  })
+
+const computeCoverage = (account: AccountProfile): { daysLabel: string; description: string } => {
+  if (account.dailyUploadTarget <= 0) {
+    return {
+      daysLabel: '—',
+      description: 'Set a daily upload schedule to estimate coverage.'
+    }
+  }
+
+  const days = account.readyVideos / account.dailyUploadTarget
+  return {
+    daysLabel: `${days.toFixed(1)} days`,
+    description: 'Estimated runway based on your current schedule.'
+  }
+}
+
+type ProfileProps = {
+  registerSearch: (bridge: SearchBridge | null) => void
+}
+
+const Profile: FC<ProfileProps> = ({ registerSearch }) => {
+  const [collapsedAccounts, setCollapsedAccounts] = useState<Set<string>>(() => new Set())
+
+  useEffect(() => {
+    registerSearch(null)
+    return () => registerSearch(null)
+  }, [registerSearch])
+
+  const summary = useMemo(() => {
+    const totalReady = PROFILE_ACCOUNTS.reduce((sum, account) => sum + account.readyVideos, 0)
+    const active = PROFILE_ACCOUNTS.filter((account) => account.status === 'active').length
+    const attention = PROFILE_ACCOUNTS.filter((account) => account.status !== 'active').length
+    return {
+      totalReady,
+      active,
+      attention
+    }
+  }, [])
+
+  const toggleAccount = useCallback((accountId: string) => {
+    setCollapsedAccounts((current) => {
+      const next = new Set(current)
+      if (next.has(accountId)) {
+        next.delete(accountId)
+      } else {
+        next.add(accountId)
+      }
+      return next
+    })
+  }, [])
+
+  return (
+    <section className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-8 px-4 py-10">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-semibold text-[var(--fg)]">Profile</h1>
+        <p className="max-w-3xl text-sm text-[var(--muted)]">
+          Manage the accounts connected to Atropos and review your upcoming content pipeline. You currently
+          have {PROFILE_ACCOUNTS.length} authenticated account{PROFILE_ACCOUNTS.length === 1 ? '' : 's'} with
+          {' '}
+          {summary.totalReady.toLocaleString()} ready video{summary.totalReady === 1 ? '' : 's'}.
+        </p>
+        <p className="text-sm text-[var(--muted)]">
+          Active connections: {summary.active}/{PROFILE_ACCOUNTS.length}.{' '}
+          {summary.attention > 0
+            ? `${summary.attention} account${summary.attention === 1 ? ' needs' : 's need'} your attention.`
+            : 'All accounts are healthy.'}
+        </p>
+      </header>
+      <div className="flex flex-col gap-6">
+        {PROFILE_ACCOUNTS.map((account) => {
+          const status = STATUS_STYLES[account.status]
+          const isCollapsed = collapsedAccounts.has(account.id)
+          const coverage = computeCoverage(account)
+          const detailsId = `profile-${account.id}`
+
+          return (
+            <article
+              key={account.id}
+              data-testid={`account-panel-${account.id}`}
+              className="rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_85%,transparent)] p-6 shadow-sm"
+            >
+              <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div className="flex flex-1 items-start gap-4">
+                  <div
+                    className={`flex h-14 w-14 items-center justify-center rounded-full border-2 font-semibold ${status.avatar}`}
+                    aria-hidden="true"
+                  >
+                    {account.initials}
+                  </div>
+                  <div className="flex flex-1 flex-col gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="text-lg font-semibold text-[var(--fg)]">{account.displayName}</h2>
+                      <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${status.badge}`}>
+                        {status.label}
+                      </span>
+                    </div>
+                    <p className="text-sm font-medium text-[var(--muted)]">{account.platform}</p>
+                    {account.statusMessage ? (
+                      <p className="text-xs text-[var(--muted)]">{account.statusMessage}</p>
+                    ) : null}
+                    <p className="text-xs text-[var(--muted)]">{status.helper}</p>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => toggleAccount(account.id)}
+                  className="self-start rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-[var(--fg)] transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+                  aria-expanded={!isCollapsed}
+                  aria-controls={detailsId}
+                  aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${account.displayName} details`}
+                >
+                  {isCollapsed ? 'Expand' : 'Collapse'}
+                </button>
+              </div>
+              <div
+                id={detailsId}
+                hidden={isCollapsed}
+                className="mt-6 flex flex-col gap-6"
+                aria-hidden={isCollapsed}
+              >
+                <dl className="grid gap-4 sm:grid-cols-3">
+                  <div className="rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_90%,transparent)] p-4">
+                    <dt className="text-xs font-medium uppercase tracking-wide text-[var(--muted)]">
+                      Ready videos
+                    </dt>
+                    <dd className="mt-2 text-2xl font-semibold text-[var(--fg)]">
+                      {account.readyVideos.toLocaleString()}
+                    </dd>
+                    <p className="mt-1 text-xs text-[var(--muted)]">Ready to publish immediately.</p>
+                  </div>
+                  <div className="rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_90%,transparent)] p-4">
+                    <dt className="text-xs font-medium uppercase tracking-wide text-[var(--muted)]">
+                      Daily target
+                    </dt>
+                    <dd className="mt-2 text-2xl font-semibold text-[var(--fg)]">
+                      {account.dailyUploadTarget.toLocaleString()} per day
+                    </dd>
+                    <p className="mt-1 text-xs text-[var(--muted)]">Scheduled uploads for this channel.</p>
+                  </div>
+                  <div className="rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_90%,transparent)] p-4">
+                    <dt className="text-xs font-medium uppercase tracking-wide text-[var(--muted)]">
+                      Coverage
+                    </dt>
+                    <dd className="mt-2 text-2xl font-semibold text-[var(--fg)]">{coverage.daysLabel}</dd>
+                    <p className="mt-1 text-xs text-[var(--muted)]">{coverage.description}</p>
+                  </div>
+                </dl>
+                <div className="flex flex-col gap-3">
+                  <h3 className="text-sm font-semibold text-[var(--fg)]">Next uploads</h3>
+                  {account.upcomingUploads.length > 0 ? (
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                      {account.upcomingUploads.map((upload) => (
+                        <article
+                          key={upload.id}
+                          className="flex flex-col gap-2 rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_92%,transparent)] p-3"
+                        >
+                          <div className="aspect-video overflow-hidden rounded-lg border border-white/10 bg-black/60">
+                            <video
+                              data-testid="profile-upload-video"
+                              controls
+                              preload="metadata"
+                              className="h-full w-full object-cover"
+                            >
+                              <source src={upload.videoUrl} type="video/mp4" />
+                              Your browser does not support the video tag.
+                            </video>
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <h4 className="text-sm font-medium text-[var(--fg)]">{upload.title}</h4>
+                            <p className="text-xs text-[var(--muted)]">Scheduled {formatScheduleTime(upload.scheduledFor)}</p>
+                            <p className="text-xs text-[var(--muted)]">Duration {formatDuration(upload.durationSec)}</p>
+                          </div>
+                        </article>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-[var(--muted)]">No upcoming uploads are scheduled for this account.</p>
+                  )}
+                </div>
+              </div>
+            </article>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+export default Profile

--- a/desktop/src/renderer/src/tests/profile.test.tsx
+++ b/desktop/src/renderer/src/tests/profile.test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom/vitest'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Profile from '../pages/Profile'
+import { PROFILE_ACCOUNTS } from '../mock/accounts'
+
+describe('Profile page', () => {
+  it('shows each account summary with coverage and videos', () => {
+    render(<Profile registerSearch={() => {}} />)
+
+    expect(screen.getByRole('heading', { level: 1, name: /profile/i })).toBeInTheDocument()
+
+    PROFILE_ACCOUNTS.forEach((account) => {
+      const panels = screen.getAllByTestId(`account-panel-${account.id}`)
+      expect(panels.length).toBeGreaterThan(0)
+      const panel = panels[0]
+      const panelQueries = within(panel)
+
+      expect(panelQueries.getByText(account.displayName)).toBeInTheDocument()
+      expect(panelQueries.getByText(/Ready videos/i)).toBeInTheDocument()
+      expect(panelQueries.getByText(account.readyVideos.toLocaleString())).toBeInTheDocument()
+
+      const coverageLabel =
+        account.dailyUploadTarget > 0
+          ? `${(account.readyVideos / account.dailyUploadTarget).toFixed(1)} days`
+          : '—'
+      expect(panelQueries.getByText(coverageLabel)).toBeInTheDocument()
+
+      const videos = panelQueries.getAllByTestId('profile-upload-video')
+      expect(videos).toHaveLength(account.upcomingUploads.length)
+    })
+  })
+
+  it('toggles details visibility when collapsing an account', () => {
+    render(<Profile registerSearch={() => {}} />)
+
+    const account = PROFILE_ACCOUNTS[0]
+    const panels = screen.getAllByTestId(`account-panel-${account.id}`)
+    expect(panels.length).toBeGreaterThan(0)
+    const panel = panels[0]
+
+    const collapseButton = within(panel).getByRole('button', {
+      name: `Collapse ${account.displayName} details`
+    })
+    expect(within(panel).getByText(/Next uploads/i)).toBeVisible()
+
+    fireEvent.click(collapseButton)
+
+    const expandButton = within(panel).getByRole('button', {
+      name: `Expand ${account.displayName} details`
+    })
+    expect(within(panel).getByText(/Next uploads/i)).not.toBeVisible()
+
+    fireEvent.click(expandButton)
+
+    expect(within(panel).getByText(/Next uploads/i)).toBeVisible()
+  })
+})

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -8,6 +8,28 @@ export interface Clip {
   thumbnail: string
 }
 
+export type AccountStatus = 'active' | 'expiring' | 'disconnected'
+
+export interface AccountUpload {
+  id: string
+  title: string
+  videoUrl: string
+  scheduledFor: string
+  durationSec: number
+}
+
+export interface AccountProfile {
+  id: string
+  displayName: string
+  platform: string
+  initials: string
+  status: AccountStatus
+  statusMessage?: string
+  dailyUploadTarget: number
+  readyVideos: number
+  upcomingUploads: AccountUpload[]
+}
+
 export type SearchBridge = {
   getQuery: () => string
   onQueryChange: (value: string) => void


### PR DESCRIPTION
## Summary
- add a primary navigation entry and route for a new profile page
- build the profile view with account status indicators, coverage metrics, and playable upcoming uploads
- supply mock account data plus tests that cover rendering and collapsing the new view

## Testing
- npm --prefix desktop test
- pytest *(fails: ImportError: libGL.so.1 missing in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c985ba08588323970895d123943c4d