### PR TITLE
Collapse pipeline progress steps around active step

### DIFF
--- a/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
+++ b/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import PipelineProgress from '../components/PipelineProgress'
 import type { PipelineStep } from '../types'
@@ -38,8 +38,18 @@ describe('PipelineProgress', () => {
     expect(screen.getByLabelText(/pipeline progress overview/i)).toBeInTheDocument()
     expect(screen.getByText(/pipeline progress/i)).toBeInTheDocument()
     expect(screen.getByText(/running step 2 of 3/i)).toBeInTheDocument()
-    expect(screen.getByText(/step 1: download source video/i)).toBeInTheDocument()
     expect(screen.getByText(/ensure audio track — 40%/i)).toBeInTheDocument()
+
+    const completedSteps = screen.getByTestId('completed-steps')
+    expect(within(completedSteps).getByText(/step 1/i)).toBeInTheDocument()
+    expect(within(completedSteps).getByText(/download source video/i)).toBeInTheDocument()
+
+    const activeStepCard = screen.getByTestId('active-step')
+    expect(within(activeStepCard).getByText(/step 2: ensure audio track/i)).toBeInTheDocument()
+
+    const upcomingSteps = screen.getByTestId('upcoming-steps')
+    expect(within(upcomingSteps).getByText(/step 3/i)).toBeInTheDocument()
+    expect(within(upcomingSteps).getByText(/generate transcript/i)).toBeInTheDocument()
 
     const progressbar = screen.getByRole('progressbar')
     expect(progressbar).toHaveAttribute('aria-valuenow', '47')


### PR DESCRIPTION
## Summary
- reshape the pipeline progress component to highlight the active step while collapsing completed and upcoming steps into evenly spaced rows
- surface clearer status messaging for the focused step and reuse helper utilities for collapsed cards
- update the pipeline progress unit test to cover the new grouped layout

## Testing
- npm run test -- --run
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ea7c1dc4832382183eb69a424c8f