### PR TITLE
Add multi-platform profile tabs and collapsed metrics

### DIFF
--- a/desktop/src/renderer/src/mock/accounts.ts
+++ b/desktop/src/renderer/src/mock/accounts.ts
@@ -6,80 +6,146 @@ const SAMPLE_VIDEO_CITY = 'https://samplelib.com/lib/preview/mp4/sample-10s.mp4'
 
 export const PROFILE_ACCOUNTS: AccountProfile[] = [
   {
-    id: 'account-youtube-main',
-    displayName: 'Main YouTube',
-    platform: 'YouTube Channel',
-    initials: 'YT',
-    status: 'active',
-    statusMessage: 'Token refreshed 2 hours ago',
-    dailyUploadTarget: 2,
-    readyVideos: 12,
-    upcomingUploads: [
+    id: 'account-creator-hub',
+    displayName: 'Creator Hub',
+    initials: 'CH',
+    description: 'Flagship team covering long-form and short-form programming.',
+    platforms: [
       {
-        id: 'yt-1',
-        title: 'Behind the Scenes: Editing Workflow',
-        videoUrl: SAMPLE_VIDEO_FLOWERS,
-        scheduledFor: '2025-05-04T14:00:00Z',
-        durationSec: 62
+        id: 'creator-hub-youtube',
+        name: 'YouTube Channel',
+        status: 'active',
+        statusMessage: 'Token refreshed 2 hours ago',
+        dailyUploadTarget: 2,
+        readyVideos: 12,
+        upcomingUploads: [
+          {
+            id: 'yt-1',
+            title: 'Behind the Scenes: Editing Workflow',
+            videoUrl: SAMPLE_VIDEO_FLOWERS,
+            scheduledFor: '2025-05-04T14:00:00Z',
+            durationSec: 62
+          },
+          {
+            id: 'yt-2',
+            title: 'Creator Q&A: May Highlights',
+            videoUrl: SAMPLE_VIDEO_OCEAN,
+            scheduledFor: '2025-05-05T16:30:00Z',
+            durationSec: 75
+          },
+          {
+            id: 'yt-3',
+            title: 'Short Form Tips for YouTube',
+            videoUrl: SAMPLE_VIDEO_CITY,
+            scheduledFor: '2025-05-06T18:15:00Z',
+            durationSec: 48
+          }
+        ]
       },
       {
-        id: 'yt-2',
-        title: 'Creator Q&A: May Highlights',
-        videoUrl: SAMPLE_VIDEO_OCEAN,
-        scheduledFor: '2025-05-05T16:30:00Z',
-        durationSec: 75
-      },
-      {
-        id: 'yt-3',
-        title: 'Short Form Tips for YouTube',
-        videoUrl: SAMPLE_VIDEO_CITY,
-        scheduledFor: '2025-05-06T18:15:00Z',
-        durationSec: 48
+        id: 'creator-hub-tiktok',
+        name: 'TikTok',
+        status: 'expiring',
+        statusMessage: 'Refresh recommended - expires in 3 days',
+        dailyUploadTarget: 1,
+        readyVideos: 5,
+        upcomingUploads: [
+          {
+            id: 'tt-1',
+            title: '60-Second Recap',
+            videoUrl: SAMPLE_VIDEO_OCEAN,
+            scheduledFor: '2025-05-04T20:00:00Z',
+            durationSec: 59
+          },
+          {
+            id: 'tt-2',
+            title: 'Creator Challenge Teaser',
+            videoUrl: SAMPLE_VIDEO_FLOWERS,
+            scheduledFor: '2025-05-05T18:00:00Z',
+            durationSec: 45
+          }
+        ]
       }
     ]
   },
   {
-    id: 'account-tiktok',
-    displayName: 'TikTok Highlights',
-    platform: 'TikTok',
-    initials: 'TT',
-    status: 'expiring',
-    statusMessage: 'Refresh recommended - expires in 3 days',
-    dailyUploadTarget: 1,
-    readyVideos: 5,
-    upcomingUploads: [
+    id: 'account-brand-studio',
+    displayName: 'Brand Studio',
+    initials: 'BS',
+    description: 'Campaign-specific channels managed by the brand partnerships team.',
+    platforms: [
       {
-        id: 'tt-1',
-        title: '60-Second Recap',
-        videoUrl: SAMPLE_VIDEO_OCEAN,
-        scheduledFor: '2025-05-04T20:00:00Z',
-        durationSec: 59
+        id: 'brand-studio-instagram',
+        name: 'Instagram Reels',
+        status: 'disconnected',
+        statusMessage: 'Re-authentication required to publish',
+        dailyUploadTarget: 1,
+        readyVideos: 2,
+        upcomingUploads: [
+          {
+            id: 'ig-1',
+            title: 'Brand Story Reel',
+            videoUrl: SAMPLE_VIDEO_FLOWERS,
+            scheduledFor: '2025-05-07T15:45:00Z',
+            durationSec: 52
+          }
+        ]
       },
       {
-        id: 'tt-2',
-        title: 'Creator Challenge Teaser',
-        videoUrl: SAMPLE_VIDEO_FLOWERS,
-        scheduledFor: '2025-05-05T18:00:00Z',
-        durationSec: 45
+        id: 'brand-studio-facebook',
+        name: 'Facebook Page',
+        status: 'active',
+        statusMessage: 'Connected via Business Manager',
+        dailyUploadTarget: 1,
+        readyVideos: 4,
+        upcomingUploads: [
+          {
+            id: 'fb-1',
+            title: 'Product Launch Livestream Replay',
+            videoUrl: SAMPLE_VIDEO_CITY,
+            scheduledFor: '2025-05-05T12:30:00Z',
+            durationSec: 90
+          },
+          {
+            id: 'fb-2',
+            title: 'Community Spotlight',
+            videoUrl: SAMPLE_VIDEO_FLOWERS,
+            scheduledFor: '2025-05-06T10:15:00Z',
+            durationSec: 54
+          }
+        ]
       }
     ]
   },
   {
-    id: 'account-instagram',
-    displayName: 'Instagram Reels',
-    platform: 'Instagram',
-    initials: 'IG',
-    status: 'disconnected',
-    statusMessage: 'Re-authentication required to publish',
-    dailyUploadTarget: 1,
-    readyVideos: 2,
-    upcomingUploads: [
+    id: 'account-podcast-lab',
+    displayName: 'Podcast Lab',
+    initials: 'PL',
+    description: 'Short-form highlights from weekly podcast recordings.',
+    platforms: [
       {
-        id: 'ig-1',
-        title: 'Brand Story Reel',
-        videoUrl: SAMPLE_VIDEO_FLOWERS,
-        scheduledFor: '2025-05-07T15:45:00Z',
-        durationSec: 52
+        id: 'podcast-lab-youtube-shorts',
+        name: 'YouTube Shorts',
+        status: 'active',
+        statusMessage: 'Synced 30 minutes ago',
+        dailyUploadTarget: 1,
+        readyVideos: 6,
+        upcomingUploads: [
+          {
+            id: 'pl-1',
+            title: 'Episode 48 — Best Moments',
+            videoUrl: SAMPLE_VIDEO_OCEAN,
+            scheduledFor: '2025-05-04T22:00:00Z',
+            durationSec: 68
+          },
+          {
+            id: 'pl-2',
+            title: 'Listener Questions Deep Dive',
+            videoUrl: SAMPLE_VIDEO_CITY,
+            scheduledFor: '2025-05-06T09:30:00Z',
+            durationSec: 72
+          }
+        ]
       }
     ]
   }

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -18,16 +18,22 @@ export interface AccountUpload {
   durationSec: number
 }
 
-export interface AccountProfile {
+export interface AccountPlatform {
   id: string
-  displayName: string
-  platform: string
-  initials: string
+  name: string
   status: AccountStatus
   statusMessage?: string
   dailyUploadTarget: number
   readyVideos: number
   upcomingUploads: AccountUpload[]
+}
+
+export interface AccountProfile {
+  id: string
+  displayName: string
+  initials: string
+  description?: string
+  platforms: AccountPlatform[]
 }
 
 export type SearchBridge = {


### PR DESCRIPTION
## Summary
- restructure account types and mock data to support multiple platform connections per account
- enhance the profile page to surface aggregate metrics in collapsed panels and add segmented tabs for platform-specific details
- update profile tests for the new multi-platform experience and collapsed summaries

## Testing
- npm run test
- pytest *(fails: ImportError: libGL.so.1 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9efa43b748323be510a5705aacfd7