### PR TITLE
Refine collapsed account layout on profile page

### DIFF
--- a/desktop/src/renderer/src/pages/Profile.tsx
+++ b/desktop/src/renderer/src/pages/Profile.tsx
@@ -199,6 +199,24 @@ const Profile: FC<ProfileProps> = ({ registerSearch }) => {
               : null
           const detailsId = `profile-${account.id}`
           const hasPlatforms = account.platforms.length > 0
+          const summaryStats = [
+            {
+              id: 'readyVideos',
+              value: totals.readyVideos.toLocaleString(),
+              label: 'ready videos'
+            },
+            {
+              id: 'dailyTarget',
+              value: totals.dailyUploadTarget.toLocaleString(),
+              label: 'daily target'
+            },
+            {
+              id: 'coverage',
+              value: coverage.daysLabel,
+              label: 'coverage',
+              title: coverage.description
+            }
+          ] as const
 
           return (
             <article
@@ -206,16 +224,28 @@ const Profile: FC<ProfileProps> = ({ registerSearch }) => {
               data-testid={`account-panel-${account.id}`}
               className="rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_85%,transparent)] p-6 shadow-sm"
             >
-              <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-                <div className="flex flex-1 items-start gap-4">
+              <div
+                className={`flex flex-col gap-4 md:flex-row md:justify-between ${
+                  isCollapsed ? 'md:items-center' : 'md:items-start'
+                }`}
+              >
+                <div className={`flex flex-1 gap-4 ${isCollapsed ? 'items-center' : 'items-start'}`}>
                   <div
                     className={`flex h-14 w-14 items-center justify-center rounded-full border-2 font-semibold ${statusStyles.avatar}`}
                     aria-hidden="true"
                   >
                     {account.initials}
                   </div>
-                  <div className="flex flex-1 flex-col gap-3">
-                    <div className="flex flex-wrap items-center gap-2">
+                  <div
+                    className={`flex flex-1 flex-col gap-3 ${
+                      isCollapsed ? 'md:flex-row md:flex-wrap md:items-center md:gap-6' : ''
+                    }`}
+                  >
+                    <div
+                      className={`flex flex-wrap items-center gap-2 ${
+                        isCollapsed ? 'md:gap-3' : ''
+                      }`}
+                    >
                       <h2 className="text-lg font-semibold text-[var(--fg)]">{account.displayName}</h2>
                       <span
                         className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusStyles.badge}`}
@@ -223,43 +253,63 @@ const Profile: FC<ProfileProps> = ({ registerSearch }) => {
                       >
                         {statusStyles.label}
                       </span>
-                    </div>
-                    {hasPlatforms ? (
-                      <ul
-                        className="flex flex-wrap items-center gap-2 pl-0"
-                        data-testid={`account-platform-tags-${account.id}`}
-                        aria-label={`${account.displayName} connected platforms`}
-                      >
-                        {account.platforms.map((platform) => {
-                          const platformStyles = STATUS_STYLES[platform.status]
-                          return (
-                            <li
-                              key={platform.id}
-                              className="list-none"
-                              title={`${platform.name}: ${platformStyles.helper}`}
-                            >
-                              <span
-                                className={`flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${platformStyles.badge}`}
-                              >
+                      {hasPlatforms ? (
+                        <ul
+                          className={`flex flex-wrap items-center gap-2 pl-0 ${
+                            isCollapsed ? '' : 'hidden'
+                          }`}
+                          data-testid={`account-platform-tags-${account.id}`}
+                          aria-label={`${account.displayName} connected platforms`}
+                          hidden={!isCollapsed}
+                        >
+                          {account.platforms.map((platform) => {
+                            const platformStyles = STATUS_STYLES[platform.status]
+                            return (
+                              <li key={platform.id} className="list-none" title={`${platform.name}: ${platformStyles.helper}`}>
                                 <span
-                                  className={`h-2 w-2 rounded-full ${platformStyles.dot}`}
-                                  aria-hidden="true"
-                                />
-                                {platform.name}
-                              </span>
-                            </li>
-                          )
-                        })}
-                      </ul>
-                    ) : (
-                      <p className="text-xs text-[var(--muted)]">No platforms connected yet.</p>
-                    )}
+                                  className={`flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${platformStyles.badge}`}
+                                >
+                                  <span
+                                    className={`h-2 w-2 rounded-full ${platformStyles.dot}`}
+                                    aria-hidden="true"
+                                  />
+                                  {platform.name}
+                                </span>
+                              </li>
+                            )
+                          })}
+                        </ul>
+                      ) : (
+                        <p
+                          className={`text-xs text-[var(--muted)] ${
+                            isCollapsed ? 'md:inline' : ''
+                          }`}
+                        >
+                          No platforms connected yet.
+                        </p>
+                      )}
+                    </div>
+                    {isCollapsed ? (
+                      <div
+                        className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-[var(--muted)]"
+                        data-testid={`account-summary-${account.id}`}
+                      >
+                        {summaryStats.map((item) => (
+                          <span key={item.id} title={item.title}>
+                            <span className="text-lg font-semibold text-[var(--fg)]">{item.value}</span>{' '}
+                            {item.label}
+                          </span>
+                        ))}
+                      </div>
+                    ) : null}
                   </div>
                 </div>
                 <button
                   type="button"
                   onClick={() => toggleAccount(account.id)}
-                  className="self-start rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-[var(--fg)] transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+                  className={`self-start rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-[var(--fg)] transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] ${
+                    isCollapsed ? 'md:self-center' : ''
+                  }`}
                   aria-expanded={!isCollapsed}
                   aria-controls={detailsId}
                   aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${account.displayName} details`}
@@ -268,31 +318,7 @@ const Profile: FC<ProfileProps> = ({ registerSearch }) => {
                 </button>
               </div>
 
-              {isCollapsed ? (
-                <div
-                  className="mt-6 rounded-xl border border-white/5 bg-[color:color-mix(in_srgb,var(--card)_96%,transparent)] p-4"
-                  data-testid={`account-summary-${account.id}`}
-                >
-                  <div className="flex flex-wrap items-center gap-x-6 gap-y-3 text-sm text-[var(--muted)]">
-                    <span>
-                      <span className="text-lg font-semibold text-[var(--fg)]">
-                        {totals.readyVideos.toLocaleString()}
-                      </span>{' '}
-                      ready videos
-                    </span>
-                    <span>
-                      <span className="text-lg font-semibold text-[var(--fg)]">
-                        {totals.dailyUploadTarget.toLocaleString()}
-                      </span>{' '}
-                      daily target
-                    </span>
-                    <span title={coverage.description}>
-                      <span className="text-lg font-semibold text-[var(--fg)]">{coverage.daysLabel}</span>{' '}
-                      coverage
-                    </span>
-                  </div>
-                </div>
-              ) : (
+              {isCollapsed ? null : (
                 <dl className="mt-6 grid gap-4 sm:grid-cols-3" data-testid={`account-summary-${account.id}`}>
                   <div className="rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_90%,transparent)] p-4">
                     <dt className="text-xs font-medium uppercase tracking-wide text-[var(--muted)]">


### PR DESCRIPTION
## Summary
- hide platform tags while an account is expanded and realign the collapsed header content for a single-row layout
- surface collapsed account metrics inline with the header so totals and status share the same row
- adjust the collapse toggle alignment to stay centered when an account is collapsed

## Testing
- npm test
- pytest *(fails: missing libGL.so.1 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2cfd11d08323b507ef8b95af28cc