### PR TITLE
Add account selection requirement to video processing form

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -22,7 +22,9 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
     steps: createInitialPipelineSteps(),
     isProcessing: false,
     clips: [],
-    selectedClipId: null
+    selectedClipId: null,
+    selectedAccountId: null,
+    accountError: null
   }))
   const [isDark, setIsDark] = useState(() => {
     if (typeof document === 'undefined') {

--- a/desktop/src/renderer/src/tests/home.test.tsx
+++ b/desktop/src/renderer/src/tests/home.test.tsx
@@ -1,0 +1,78 @@
+import '@testing-library/jest-dom/vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Home from '../pages/Home'
+import { createInitialPipelineSteps } from '../data/pipeline'
+import type { HomePipelineState } from '../types'
+import { PROFILE_ACCOUNTS } from '../mock/accounts'
+
+const { startPipelineJobMock, subscribeToPipelineEventsMock } = vi.hoisted(() => ({
+  startPipelineJobMock: vi.fn(),
+  subscribeToPipelineEventsMock: vi.fn()
+}))
+
+vi.mock('../services/pipelineApi', async () => {
+  const actual = await vi.importActual<typeof import('../services/pipelineApi')>(
+    '../services/pipelineApi'
+  )
+  return {
+    ...actual,
+    startPipelineJob: startPipelineJobMock,
+    subscribeToPipelineEvents: subscribeToPipelineEventsMock
+  }
+})
+
+const createInitialState = (overrides: Partial<HomePipelineState> = {}): HomePipelineState => ({
+  videoUrl: '',
+  urlError: null,
+  pipelineError: null,
+  steps: createInitialPipelineSteps(),
+  isProcessing: false,
+  clips: [],
+  selectedClipId: null,
+  selectedAccountId: null,
+  accountError: null,
+  ...overrides
+})
+
+describe('Home account selection', () => {
+  beforeEach(() => {
+    startPipelineJobMock.mockReset()
+    startPipelineJobMock.mockResolvedValue({ jobId: 'test-job' })
+    subscribeToPipelineEventsMock.mockReset()
+    subscribeToPipelineEventsMock.mockReturnValue(vi.fn())
+  })
+
+  it('requires an account selection before starting processing', () => {
+    render(
+      <Home registerSearch={() => {}} initialState={createInitialState()} onStateChange={() => {}} />
+    )
+
+    fireEvent.change(screen.getByLabelText(/video url/i), {
+      target: { value: 'https://www.youtube.com/watch?v=example' }
+    })
+    const [startButton] = screen.getAllByRole('button', { name: /start processing/i })
+    fireEvent.click(startButton)
+
+    expect(screen.getByText(/select an account to start processing/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/account/i)).toHaveAttribute('aria-invalid', 'true')
+    expect(startPipelineJobMock).not.toHaveBeenCalled()
+  })
+
+  it('passes the selected account when starting the pipeline job', async () => {
+    render(
+      <Home registerSearch={() => {}} initialState={createInitialState()} onStateChange={() => {}} />
+    )
+
+    const videoUrl = 'https://www.youtube.com/watch?v=another'
+    const accountId = PROFILE_ACCOUNTS[0]?.id ?? 'account-1'
+
+    fireEvent.change(screen.getByLabelText(/account/i), { target: { value: accountId } })
+    fireEvent.change(screen.getByLabelText(/video url/i), { target: { value: videoUrl } })
+    const [startButton] = screen.getAllByRole('button', { name: /start processing/i })
+    fireEvent.click(startButton)
+
+    await waitFor(() => expect(startPipelineJobMock).toHaveBeenCalledTimes(1))
+    expect(startPipelineJobMock).toHaveBeenCalledWith({ account: accountId, url: videoUrl })
+  })
+})

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -76,6 +76,8 @@ export interface HomePipelineState {
   isProcessing: boolean
   clips: Clip[]
   selectedClipId: string | null
+  selectedAccountId: string | null
+  accountError: string | null
 }
 
 export type PipelineEventType =


### PR DESCRIPTION
## Summary
- add a required account dropdown to the Home video processing form and use the selected account when starting jobs
- extend the Home pipeline state with account selection metadata and validation messaging
- cover the new workflow with tests that mock the pipeline API

## Testing
- npm test
- pytest *(fails: missing fastapi and libGL dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6e2bf8fc8323ae4c837980faf235