### PR TITLE
Enhance clip metadata display and enable playback

### DIFF
--- a/desktop/src/renderer/index.html
+++ b/desktop/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:* http://[::1]:* ws://[::1]:*"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:* http://[::1]:* ws://[::1]:*; media-src 'self' data: blob: http://127.0.0.1:* http://localhost:* http://[::1]:* https://127.0.0.1:* https://localhost:* https://[::1]:*"
     />
   </head>
 

--- a/desktop/src/renderer/src/lib/clipMetadata.ts
+++ b/desktop/src/renderer/src/lib/clipMetadata.ts
@@ -1,0 +1,69 @@
+export interface ClipTimestampMetadata {
+  timestampUrl: string | null
+  timestampSeconds: number | null
+}
+
+const FULL_VIDEO_PATTERN = /^full video:\s*(https?:\/\/\S+)/i
+
+const TIME_COMPONENT_PATTERN = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)(?:s)?)?$/
+
+const extractSecondsFromComponent = (value: string | null): number | null => {
+  if (!value) {
+    return null
+  }
+
+  const normalised = value.trim().toLowerCase()
+  if (normalised.length === 0) {
+    return null
+  }
+
+  if (/^\d+$/.test(normalised)) {
+    return Number.parseInt(normalised, 10)
+  }
+
+  if (TIME_COMPONENT_PATTERN.test(normalised)) {
+    const [, hoursPart, minutesPart, secondsPart] = normalised.match(TIME_COMPONENT_PATTERN) ?? []
+    const hours = hoursPart ? Number.parseInt(hoursPart, 10) : 0
+    const minutes = minutesPart ? Number.parseInt(minutesPart, 10) : 0
+    const seconds = secondsPart ? Number.parseInt(secondsPart, 10) : 0
+    return hours * 3600 + minutes * 60 + seconds
+  }
+
+  const digits = normalised.match(/\d+/)
+  return digits ? Number.parseInt(digits[0], 10) : null
+}
+
+const parseTimestampFromUrl = (rawUrl: string): number | null => {
+  try {
+    const url = new URL(rawUrl)
+    const searchValue = url.searchParams.get('t') ?? url.searchParams.get('start')
+    const hashMatch = url.hash.match(/t=([^&]+)/)
+    const candidate = searchValue ?? (hashMatch ? hashMatch[1] : null)
+    return extractSecondsFromComponent(candidate)
+  } catch (error) {
+    return null
+  }
+}
+
+export const parseClipTimestamp = (description: string | null | undefined): ClipTimestampMetadata => {
+  if (!description) {
+    return { timestampUrl: null, timestampSeconds: null }
+  }
+
+  const lines = description.split(/\r?\n/)
+  for (const line of lines) {
+    const match = line.match(FULL_VIDEO_PATTERN)
+    if (match) {
+      const url = match[1].trim()
+      if (url.length === 0) {
+        break
+      }
+      return {
+        timestampUrl: url,
+        timestampSeconds: parseTimestampFromUrl(url)
+      }
+    }
+  }
+
+  return { timestampUrl: null, timestampSeconds: null }
+}

--- a/desktop/src/renderer/src/pages/Clip.tsx
+++ b/desktop/src/renderer/src/pages/Clip.tsx
@@ -64,35 +64,103 @@ const ClipPage: FC<ClipPageProps> = ({ registerSearch }) => {
             Your browser does not support the video tag.
           </video>
         </div>
-        <div className="flex w-full max-w-xl flex-col gap-5">
-          <h1 className="text-2xl font-semibold text-[var(--fg)]">{clip.title}</h1>
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-[var(--muted)]">
-            <span className="font-medium text-[var(--fg)]">{clip.channel}</span>
-            {clip.views !== null ? <span>• {formatViews(clip.views)} views</span> : null}
-            {clip.sourcePublishedAt ? <span>• {timeAgo(clip.sourcePublishedAt)}</span> : null}
+        <div className="flex w-full max-w-xl flex-col gap-6">
+          <div className="space-y-4">
+            {clip.quote ? (
+              <h1 className="text-3xl font-semibold text-[var(--fg)] leading-tight">
+                “{clip.quote}”
+              </h1>
+            ) : clip.title ? (
+              <h1 className="text-3xl font-semibold text-[var(--fg)] leading-tight">{clip.title}</h1>
+            ) : (
+              <h1 className="text-3xl font-semibold text-[var(--fg)] leading-tight">Highlight clip</h1>
+            )}
+            {clip.reason ? (
+              <div className="space-y-1">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_80%,transparent)]">
+                  Reason
+                </span>
+                <p className="rounded-lg border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_60%,transparent)] p-3 text-sm leading-relaxed text-[var(--fg)]/80">
+                  {clip.reason}
+                </p>
+              </div>
+            ) : null}
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-[var(--muted)]">
+              <span className="font-medium text-[var(--fg)]">{clip.channel}</span>
+              {clip.views !== null ? <span>• {formatViews(clip.views)} views</span> : null}
+              {clip.sourcePublishedAt ? <span>• {timeAgo(clip.sourcePublishedAt)}</span> : null}
+            </div>
           </div>
-          <dl className="grid gap-3 text-sm text-[var(--muted)] sm:grid-cols-[auto_1fr]">
+          <dl className="grid gap-3 rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-4 text-sm text-[var(--muted)] sm:grid-cols-[auto_1fr]">
             <dt className="font-medium text-[var(--fg)]">Duration</dt>
             <dd>{formatDuration(clip.durationSec)}</dd>
-            <dt className="font-medium text-[var(--fg)]">Uploaded</dt>
-            <dd>{new Date(clip.createdAt).toLocaleString(undefined, {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric'
-            })}</dd>
+            {clip.rating !== null && clip.rating !== undefined ? (
+              <>
+                <dt className="font-medium text-[var(--fg)]">Score</dt>
+                <dd className="text-[var(--fg)]">{clip.rating.toFixed(1).replace(/\.0$/, '')}</dd>
+              </>
+            ) : null}
+            <dt className="font-medium text-[var(--fg)]">Clip created</dt>
+            <dd>
+              {new Date(clip.createdAt).toLocaleString(undefined, {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit'
+              })}
+            </dd>
+            <dt className="font-medium text-[var(--fg)]">Source uploaded</dt>
+            <dd>
+              {clip.sourcePublishedAt
+                ? new Date(clip.sourcePublishedAt).toLocaleString(undefined, {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: '2-digit'
+                  })
+                : 'Unknown'}
+            </dd>
+            {clip.timestampSeconds !== null && clip.timestampSeconds !== undefined ? (
+              <>
+                <dt className="font-medium text-[var(--fg)]">Starts at</dt>
+                <dd>{formatDuration(clip.timestampSeconds)}</dd>
+              </>
+            ) : null}
           </dl>
-          <a
-            href={clip.sourceUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex w-fit items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-[var(--fg)] transition hover:border-[var(--ring)] hover:text-white"
-          >
-            View full video
-          </a>
-          <ClipDescription
-            text={clip.description}
-            className="text-sm leading-relaxed text-[var(--muted)]"
-          />
+          <div className="flex flex-wrap items-center gap-3">
+            <a
+              href={clip.sourceUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex w-fit items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-[var(--fg)] transition hover:border-[var(--ring)] hover:text-white"
+            >
+              View full video
+            </a>
+            {clip.timestampUrl ? (
+              <a
+                href={clip.timestampUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex w-fit items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-[var(--fg)] transition hover:border-[var(--ring)] hover:text-white"
+              >
+                Jump to
+                <span className="font-semibold text-white">
+                  {clip.timestampSeconds !== null && clip.timestampSeconds !== undefined
+                    ? formatDuration(clip.timestampSeconds)
+                    : 'timestamp'}
+                </span>
+              </a>
+            ) : null}
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-lg font-semibold text-[var(--fg)]">Description</h2>
+            <ClipDescription
+              text={clip.description}
+              className="text-sm leading-relaxed text-[var(--muted)]"
+            />
+          </div>
           <div className="rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-4 text-sm text-[var(--muted)]">
             Bookmark this clip to revisit the key moment or share it with your team for quick inspiration.
           </div>

--- a/desktop/src/renderer/src/tests/clipMetadata.test.ts
+++ b/desktop/src/renderer/src/tests/clipMetadata.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { parseClipTimestamp } from '../lib/clipMetadata'
+
+describe('parseClipTimestamp', () => {
+  it('extracts timestamp url and seconds from a description', () => {
+    const description = `Full video: https://www.youtube.com/watch?v=abc123&t=125s\nCredit: Creator\n`
+    const result = parseClipTimestamp(description)
+    expect(result.timestampUrl).toBe('https://www.youtube.com/watch?v=abc123&t=125s')
+    expect(result.timestampSeconds).toBe(125)
+  })
+
+  it('supports minute and second notation', () => {
+    const description = 'Full video: https://youtu.be/example?t=1m30s\nMade by Atropos'
+    const result = parseClipTimestamp(description)
+    expect(result.timestampUrl).toBe('https://youtu.be/example?t=1m30s')
+    expect(result.timestampSeconds).toBe(90)
+  })
+
+  it('returns null metadata when no timestamp link is present', () => {
+    const description = 'Watch the full video on our channel!'
+    const result = parseClipTimestamp(description)
+    expect(result.timestampUrl).toBeNull()
+    expect(result.timestampSeconds).toBeNull()
+  })
+})

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -14,6 +14,8 @@ export interface Clip {
   rating?: number | null
   quote?: string | null
   reason?: string | null
+  timestampUrl?: string | null
+  timestampSeconds?: number | null
 }
 
 export type SupportedPlatform = 'tiktok' | 'youtube' | 'instagram'


### PR DESCRIPTION
## Summary
- allow the renderer to load clip media from the local API host so videos can play
- parse timestamp links from clip descriptions and store them on clip state
- refresh the clip preview and detail layouts to highlight quote, reason, score, dates, and provide a jump-to-timestamp link
- add unit coverage for the new clip timestamp parser

## Testing
- `npm test -- --run`
- `pytest` *(fails: requires YouTube client secrets and external proxy access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7f6cfc248323bdec0d0371584f4e