### PR TITLE
Load account clips and tighten progress layout

### DIFF
--- a/desktop/src/main/clipLibrary.ts
+++ b/desktop/src/main/clipLibrary.ts
@@ -1,0 +1,407 @@
+import { promises as fs } from 'fs'
+import type { Stats } from 'fs'
+import path from 'path'
+import { pathToFileURL } from 'url'
+import type { Clip } from '../renderer/src/types'
+
+interface CandidateEntry {
+  start: number
+  end: number
+  rating?: number | null
+  quote?: string | null
+  reason?: string | null
+}
+
+interface CandidateMetadata {
+  quote: string | null
+  reason: string | null
+  rating: number | null
+}
+
+interface DescriptionMetadata {
+  description: string
+  sourceUrl: string | null
+  timestampUrl: string | null
+  timestampSeconds: number | null
+  channel: string | null
+}
+
+interface ProjectMetadata {
+  title: string
+  publishedAt: string | null
+}
+
+const CLIP_FILENAME_PATTERN = /^clip_(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)(?:_r(\d+(?:\.\d+)?))?$/i
+const FULL_VIDEO_PATTERN = /^full video:\s*(https?:\/\/\S+)/i
+const CREDIT_PATTERN = /^credit:\s*(.+)$/i
+const DATE_SUFFIX_PATTERN = /_(\d{8})$/
+const TIME_COMPONENT_PATTERN = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)(?:s)?)?$/
+
+const CANDIDATE_MANIFEST_FILES = [
+  'render_queue.json',
+  'candidates.json',
+  'candidates_top.json',
+  'candidates_all.json'
+]
+
+let cachedOutRoot: string | null | undefined
+
+const roundTwo = (value: number): number => Math.round(value * 100) / 100
+
+const formatCandidateKey = (start: number, end: number): string => {
+  return `${roundTwo(start).toFixed(2)}-${roundTwo(end).toFixed(2)}`
+}
+
+const parseClipFilename = (stem: string) => {
+  const match = stem.match(CLIP_FILENAME_PATTERN)
+  if (!match) {
+    return null
+  }
+  const [, startRaw, endRaw, ratingRaw] = match
+  const start = Number.parseFloat(startRaw)
+  const end = Number.parseFloat(endRaw)
+  const rating = ratingRaw ? Number.parseFloat(ratingRaw) : null
+  if (Number.isNaN(start) || Number.isNaN(end)) {
+    return null
+  }
+  return { start, end, rating }
+}
+
+const parseTimestampToken = (token: string | null): number | null => {
+  if (!token) {
+    return null
+  }
+  const value = token.trim().toLowerCase()
+  if (!value) {
+    return null
+  }
+  if (/^\d+$/.test(value)) {
+    return Number.parseInt(value, 10)
+  }
+  if (TIME_COMPONENT_PATTERN.test(value)) {
+    const [, hoursPart, minutesPart, secondsPart] = value.match(TIME_COMPONENT_PATTERN) ?? []
+    const hours = hoursPart ? Number.parseInt(hoursPart, 10) : 0
+    const minutes = minutesPart ? Number.parseInt(minutesPart, 10) : 0
+    const seconds = secondsPart ? Number.parseInt(secondsPart, 10) : 0
+    return hours * 3600 + minutes * 60 + seconds
+  }
+  const digits = value.match(/\d+/)
+  return digits ? Number.parseInt(digits[0] ?? '', 10) : null
+}
+
+const parseTimestampFromUrl = (rawUrl: string): number | null => {
+  try {
+    const url = new URL(rawUrl)
+    const searchValue = url.searchParams.get('t') ?? url.searchParams.get('start')
+    const hashMatch = url.hash.match(/t=([^&]+)/)
+    const token = searchValue ?? (hashMatch ? hashMatch[1] : null)
+    return parseTimestampToken(token)
+  } catch (error) {
+    return null
+  }
+}
+
+const parseDescriptionMetadata = (description: string): DescriptionMetadata => {
+  const lines = description.split(/\r?\n/)
+  let timestampUrl: string | null = null
+  let channel: string | null = null
+
+  for (const line of lines) {
+    const fullMatch = line.match(FULL_VIDEO_PATTERN)
+    if (fullMatch) {
+      const candidate = fullMatch[1]?.trim()
+      if (candidate) {
+        timestampUrl = candidate
+      }
+    }
+    const creditMatch = line.match(CREDIT_PATTERN)
+    if (creditMatch && !channel) {
+      const credit = creditMatch[1]?.trim()
+      if (credit) {
+        channel = credit
+      }
+    }
+  }
+
+  let sourceUrl: string | null = null
+  if (timestampUrl) {
+    try {
+      const url = new URL(timestampUrl)
+      url.searchParams.delete('t')
+      url.searchParams.delete('start')
+      url.hash = ''
+      sourceUrl = url.toString()
+    } catch (error) {
+      sourceUrl = timestampUrl
+    }
+  }
+
+  const timestampSeconds = timestampUrl ? parseTimestampFromUrl(timestampUrl) : null
+
+  return {
+    description,
+    sourceUrl,
+    timestampUrl,
+    timestampSeconds,
+    channel
+  }
+}
+
+const parseDateToken = (token: string): string | null => {
+  if (token.length !== 8 || !/^\d{8}$/.test(token)) {
+    return null
+  }
+  const year = Number.parseInt(token.slice(0, 4), 10)
+  const month = Number.parseInt(token.slice(4, 6), 10)
+  const day = Number.parseInt(token.slice(6, 8), 10)
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+    return null
+  }
+  try {
+    const iso = new Date(Date.UTC(year, month - 1, day)).toISOString()
+    return iso
+  } catch (error) {
+    return null
+  }
+}
+
+const inferProjectMetadata = (projectName: string): ProjectMetadata => {
+  let titleSource = projectName
+  let publishedAt: string | null = null
+  const dateMatch = projectName.match(DATE_SUFFIX_PATTERN)
+  if (dateMatch) {
+    const raw = dateMatch[1] ?? ''
+    const iso = parseDateToken(raw)
+    if (iso) {
+      publishedAt = iso
+      titleSource = projectName.slice(0, -(raw.length + 1))
+    }
+  }
+  const normalised = titleSource.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim()
+  const title = normalised.length > 0 ? normalised : projectName
+  return { title, publishedAt }
+}
+
+const resolveOutRoot = async (): Promise<string | null> => {
+  if (cachedOutRoot !== undefined) {
+    return cachedOutRoot
+  }
+
+  const configured = process.env.OUT_ROOT
+  if (configured && configured.length > 0) {
+    cachedOutRoot = configured
+    return cachedOutRoot
+  }
+
+  const candidates = [
+    path.resolve(process.cwd(), 'server', 'out'),
+    path.resolve(process.cwd(), '..', 'server', 'out')
+  ]
+
+  for (const candidate of candidates) {
+    try {
+      const stats = await fs.stat(candidate)
+      if (stats.isDirectory()) {
+        cachedOutRoot = candidate
+        return candidate
+      }
+    } catch (error) {
+      // Ignore candidates that do not exist
+    }
+  }
+
+  cachedOutRoot = candidates[0] ?? null
+  return cachedOutRoot
+}
+
+const loadCandidateMetadata = async (projectDir: string): Promise<Map<string, CandidateMetadata>> => {
+  const map = new Map<string, CandidateMetadata>()
+
+  for (const manifestName of CANDIDATE_MANIFEST_FILES) {
+    const manifestPath = path.join(projectDir, manifestName)
+    let payload: CandidateEntry[]
+    try {
+      const content = await fs.readFile(manifestPath, 'utf-8')
+      const data = JSON.parse(content) as CandidateEntry[]
+      if (!Array.isArray(data)) {
+        continue
+      }
+      payload = data
+    } catch (error) {
+      continue
+    }
+
+    for (const entry of payload) {
+      if (typeof entry?.start !== 'number' || typeof entry?.end !== 'number') {
+        continue
+      }
+      const key = formatCandidateKey(entry.start, entry.end)
+      const existing = map.get(key)
+      const quote = typeof entry.quote === 'string' && entry.quote.trim().length > 0 ? entry.quote.trim() : null
+      const reason = typeof entry.reason === 'string' && entry.reason.trim().length > 0 ? entry.reason.trim() : null
+      const rating = typeof entry.rating === 'number' ? entry.rating : null
+      if (!existing) {
+        map.set(key, { quote, reason, rating })
+      } else {
+        if (!existing.quote && quote) {
+          existing.quote = quote
+        }
+        if (!existing.reason && reason) {
+          existing.reason = reason
+        }
+        if (existing.rating === null && rating !== null) {
+          existing.rating = rating
+        }
+      }
+    }
+  }
+
+  return map
+}
+
+const buildClip = async (
+  filePath: string,
+  projectInfo: ProjectMetadata,
+  candidateMap: Map<string, CandidateMetadata>
+): Promise<Clip | null> => {
+  const fileName = path.basename(filePath)
+  const stem = fileName.replace(/\.mp4$/i, '')
+  const parsed = parseClipFilename(stem)
+  if (!parsed) {
+    return null
+  }
+
+  const { start, end, rating } = parsed
+  const candidateKey = formatCandidateKey(start, end)
+  const candidate = candidateMap.get(candidateKey)
+  const descriptionPath = path.join(path.dirname(filePath), `${stem}.txt`)
+
+  let descriptionText = ''
+  try {
+    descriptionText = (await fs.readFile(descriptionPath, 'utf-8')).trim()
+  } catch (error) {
+    descriptionText = ''
+  }
+
+  const descriptionMetadata = parseDescriptionMetadata(descriptionText)
+  const stats = await fs.stat(filePath)
+  const duration = Math.max(0, end - start)
+
+  let title = candidate?.quote ?? ''
+  if (!title) {
+    title = projectInfo.title ? `${projectInfo.title}` : stem
+  }
+
+  const playbackUrl = pathToFileURL(filePath).toString()
+
+  let timestampUrl = descriptionMetadata.timestampUrl
+  if (!timestampUrl && descriptionMetadata.sourceUrl && Number.isFinite(start)) {
+    try {
+      const url = new URL(descriptionMetadata.sourceUrl)
+      url.searchParams.set('t', Math.round(start).toString())
+      timestampUrl = url.toString()
+    } catch (error) {
+      timestampUrl = null
+    }
+  }
+
+  const clip: Clip = {
+    id: stem,
+    title,
+    channel: descriptionMetadata.channel ?? 'Unknown channel',
+    views: null,
+    createdAt: stats.mtime.toISOString(),
+    durationSec: duration,
+    thumbnail: null,
+    playbackUrl,
+    description: descriptionText,
+    sourceUrl: descriptionMetadata.sourceUrl ?? descriptionMetadata.timestampUrl ?? '',
+    sourceTitle: projectInfo.title,
+    sourcePublishedAt: projectInfo.publishedAt,
+    rating: candidate?.rating ?? rating,
+    quote: candidate?.quote ?? null,
+    reason: candidate?.reason ?? null,
+    timestampUrl,
+    timestampSeconds: descriptionMetadata.timestampSeconds ?? (Number.isFinite(start) ? start : null)
+  }
+
+  return clip
+}
+
+export const listAccountClips = async (accountId: string | null): Promise<Clip[]> => {
+  const base = await resolveOutRoot()
+  if (!base) {
+    return []
+  }
+
+  const accountDir = accountId ? path.join(base, accountId) : base
+  try {
+    const stats = await fs.stat(accountDir)
+    if (!stats.isDirectory()) {
+      return []
+    }
+  } catch (error) {
+    return []
+  }
+
+  let entries: string[] = []
+  try {
+    entries = await fs.readdir(accountDir)
+  } catch (error) {
+    return []
+  }
+
+  const clips: Clip[] = []
+  for (const entry of entries) {
+    const projectDir = path.join(accountDir, entry)
+    let projectStats: Stats
+    try {
+      projectStats = await fs.stat(projectDir)
+    } catch (error) {
+      continue
+    }
+    if (!projectStats.isDirectory()) {
+      continue
+    }
+
+    const shortsDir = path.join(projectDir, 'shorts')
+    try {
+      const shortsStats = await fs.stat(shortsDir)
+      if (!shortsStats.isDirectory()) {
+        continue
+      }
+    } catch (error) {
+      continue
+    }
+
+    const projectInfo = inferProjectMetadata(entry)
+    const candidateMap = await loadCandidateMetadata(projectDir)
+
+    let shortFiles: string[] = []
+    try {
+      shortFiles = await fs.readdir(shortsDir)
+    } catch (error) {
+      continue
+    }
+
+    for (const fileName of shortFiles) {
+      if (!fileName.toLowerCase().endsWith('.mp4')) {
+        continue
+      }
+      const filePath = path.join(shortsDir, fileName)
+      try {
+        const clip = await buildClip(filePath, projectInfo, candidateMap)
+        if (clip) {
+          clips.push(clip)
+        }
+      } catch (error) {
+        // Skip clips that cannot be parsed
+      }
+    }
+  }
+
+  clips.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+  return clips
+}
+
+export default listAccountClips

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, shell, BrowserWindow, ipcMain } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
+import { listAccountClips } from './clipLibrary'
 
 function createWindow(): void {
   // Create the browser window.
@@ -53,6 +54,14 @@ app.whenReady().then(() => {
 
   // IPC test
   ipcMain.on('ping', () => console.log('pong'))
+  ipcMain.handle('clips:list', async (_event, accountId: string | null) => {
+    try {
+      return await listAccountClips(accountId)
+    } catch (error) {
+      console.error('Failed to list clips', error)
+      return []
+    }
+  })
 
   createWindow()
 

--- a/desktop/src/preload/index.d.ts
+++ b/desktop/src/preload/index.d.ts
@@ -1,8 +1,13 @@
 import { ElectronAPI } from '@electron-toolkit/preload'
+import type { Clip } from '../renderer/src/types'
+
+export interface ClipLibraryApi {
+  listAccountClips(accountId: string | null): Promise<Clip[]>
+}
 
 declare global {
   interface Window {
     electron: ElectronAPI
-    api: unknown
+    api: ClipLibraryApi
   }
 }

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,8 +1,13 @@
-import { contextBridge } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 
 // Custom APIs for renderer
-const api = {}
+type Clip = import('../renderer/src/types').Clip
+
+const api = {
+  listAccountClips: (accountId: string | null): Promise<Clip[]> =>
+    ipcRenderer.invoke('clips:list', accountId)
+}
 
 // Use `contextBridge` APIs to expose Electron APIs to
 // renderer only if context isolation is enabled, otherwise

--- a/desktop/src/renderer/src/components/PipelineProgress.tsx
+++ b/desktop/src/renderer/src/components/PipelineProgress.tsx
@@ -288,11 +288,11 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
             : 'bg-white/40'
 
     return (
-      <li key={substep.id} className="w-full">
+      <li key={substep.id} className="h-full">
         <button
           type="button"
           onClick={() => toggleSubstep(step.id, substep.id)}
-          className="group flex min-w-0 max-w-full flex-col gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-left text-[11px] transition hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          className="group flex h-full w-full min-w-0 max-w-full flex-col gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-left text-[11px] transition hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
           aria-expanded={false}
           aria-controls={`substep-${step.id}-${substep.id}`}
         >
@@ -487,7 +487,7 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
                   {activeSubstep ? <span>Active: {activeSubstep.title}</span> : null}
                 </div>
                 <ul
-                  className="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-4"
+                  className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-4"
                   data-testid={`substeps-${step.id}`}
                 >
                   {step.substeps.map((substep, subIndex) => renderSubstep(step, substep, subIndex))}

--- a/desktop/src/renderer/src/components/PipelineProgress.tsx
+++ b/desktop/src/renderer/src/components/PipelineProgress.tsx
@@ -288,11 +288,11 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
             : 'bg-white/40'
 
     return (
-      <li key={substep.id}>
+      <li key={substep.id} className="flex max-w-full">
         <button
           type="button"
           onClick={() => toggleSubstep(step.id, substep.id)}
-          className="group flex w-full flex-col gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-left text-[11px] transition hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          className="group flex min-w-0 max-w-full flex-col gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-left text-[11px] transition hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
           aria-expanded={false}
           aria-controls={`substep-${step.id}-${substep.id}`}
         >
@@ -339,7 +339,7 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
     return (
       <li
         key={substep.id}
-        className="rounded-xl border border-white/10 bg-white/5"
+        className="flex w-full flex-col rounded-xl border border-white/10 bg-white/5"
       >
         <button
           type="button"
@@ -486,7 +486,7 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
                   <span>Substeps</span>
                   {activeSubstep ? <span>Active: {activeSubstep.title}</span> : null}
                 </div>
-                <ul className="flex flex-col gap-2" data-testid={`substeps-${step.id}`}>
+                <ul className="flex flex-wrap gap-2" data-testid={`substeps-${step.id}`}>
                   {step.substeps.map((substep, subIndex) => renderSubstep(step, substep, subIndex))}
                 </ul>
               </div>

--- a/desktop/src/renderer/src/components/PipelineProgress.tsx
+++ b/desktop/src/renderer/src/components/PipelineProgress.tsx
@@ -288,7 +288,7 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
             : 'bg-white/40'
 
     return (
-      <li key={substep.id} className="flex max-w-full">
+      <li key={substep.id} className="w-full">
         <button
           type="button"
           onClick={() => toggleSubstep(step.id, substep.id)}
@@ -339,7 +339,7 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
     return (
       <li
         key={substep.id}
-        className="flex w-full flex-col rounded-xl border border-white/10 bg-white/5"
+        className="col-span-full flex w-full flex-col rounded-xl border border-white/10 bg-white/5"
       >
         <button
           type="button"
@@ -486,7 +486,10 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
                   <span>Substeps</span>
                   {activeSubstep ? <span>Active: {activeSubstep.title}</span> : null}
                 </div>
-                <ul className="flex flex-wrap gap-2" data-testid={`substeps-${step.id}`}>
+                <ul
+                  className="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-4"
+                  data-testid={`substeps-${step.id}`}
+                >
                   {step.substeps.map((substep, subIndex) => renderSubstep(step, substep, subIndex))}
                 </ul>
               </div>

--- a/desktop/src/renderer/src/components/PipelineProgress.tsx
+++ b/desktop/src/renderer/src/components/PipelineProgress.tsx
@@ -238,21 +238,32 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
   )
 }
 
-const renderStepProgress = (step: PipelineStep) => {
-    if (step.status !== 'running') {
-      return null
-    }
-    const percent = Math.round(clamp01(step.progress) * 100)
-    const etaLabel = step.etaSeconds !== null ? formatEta(step.etaSeconds) : null
+  const renderStepProgress = (step: PipelineStep) => {
+    const percent = Math.round(computeStepProgressValue(step) * 100)
+    const etaLabel =
+      step.status === 'running' && step.etaSeconds !== null ? formatEta(step.etaSeconds) : null
+    const progressColor =
+      step.status === 'failed'
+        ? 'bg-rose-500'
+        : step.status === 'completed'
+          ? 'bg-emerald-500'
+          : step.status === 'running'
+            ? 'bg-sky-400'
+            : 'bg-white/30'
+
     return (
-      <div className="flex flex-col gap-2">
-        <div className="flex items-center justify-between text-xs">
+      <div
+        className="flex flex-col gap-1.5"
+        data-testid={`step-progress-${step.id}`}
+        aria-label={`${step.title} progress`}
+      >
+        <div className="flex items-center justify-between text-[11px] text-[var(--muted)]">
           <span className="font-semibold text-[var(--fg)]">{percent}%</span>
-          {etaLabel ? <span className="text-[var(--muted)]">{etaLabel}</span> : null}
+          {etaLabel ? <span>{etaLabel}</span> : null}
         </div>
-        <div className="h-2 w-full overflow-hidden rounded-full bg-white/10">
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10">
           <div
-            className="h-full rounded-full bg-sky-400 transition-all duration-500 ease-out"
+            className={`h-full rounded-full transition-all duration-500 ease-out ${progressColor}`}
             style={{ width: `${percent}%` }}
           />
         </div>
@@ -281,24 +292,20 @@ const renderStepProgress = (step: PipelineStep) => {
         <button
           type="button"
           onClick={() => toggleSubstep(step.id, substep.id)}
-          className="group flex w-full flex-col gap-1 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-left text-xs transition hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          className="group flex w-full flex-col gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-left text-[11px] transition hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
           aria-expanded={false}
           aria-controls={`substep-${step.id}-${substep.id}`}
         >
-          <div className="flex items-center gap-2 text-[10px] uppercase tracking-wide text-[var(--muted)]">
+          <div className="flex items-center gap-2 text-[9px] uppercase tracking-[0.16em] text-[var(--muted)]">
             <span className={`h-1.5 w-1.5 rounded-full ${indicatorClasses[substep.status]}`} aria-hidden="true" />
             <span className="font-semibold">Substep {getSubstepLabel(index)}</span>
             <span className="ml-auto">{statusLabels[substep.status]}</span>
           </div>
-          <div className="flex items-center gap-2 text-sm">
+          <div className="flex items-center gap-2 text-[11px]">
             <span className="truncate font-semibold text-[var(--fg)]">{substep.title}</span>
-            <span className="ml-auto flex items-center gap-2 text-[11px] text-[var(--muted)]">
+            <span className="ml-auto flex items-center gap-1 text-[10px] text-[var(--muted)]">
               <span className="font-semibold text-[var(--fg)]">{percent}%</span>
-              {substep.status === 'running' && etaLabel ? (
-                <span className="text-[10px] uppercase tracking-wide text-[var(--muted)] normal-case">
-                  {etaLabel}
-                </span>
-              ) : null}
+              {substep.status === 'running' && etaLabel ? <span>{etaLabel}</span> : null}
             </span>
           </div>
           <div className="h-1 w-full overflow-hidden rounded-full bg-white/10">
@@ -406,7 +413,7 @@ const renderStepProgress = (step: PipelineStep) => {
     isActive: boolean,
     isExpanded: boolean
   ) => {
-    const percent = Math.round(clamp01(step.progress) * 100)
+    const percent = Math.round(computeStepProgressValue(step) * 100)
     const etaLabel = step.etaSeconds !== null && step.status === 'running' ? formatEta(step.etaSeconds) : null
     const headerProgressLabel = step.status === 'running'
       ? `${percent}%${etaLabel ? ` • ${etaLabel}` : ''}`
@@ -501,22 +508,22 @@ const renderStepProgress = (step: PipelineStep) => {
         <button
           type="button"
           onClick={() => toggleStep(step.id)}
-          className={`group flex w-full flex-col gap-1 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-left text-xs transition hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 ${
+          className={`group flex w-full flex-col gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-left text-[11px] transition hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 ${
             step.status === 'completed' ? 'opacity-85' : ''
           }`}
           aria-expanded={false}
           aria-controls={`step-${step.id}-details`}
         >
-          <div className="flex items-center gap-2 text-[10px] uppercase tracking-wide text-[var(--muted)]">
+          <div className="flex items-center gap-2 text-[9px] uppercase tracking-[0.16em] text-[var(--muted)]">
             <span className={`h-2 w-2 rounded-full ${indicatorClasses[step.status]}`} aria-hidden="true" />
             <span className="font-semibold">Step {index + 1}</span>
             <span className="ml-auto">{statusLabels[step.status]}</span>
           </div>
-          <div className="flex items-center gap-2 text-sm">
+          <div className="flex items-center gap-2 text-[11px]">
             <span className="truncate font-semibold text-[var(--fg)]">{step.title}</span>
             {clipBadge}
           </div>
-          <div className="flex items-center justify-between text-[11px] text-[var(--muted)]">
+          <div className="flex items-center justify-between text-[10px] text-[var(--muted)]">
             <span className="font-semibold text-[var(--fg)]">{percent}%</span>
             {etaLabel ? <span>{etaLabel}</span> : null}
           </div>

--- a/desktop/src/renderer/src/components/PipelineProgress.tsx
+++ b/desktop/src/renderer/src/components/PipelineProgress.tsx
@@ -344,14 +344,14 @@ const PipelineProgress: FC<PipelineProgressProps> = ({ steps, className }) => {
     return (
       <li
         key={step.id}
-        className={`col-span-full rounded-2xl border ${
-          isActive ? 'border-sky-400 shadow-[0_20px_40px_-24px_rgba(56,189,248,0.4)]' : 'border-white/10'
+        className={`col-span-full rounded-xl border ${
+          isActive ? 'border-sky-400 shadow-[0_14px_28px_-20px_rgba(56,189,248,0.35)]' : 'border-white/10'
         } bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)]`}
       >
         <button
           type="button"
           onClick={() => toggleStep(step.id)}
-          className="flex w-full items-center justify-between gap-3 px-4 py-4 text-left sm:px-5"
+          className="flex w-full items-center justify-between gap-3 px-3 py-3 text-left sm:px-4"
           aria-expanded={showDetails}
           aria-controls={`step-${step.id}-details`}
         >
@@ -383,7 +383,7 @@ const PipelineProgress: FC<PipelineProgressProps> = ({ steps, className }) => {
         {showDetails ? (
           <div
             id={`step-${step.id}-details`}
-            className="flex flex-col gap-3 border-t border-white/5 px-4 pb-4 pt-3 text-sm text-[var(--muted)] sm:px-5"
+            className="flex flex-col gap-2 border-t border-white/5 px-3 pb-3 pt-2 text-sm text-[var(--muted)] sm:px-4"
           >
             <p>{step.description}</p>
             {renderStepProgress(step)}

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -894,7 +894,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
             </div>
             {selectedClip ? (
               <div className="mt-4 flex flex-col gap-4">
-                <div className="aspect-video w-full overflow-hidden rounded-xl bg-black/60">
+                <div className="flex w-full justify-center overflow-hidden rounded-xl bg-black/80 p-2">
                   <video
                     key={selectedClip.id}
                     src={selectedClip.playbackUrl}
@@ -902,7 +902,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
                     controls
                     playsInline
                     preload="metadata"
-                    className="h-full w-full object-cover"
+                    className="h-full w-full max-w-sm object-contain"
                   >
                     Your browser does not support the video tag.
                   </video>

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -22,6 +22,7 @@ import {
   subscribeToPipelineEvents,
   type PipelineEventMessage
 } from '../services/pipelineApi'
+import { listAccountClips } from '../services/clipLibrary'
 import { parseClipTimestamp } from '../lib/clipMetadata'
 import { formatDuration, formatViews, timeAgo } from '../lib/format'
 import type { AccountSummary, HomePipelineState, SearchBridge } from '../types'
@@ -93,6 +94,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
   const runStepRef = useRef<(index: number) => void>(() => {})
   const connectionCleanupRef = useRef<(() => void) | null>(null)
   const activeJobIdRef = useRef<string | null>(initialState.activeJobId ?? null)
+  const lastLoadedAccountRef = useRef<string | null>(null)
 
   const isMockBackend = BACKEND_MODE === 'mock'
 
@@ -564,6 +566,78 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
     activeJobIdRef.current = activeJobId
   }, [activeJobId])
 
+  const loadAccountClips = useCallback(
+    async (
+      accountId: string,
+      options?: { force?: boolean; canceledRef?: { current: boolean } }
+    ) => {
+      if (!accountId) {
+        return
+      }
+      if (!options?.force && lastLoadedAccountRef.current === accountId) {
+        return
+      }
+
+      try {
+        const existingClips = await listAccountClips(accountId)
+        if (options?.canceledRef?.current) {
+          return
+        }
+        let didUpdate = false
+        updateState((prev) => {
+          if (prev.selectedAccountId !== accountId) {
+            return prev
+          }
+          const mergedMap = new Map<string, typeof existingClips[number]>()
+          for (const clip of existingClips) {
+            mergedMap.set(clip.id, clip)
+          }
+          for (const clip of prev.clips) {
+            mergedMap.set(clip.id, clip)
+          }
+          const mergedClips = Array.from(mergedMap.values())
+          mergedClips.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+          const hasSelection = mergedClips.some((clip) => clip.id === prev.selectedClipId)
+          didUpdate = true
+          return {
+            ...prev,
+            clips: mergedClips,
+            selectedClipId: hasSelection ? prev.selectedClipId : mergedClips[0]?.id ?? null
+          }
+        })
+        if (didUpdate) {
+          lastLoadedAccountRef.current = accountId
+        }
+      } catch (error) {
+        if (!options?.canceledRef?.current) {
+          console.error('Failed to load clips for account', accountId, error)
+        }
+      }
+    },
+    [updateState]
+  )
+
+  useEffect(() => {
+    let isActive = true
+    const accountId = selectedAccountId
+
+    if (!accountId) {
+      lastLoadedAccountRef.current = null
+      updateState((prev) => ({ ...prev, clips: [], selectedClipId: null }))
+      return () => {
+        isActive = false
+      }
+    }
+
+    const canceledRef = { current: false }
+    void loadAccountClips(accountId, { canceledRef })
+
+    return () => {
+      canceledRef.current = true
+      isActive = false
+    }
+  }, [loadAccountClips, selectedAccountId, updateState])
+
   const handleUrlChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const value = event.target.value
@@ -579,13 +653,22 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
   const handleAccountChange = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {
       const value = event.target.value
+      if (value.length === 0) {
+        lastLoadedAccountRef.current = null
+      }
       updateState((prev) => ({
         ...prev,
         selectedAccountId: value.length > 0 ? value : null,
-        accountError: prev.accountError ? null : prev.accountError
+        accountError: prev.accountError ? null : prev.accountError,
+        clips: [],
+        selectedClipId: null
       }))
+      if (value.length > 0) {
+        lastLoadedAccountRef.current = null
+        void loadAccountClips(value, { force: true })
+      }
     },
-    [updateState]
+    [loadAccountClips, updateState]
   )
 
   const handleSubmit = useCallback(
@@ -768,7 +851,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
                 <button
                   type="submit"
                   disabled={!videoUrl.trim() || isProcessing}
-                  className="rounded-lg border border-transparent bg-[var(--ring)] px-4 py-2 text-sm font-semibold text-white transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)] disabled:cursor-not-allowed disabled:opacity-60"
+                  className="rounded-lg border border-transparent bg-[var(--ring)] px-3 py-2 text-xs font-semibold leading-tight text-white transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)] disabled:cursor-not-allowed disabled:opacity-60 sm:px-4 sm:text-sm whitespace-nowrap"
                 >
                   {isProcessing ? 'Processing…' : 'Start processing'}
                 </button>
@@ -776,7 +859,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
                   type="button"
                   onClick={handleReset}
                   disabled={!hasProgress && clips.length === 0 && !pipelineError}
-                  className="rounded-lg border border-white/10 px-4 py-2 text-sm font-medium text-[var(--fg)] transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-lg border border-white/10 px-3 py-2 text-xs font-medium leading-tight text-[var(--fg)] transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50 sm:px-4 sm:text-sm whitespace-nowrap"
                 >
                   Reset
                 </button>
@@ -796,11 +879,11 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
             {urlError ? <p className="text-xs font-medium text-rose-400">{urlError}</p> : null}
           </form>
 
-          <div className="rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-6 shadow-[0_20px_40px_-24px_rgba(15,23,42,0.6)]">
+          <div className="rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-4 shadow-[0_14px_28px_-22px_rgba(15,23,42,0.55)]">
             <PipelineProgress steps={steps} />
           </div>
 
-          <div className="rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-6 shadow-[0_20px_40px_-24px_rgba(15,23,42,0.6)]">
+          <div className="rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-4 shadow-[0_14px_28px_-22px_rgba(15,23,42,0.55)]">
             <div className="flex flex-col gap-1">
               <h3 className="text-lg font-semibold text-[var(--fg)]">Selected clip</h3>
               <p className="text-sm text-[var(--muted)]">

--- a/desktop/src/renderer/src/services/clipLibrary.ts
+++ b/desktop/src/renderer/src/services/clipLibrary.ts
@@ -1,0 +1,25 @@
+import type { Clip } from '../types'
+
+const isClipArray = (value: unknown): value is Clip[] => {
+  return Array.isArray(value) && value.every((item) => typeof item === 'object' && item !== null && 'id' in item)
+}
+
+export const listAccountClips = async (accountId: string | null): Promise<Clip[]> => {
+  if (!accountId) {
+    return []
+  }
+
+  try {
+    const api = window.api
+    if (api && typeof api.listAccountClips === 'function') {
+      const clips = await api.listAccountClips(accountId)
+      return isClipArray(clips) ? clips : []
+    }
+  } catch (error) {
+    console.error('Unable to load clips from library', error)
+  }
+
+  return []
+}
+
+export default listAccountClips

--- a/desktop/src/renderer/src/tests/home.test.tsx
+++ b/desktop/src/renderer/src/tests/home.test.tsx
@@ -3,12 +3,21 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Home from '../pages/Home'
 import { createInitialPipelineSteps } from '../data/pipeline'
-import type { AccountPlatformConnection, AccountSummary, HomePipelineState } from '../types'
+import type {
+  AccountPlatformConnection,
+  AccountSummary,
+  Clip,
+  HomePipelineState
+} from '../types'
 import type { PipelineEventHandlers } from '../services/pipelineApi'
 
 const { startPipelineJobMock, subscribeToPipelineEventsMock } = vi.hoisted(() => ({
   startPipelineJobMock: vi.fn(),
   subscribeToPipelineEventsMock: vi.fn()
+}))
+
+const { listAccountClipsMock } = vi.hoisted(() => ({
+  listAccountClipsMock: vi.fn<[_accountId: string | null], Promise<Clip[]>>()
 }))
 
 vi.mock('../services/pipelineApi', async () => {
@@ -21,6 +30,10 @@ vi.mock('../services/pipelineApi', async () => {
     subscribeToPipelineEvents: subscribeToPipelineEventsMock
   }
 })
+
+vi.mock('../services/clipLibrary', () => ({
+  listAccountClips: listAccountClipsMock
+}))
 
 const createPlatform = (
   overrides: Partial<AccountPlatformConnection> = {}
@@ -86,6 +99,11 @@ const createInitialState = (overrides: Partial<HomePipelineState> = {}): HomePip
   ...overrides
 })
 
+beforeEach(() => {
+  listAccountClipsMock.mockReset()
+  listAccountClipsMock.mockResolvedValue([])
+})
+
 describe('Home account selection', () => {
   beforeEach(() => {
     startPipelineJobMock.mockReset()
@@ -135,8 +153,53 @@ describe('Home account selection', () => {
     expect(form).not.toBeNull()
     fireEvent.submit(form as HTMLFormElement)
 
-    await waitFor(() => expect(startPipelineJobMock).toHaveBeenCalledTimes(1))
-    expect(startPipelineJobMock).toHaveBeenCalledWith({ account: accountId, url: videoUrl })
+  await waitFor(() => expect(startPipelineJobMock).toHaveBeenCalledTimes(1))
+  expect(startPipelineJobMock).toHaveBeenCalledWith({ account: accountId, url: videoUrl })
+  })
+
+  it('loads existing clips for the selected account', async () => {
+    const existingClip: Clip = {
+      id: 'clip-001',
+      title: 'Existing Clip',
+      channel: 'Creator',
+      views: null,
+      createdAt: new Date('2024-05-01T12:00:00Z').toISOString(),
+      durationSec: 42,
+      thumbnail: null,
+      playbackUrl: 'file:///clip.mp4',
+      description: 'Full video: https://example.com\nCredit: Creator',
+      sourceUrl: 'https://example.com',
+      sourceTitle: 'Example Video',
+      sourcePublishedAt: null,
+      rating: 4.5,
+      quote: 'Existing Clip',
+      reason: null,
+      timestampUrl: 'https://example.com?t=12',
+      timestampSeconds: 12
+    }
+
+    listAccountClipsMock.mockResolvedValueOnce([existingClip])
+
+    render(
+      <Home
+        registerSearch={() => {}}
+        initialState={createInitialState()}
+        onStateChange={() => {}}
+        accounts={[AVAILABLE_ACCOUNT]}
+      />
+    )
+
+    const select = screen.getByLabelText(/account/i)
+    await act(async () => {
+      fireEvent.change(select, { target: { value: AVAILABLE_ACCOUNT.id } })
+    })
+    await act(async () => {})
+    expect((select as HTMLSelectElement).value).toBe(AVAILABLE_ACCOUNT.id)
+
+    await waitFor(() => expect(listAccountClipsMock).toHaveBeenCalled())
+    expect(await screen.findByText(existingClip.title)).toBeInTheDocument()
+    const [[accountUsed]] = listAccountClipsMock.mock.calls
+    expect(accountUsed).toBe(AVAILABLE_ACCOUNT.id)
   })
 
   it('filters the account dropdown to active accounts with active platforms', () => {

--- a/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
+++ b/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
@@ -104,6 +104,7 @@ describe('PipelineProgress', () => {
 
     expect(within(stepList).getByText(/clips 2\/5/i)).toBeInTheDocument()
     const substepsList = within(stepList).getByTestId('substeps-produce-clips')
+    expect(substepsList).toHaveClass('grid')
     expect(within(substepsList).getByText(/generate subtitles/i)).toBeInTheDocument()
     expect(within(substepsList).getByText(/substep a/i)).toBeInTheDocument()
     expect(within(stepList).getAllByText(/40%/i).length).toBeGreaterThan(0)

--- a/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
+++ b/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
@@ -100,6 +100,7 @@ describe('PipelineProgress', () => {
     expect(within(stepList).getByText(/clips 2\/5/i)).toBeInTheDocument()
     const substepsList = within(stepList).getByTestId('substeps-produce-clips')
     expect(within(substepsList).getByText(/generate subtitles/i)).toBeInTheDocument()
+    expect(within(substepsList).getByText(/substep a/i)).toBeInTheDocument()
     expect(within(stepList).getAllByText(/40%/i).length).toBeGreaterThan(0)
     expect(within(stepList).getAllByText(/≈1m remaining/i).length).toBeGreaterThan(0)
   })

--- a/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
+++ b/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
@@ -101,6 +101,6 @@ describe('PipelineProgress', () => {
     const substepsList = within(stepList).getByTestId('substeps-produce-clips')
     expect(within(substepsList).getByText(/generate subtitles/i)).toBeInTheDocument()
     expect(within(stepList).getAllByText(/40%/i).length).toBeGreaterThan(0)
-    expect(within(stepList).getByText(/≈1m remaining/i)).toBeInTheDocument()
+    expect(within(stepList).getAllByText(/≈1m remaining/i).length).toBeGreaterThan(0)
   })
 })

--- a/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
+++ b/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest'
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import PipelineProgress from '../components/PipelineProgress'
 import type { PipelineStep } from '../types'
@@ -97,11 +97,18 @@ describe('PipelineProgress', () => {
     const transcriptButton = within(stepList).getByRole('button', { name: /generate transcript/i })
     expect(within(transcriptButton).getByText(/0%/i)).toBeInTheDocument()
 
+    fireEvent.click(transcriptButton)
+    expect(transcriptButton).toHaveAttribute('aria-expanded', 'true')
+    const transcriptProgress = within(stepList).getByTestId('step-progress-transcript')
+    expect(within(transcriptProgress).getByText('0%')).toBeInTheDocument()
+
     expect(within(stepList).getByText(/clips 2\/5/i)).toBeInTheDocument()
     const substepsList = within(stepList).getByTestId('substeps-produce-clips')
     expect(within(substepsList).getByText(/generate subtitles/i)).toBeInTheDocument()
     expect(within(substepsList).getByText(/substep a/i)).toBeInTheDocument()
     expect(within(stepList).getAllByText(/40%/i).length).toBeGreaterThan(0)
     expect(within(stepList).getAllByText(/≈1m remaining/i).length).toBeGreaterThan(0)
+    const produceStepProgress = within(stepList).getByTestId('step-progress-produce-clips')
+    expect(produceStepProgress).toHaveAccessibleName(/produce final clips progress/i)
   })
 })


### PR DESCRIPTION
## Summary
- load existing clips for the selected account by wiring a renderer service through the preload bridge into a new filesystem-backed clip library module
- update the home page to fetch clips on account changes, reset state when deselecting an account, and shrink the processing controls/button sizing
- tweak pipeline progress cards to reduce padding and shadow weight so the layout feels denser

## Testing
- pytest *(fails: missing httpx dependency and libGL.so.1 for cv2)*
- npm test -- --run


------
https://chatgpt.com/codex/tasks/task_e_68cdc0fb97508323af48ece56fb89865