### PR TITLE
Refine clip production progress tracking

### DIFF
--- a/desktop/src/renderer/src/tests/home.test.tsx
+++ b/desktop/src/renderer/src/tests/home.test.tsx
@@ -356,6 +356,8 @@ describe('Home pipeline events', () => {
     const [stepsList] = screen.getAllByTestId('pipeline-steps')
     expect(within(stepsList).getByText(/produce final clips/i)).toBeInTheDocument()
     expect(within(stepsList).getByText(/clips 2\/5/i)).toBeInTheDocument()
+    expect(within(stepsList).getByText(/clip 2\/5/i)).toBeInTheDocument()
+    expect(within(stepsList).getByText(/2\/5 clips done/i)).toBeInTheDocument()
     expect(within(stepsList).getAllByText(/40%/i).length).toBeGreaterThan(0)
   })
 })

--- a/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
+++ b/desktop/src/renderer/src/tests/pipelineprogress.test.tsx
@@ -34,7 +34,10 @@ const mockSteps: PipelineStep[] = [
         description: 'Trim the source video according to clip timing.',
         status: 'completed',
         progress: 1,
-        etaSeconds: null
+        etaSeconds: null,
+        completedClips: 2,
+        totalClips: 5,
+        activeClipIndex: null
       },
       {
         id: 'generate-subtitles',
@@ -42,7 +45,10 @@ const mockSteps: PipelineStep[] = [
         description: 'Produce subtitles for each clip.',
         status: 'running',
         progress: 0.4,
-        etaSeconds: 60
+        etaSeconds: 60,
+        completedClips: 1,
+        totalClips: 5,
+        activeClipIndex: 2
       },
       {
         id: 'render-verticals',
@@ -50,7 +56,10 @@ const mockSteps: PipelineStep[] = [
         description: 'Render the vertical video output.',
         status: 'pending',
         progress: 0,
-        etaSeconds: null
+        etaSeconds: null,
+        completedClips: 0,
+        totalClips: 5,
+        activeClipIndex: null
       }
     ]
   },
@@ -83,7 +92,7 @@ describe('PipelineProgress', () => {
     expect(screen.getByText(/currently running: produce final clips/i)).toBeInTheDocument()
 
     const progressbar = screen.getByRole('progressbar')
-    expect(progressbar).toHaveAttribute('aria-valuenow', '50')
+    expect(progressbar).toHaveAttribute('aria-valuenow', '41')
 
     const stepList = screen.getByTestId('pipeline-steps')
     expect(stepList).toHaveClass('grid')
@@ -108,6 +117,8 @@ describe('PipelineProgress', () => {
     expect(within(substepsList).getByText(/generate subtitles/i)).toBeInTheDocument()
     expect(within(substepsList).getByText(/substep a/i)).toBeInTheDocument()
     expect(within(stepList).getAllByText(/40%/i).length).toBeGreaterThan(0)
+    expect(within(stepList).getByText(/clip 2\/5/i)).toBeInTheDocument()
+    expect(within(stepList).getByText(/2\/5 clips done/i)).toBeInTheDocument()
     expect(within(stepList).getAllByText(/≈1m remaining/i).length).toBeGreaterThan(0)
     const produceStepProgress = within(stepList).getByTestId('step-progress-produce-clips')
     expect(produceStepProgress).toHaveAccessibleName(/produce final clips progress/i)

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -91,6 +91,9 @@ export interface PipelineSubstep extends PipelineSubstepDefinition {
   status: PipelineStepStatus
   progress: number
   etaSeconds: number | null
+  completedClips: number
+  totalClips: number
+  activeClipIndex: number | null
 }
 
 export interface PipelineStep extends PipelineStepDefinition {


### PR DESCRIPTION
## Summary
- track clip-level metadata for pipeline substeps and compute step 7 progress from substep completions
- auto-collapse completed pipeline items and surface clip position/count labels in the progress UI
- parse clip-indexed events and update tests to reflect the refined progress behaviour

## Testing
- `npx vitest run --config src/renderer/vitest.config.ts`
- `pytest` *(fails: missing httpx/cv2 system deps)*

------
https://chatgpt.com/codex/tasks/task_e_68ce33f5f4a88323b743fc10b71613f5