### PR TITLE
Add library page with account filters and shared selection

### DIFF
--- a/desktop/src/renderer/src/components/ClipCard.tsx
+++ b/desktop/src/renderer/src/components/ClipCard.tsx
@@ -25,12 +25,22 @@ const ClipCard: FC<ClipCardProps> = ({ clip, onClick }) => {
       className="group relative flex cursor-pointer flex-col overflow-hidden rounded-xl bg-[var(--card)] shadow-sm transition hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
     >
       <div className="relative aspect-video w-full overflow-hidden">
-        <img
-          src={clip.thumbnail}
-          alt={clip.title}
-          loading="lazy"
-          className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
-        />
+        {clip.thumbnail ? (
+          <img
+            src={clip.thumbnail}
+            alt={clip.title}
+            loading="lazy"
+            className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+          />
+        ) : (
+          <video
+            src={clip.playbackUrl}
+            muted
+            playsInline
+            preload="metadata"
+            className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+          />
+        )}
         <span className="absolute bottom-2 right-2 rounded-md bg-black/70 px-2 py-0.5 text-xs font-medium text-white">
           {formatDuration(clip.durationSec)}
         </span>

--- a/desktop/src/renderer/src/components/ClipDrawer.tsx
+++ b/desktop/src/renderer/src/components/ClipDrawer.tsx
@@ -28,7 +28,7 @@ const ClipDrawer: FC<ClipDrawerProps> = ({ clips, selectedClipId, onSelect, onRe
         onClick={() => setIsOpen((current) => !current)}
         className="flex items-center justify-between gap-3 px-4 py-3 text-left text-sm font-medium text-[var(--fg)] transition hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
       >
-        <span>Clip library</span>
+        <span>Clips from source</span>
         <span className="flex items-center gap-2 text-xs text-[var(--muted)]">
           {clips.length} {clips.length === 1 ? 'clip' : 'clips'}
           <svg

--- a/desktop/src/renderer/src/config/backend.ts
+++ b/desktop/src/renderer/src/config/backend.ts
@@ -117,6 +117,11 @@ export const buildAccountUrl = (accountId: string): string => {
   return url.toString()
 }
 
+export const buildAccountClipsUrl = (accountId: string): string => {
+  const url = new URL(`/api/accounts/${encodeURIComponent(accountId)}/clips`, getApiBaseUrl())
+  return url.toString()
+}
+
 export const buildAccountPlatformUrl = (accountId: string): string => {
   const url = new URL(`/api/accounts/${encodeURIComponent(accountId)}/platforms`, getApiBaseUrl())
   return url.toString()

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -49,7 +49,11 @@ type HomeProps = {
 }
 
 const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, accounts }) => {
-  const [state, setState] = useState<HomePipelineState>(() => initialState)
+  const [state, setState] = useState<HomePipelineState>(initialState)
+
+  useEffect(() => {
+    setState(initialState)
+  }, [initialState])
 
   const updateState = useCallback(
     (updater: (prev: HomePipelineState) => HomePipelineState) =>

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -494,6 +494,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
         const reason = typeof data.reason === 'string' ? data.reason : null
         const rating = typeof data.rating === 'number' ? data.rating : null
         const playbackClipId = typeof data.clip_id === 'string' ? data.clip_id : null
+        const accountIdValue = typeof data.account === 'string' ? data.account : null
 
         if (!clipId || !description || !createdAt || !playbackClipId || !durationValue || !sourceUrl) {
           return
@@ -520,7 +521,8 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
             reason,
             rating,
             timestampUrl,
-            timestampSeconds
+            timestampSeconds,
+            accountId: accountIdValue
           }
 
           const existingIndex = prev.clips.findIndex((clip) => clip.id === clipId)

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -489,6 +489,9 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
         const sourceTitle = typeof data.source_title === 'string' ? data.source_title : title
         const sourcePublishedAt =
           typeof data.source_published_at === 'string' ? data.source_published_at : null
+        const videoId = typeof data.video_id === 'string' && data.video_id.length > 0 ? data.video_id : clipId
+        const videoTitle =
+          typeof data.video_title === 'string' && data.video_title.length > 0 ? data.video_title : sourceTitle
         const views = typeof data.views === 'number' ? data.views : null
         const quote = typeof data.quote === 'string' ? data.quote : null
         const reason = typeof data.reason === 'string' ? data.reason : null
@@ -517,6 +520,8 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
             sourceUrl,
             sourceTitle,
             sourcePublishedAt,
+            videoId,
+            videoTitle,
             quote,
             reason,
             rating,

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -22,7 +22,6 @@ import {
   subscribeToPipelineEvents,
   type PipelineEventMessage
 } from '../services/pipelineApi'
-import { listAccountClips } from '../services/clipLibrary'
 import { parseClipTimestamp } from '../lib/clipMetadata'
 import { formatDuration, formatViews, timeAgo } from '../lib/format'
 import type { AccountSummary, HomePipelineState, SearchBridge } from '../types'
@@ -98,7 +97,6 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
   const runStepRef = useRef<(index: number) => void>(() => {})
   const connectionCleanupRef = useRef<(() => void) | null>(null)
   const activeJobIdRef = useRef<string | null>(initialState.activeJobId ?? null)
-  const lastLoadedAccountRef = useRef<string | null>(null)
 
   const isMockBackend = BACKEND_MODE === 'mock'
 
@@ -653,78 +651,6 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
     activeJobIdRef.current = activeJobId
   }, [activeJobId])
 
-  const loadAccountClips = useCallback(
-    async (
-      accountId: string,
-      options?: { force?: boolean; canceledRef?: { current: boolean } }
-    ) => {
-      if (!accountId) {
-        return
-      }
-      if (!options?.force && lastLoadedAccountRef.current === accountId) {
-        return
-      }
-
-      try {
-        const existingClips = await listAccountClips(accountId)
-        if (options?.canceledRef?.current) {
-          return
-        }
-        let didUpdate = false
-        updateState((prev) => {
-          if (prev.selectedAccountId !== accountId) {
-            return prev
-          }
-          const mergedMap = new Map<string, typeof existingClips[number]>()
-          for (const clip of existingClips) {
-            mergedMap.set(clip.id, clip)
-          }
-          for (const clip of prev.clips) {
-            mergedMap.set(clip.id, clip)
-          }
-          const mergedClips = Array.from(mergedMap.values())
-          mergedClips.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
-          const hasSelection = mergedClips.some((clip) => clip.id === prev.selectedClipId)
-          didUpdate = true
-          return {
-            ...prev,
-            clips: mergedClips,
-            selectedClipId: hasSelection ? prev.selectedClipId : mergedClips[0]?.id ?? null
-          }
-        })
-        if (didUpdate) {
-          lastLoadedAccountRef.current = accountId
-        }
-      } catch (error) {
-        if (!options?.canceledRef?.current) {
-          console.error('Failed to load clips for account', accountId, error)
-        }
-      }
-    },
-    [updateState]
-  )
-
-  useEffect(() => {
-    let isActive = true
-    const accountId = selectedAccountId
-
-    if (!accountId) {
-      lastLoadedAccountRef.current = null
-      updateState((prev) => ({ ...prev, clips: [], selectedClipId: null }))
-      return () => {
-        isActive = false
-      }
-    }
-
-    const canceledRef = { current: false }
-    void loadAccountClips(accountId, { canceledRef })
-
-    return () => {
-      canceledRef.current = true
-      isActive = false
-    }
-  }, [loadAccountClips, selectedAccountId, updateState])
-
   const handleUrlChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const value = event.target.value
@@ -740,9 +666,6 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
   const handleAccountChange = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {
       const value = event.target.value
-      if (value.length === 0) {
-        lastLoadedAccountRef.current = null
-      }
       updateState((prev) => ({
         ...prev,
         selectedAccountId: value.length > 0 ? value : null,
@@ -750,12 +673,8 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
         clips: [],
         selectedClipId: null
       }))
-      if (value.length > 0) {
-        lastLoadedAccountRef.current = null
-        void loadAccountClips(value, { force: true })
-      }
     },
-    [loadAccountClips, updateState]
+    [updateState]
   )
 
   const handleSubmit = useCallback(

--- a/desktop/src/renderer/src/pages/Library.tsx
+++ b/desktop/src/renderer/src/pages/Library.tsx
@@ -1,0 +1,301 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import type { ChangeEvent, FC } from 'react'
+import { useNavigate } from 'react-router-dom'
+import ClipCard from '../components/ClipCard'
+import { listAccountClips } from '../services/clipLibrary'
+import type { AccountSummary, Clip, SearchBridge } from '../types'
+
+const ALL_ACCOUNTS_VALUE = 'all'
+
+const isAccountAvailable = (account: AccountSummary): boolean =>
+  account.active && account.platforms.some((platform) => platform.active)
+
+type LibraryProps = {
+  registerSearch: (bridge: SearchBridge | null) => void
+  accounts: AccountSummary[]
+  selectedAccountId: string | null
+  onSelectAccount: (accountId: string | null) => void
+  isLoadingAccounts: boolean
+}
+
+const Library: FC<LibraryProps> = ({
+  registerSearch,
+  accounts,
+  selectedAccountId,
+  onSelectAccount,
+  isLoadingAccounts
+}) => {
+  const [clips, setClips] = useState<Clip[]>([])
+  const [isLoadingClips, setIsLoadingClips] = useState(false)
+  const [clipsError, setClipsError] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
+  const queryRef = useRef('')
+  const navigate = useNavigate()
+
+  const availableAccounts = useMemo(
+    () => accounts.filter((account) => isAccountAvailable(account)),
+    [accounts]
+  )
+  const hasMultipleAccounts = availableAccounts.length > 1
+  const hasAccounts = availableAccounts.length > 0
+
+  useEffect(() => {
+    if (!hasAccounts) {
+      if (clips.length > 0) {
+        setClips([])
+      }
+      return
+    }
+
+    if (selectedAccountId) {
+      const exists = availableAccounts.some((account) => account.id === selectedAccountId)
+      if (!exists) {
+        onSelectAccount(hasMultipleAccounts ? null : availableAccounts[0].id)
+      }
+      return
+    }
+
+    if (!hasMultipleAccounts && availableAccounts[0]) {
+      onSelectAccount(availableAccounts[0].id)
+    }
+  }, [
+    availableAccounts,
+    hasAccounts,
+    hasMultipleAccounts,
+    onSelectAccount,
+    selectedAccountId,
+    clips.length
+  ])
+
+  const handleQueryChange = useCallback((value: string) => {
+    queryRef.current = value
+    setQuery(value)
+  }, [])
+
+  const handleQueryClear = useCallback(() => {
+    queryRef.current = ''
+    setQuery('')
+  }, [])
+
+  useEffect(() => {
+    const bridge: SearchBridge = {
+      getQuery: () => queryRef.current,
+      onQueryChange: handleQueryChange,
+      clear: handleQueryClear
+    }
+
+    registerSearch(bridge)
+    return () => registerSearch(null)
+  }, [handleQueryChange, handleQueryClear, registerSearch])
+
+  const targetAccountIds = useMemo(() => {
+    if (!hasAccounts) {
+      return []
+    }
+
+    if (selectedAccountId) {
+      return [selectedAccountId]
+    }
+
+    if (hasMultipleAccounts) {
+      return availableAccounts.map((account) => account.id)
+    }
+
+    return availableAccounts[0] ? [availableAccounts[0].id] : []
+  }, [availableAccounts, hasAccounts, hasMultipleAccounts, selectedAccountId])
+
+  useEffect(() => {
+    let isActive = true
+
+    if (targetAccountIds.length === 0) {
+      setClips([])
+      setClipsError(null)
+      setIsLoadingClips(false)
+      return () => {
+        isActive = false
+      }
+    }
+
+    const loadClips = async (): Promise<void> => {
+      setIsLoadingClips(true)
+      setClipsError(null)
+      try {
+        const results = await Promise.all(
+          targetAccountIds.map(async (accountId) => {
+            try {
+              return await listAccountClips(accountId)
+            } catch (error) {
+              console.error('Failed to load clips for account', accountId, error)
+              return [] as Clip[]
+            }
+          })
+        )
+
+        if (!isActive) {
+          return
+        }
+
+        const merged = new Map<string, Clip>()
+        for (const accountClips of results) {
+          for (const clip of accountClips) {
+            merged.set(clip.id, clip)
+          }
+        }
+
+        const mergedClips = Array.from(merged.values())
+        mergedClips.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+        setClips(mergedClips)
+      } catch (error) {
+        if (!isActive) {
+          return
+        }
+        console.error('Failed to load clips for library view', error)
+        setClips([])
+        setClipsError('Unable to load clips. Please try again.')
+      } finally {
+        if (isActive) {
+          setIsLoadingClips(false)
+        }
+      }
+    }
+
+    void loadClips()
+
+    return () => {
+      isActive = false
+    }
+  }, [targetAccountIds])
+
+  const filteredClips = useMemo(() => {
+    const trimmed = query.trim().toLowerCase()
+    if (!trimmed) {
+      return clips
+    }
+
+    return clips.filter((clip) => {
+      const haystack = [
+        clip.title,
+        clip.channel,
+        clip.description,
+        clip.quote ?? undefined,
+        clip.reason ?? undefined
+      ]
+        .filter((value): value is string => typeof value === 'string' && value.length > 0)
+        .join(' ') 
+        .toLowerCase()
+
+      return haystack.includes(trimmed)
+    })
+  }, [clips, query])
+
+  const handleAccountChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const { value } = event.target
+      if (value === ALL_ACCOUNTS_VALUE) {
+        onSelectAccount(null)
+      } else {
+        onSelectAccount(value)
+      }
+    },
+    [onSelectAccount]
+  )
+
+  const handleClipOpen = useCallback(
+    (clip: Clip) => {
+      navigate(`/clip/${clip.id}`, { state: { clip } })
+    },
+    [navigate]
+  )
+
+  const dropdownValue = useMemo(() => {
+    if (!hasAccounts) {
+      return ''
+    }
+    if (selectedAccountId) {
+      return selectedAccountId
+    }
+    return hasMultipleAccounts ? ALL_ACCOUNTS_VALUE : availableAccounts[0]?.id ?? ''
+  }, [availableAccounts, hasAccounts, hasMultipleAccounts, selectedAccountId])
+
+  return (
+    <section className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-8">
+      <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-6 shadow-[0_20px_40px_-24px_rgba(15,23,42,0.6)]">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-[var(--fg)]">Clip library</h2>
+            <p className="text-sm text-[var(--muted)]">
+              Browse generated clips by account or review everything at once.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 sm:max-w-xs">
+            <label htmlFor="library-account" className="text-xs font-semibold uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_75%,transparent)]">
+              Account
+            </label>
+            <select
+              id="library-account"
+              value={dropdownValue}
+              onChange={handleAccountChange}
+              disabled={!hasAccounts || isLoadingAccounts}
+              className="w-full rounded-lg border border-white/10 bg-[var(--card)] px-4 py-2 text-sm text-[var(--fg)] shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)] focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {!hasAccounts ? (
+                <option value="">No available accounts</option>
+              ) : null}
+              {hasMultipleAccounts ? (
+                <option value={ALL_ACCOUNTS_VALUE}>All accounts</option>
+              ) : null}
+              {availableAccounts.map((account) => (
+                <option key={account.id} value={account.id}>
+                  {account.displayName}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        {clipsError ? (
+          <div className="rounded-lg border border-rose-400/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+            {clipsError}
+          </div>
+        ) : null}
+        {!hasAccounts && !isLoadingAccounts ? (
+          <div className="rounded-lg border border-dashed border-white/10 bg-black/20 px-4 py-6 text-sm text-[var(--muted)]">
+            Connect an account with an active platform from your profile to start collecting clips.
+          </div>
+        ) : null}
+        {hasAccounts ? (
+          <div className="flex items-center justify-between text-xs text-[var(--muted)]">
+            <span>
+              Showing {filteredClips.length} {filteredClips.length === 1 ? 'clip' : 'clips'}
+              {selectedAccountId ? ' for the selected account.' : hasMultipleAccounts ? ' from all accounts.' : '.'}
+            </span>
+            {isLoadingClips ? <span className="text-[var(--fg)]">Loading clips…</span> : null}
+          </div>
+        ) : null}
+      </div>
+
+      {hasAccounts ? (
+        filteredClips.length > 0 ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {filteredClips.map((clip) => (
+              <ClipCard key={clip.id} clip={clip} onClick={() => handleClipOpen(clip)} />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-1 flex-col items-center justify-center rounded-2xl border border-dashed border-white/10 bg-[color:color-mix(in_srgb,var(--card)_65%,transparent)] p-10 text-center text-sm text-[var(--muted)]">
+            {isLoadingClips
+              ? 'Loading your clips…'
+              : 'No clips match the current filters. Try selecting a different account or clearing your search.'}
+          </div>
+        )
+      ) : null}
+    </section>
+  )
+}
+
+export default Library

--- a/desktop/src/renderer/src/services/clipLibrary.ts
+++ b/desktop/src/renderer/src/services/clipLibrary.ts
@@ -1,7 +1,121 @@
+import { BACKEND_MODE, buildAccountClipsUrl } from '../config/backend'
 import type { Clip } from '../types'
+
+type RawClipPayload = {
+  id?: unknown
+  title?: unknown
+  channel?: unknown
+  created_at?: unknown
+  duration_seconds?: unknown
+  description?: unknown
+  playback_url?: unknown
+  source_url?: unknown
+  source_title?: unknown
+  source_published_at?: unknown
+  views?: unknown
+  rating?: unknown
+  quote?: unknown
+  reason?: unknown
+  account?: unknown
+  timestamp_url?: unknown
+  timestamp_seconds?: unknown
+  thumbnail_url?: unknown
+}
 
 const isClipArray = (value: unknown): value is Clip[] => {
   return Array.isArray(value) && value.every((item) => typeof item === 'object' && item !== null && 'id' in item)
+}
+
+const normaliseClip = (payload: RawClipPayload): Clip | null => {
+  const {
+    id,
+    title,
+    channel,
+    created_at: createdAt,
+    duration_seconds: durationSeconds,
+    description,
+    playback_url: playbackUrl,
+    source_url: sourceUrl,
+    source_title: sourceTitle,
+    source_published_at: sourcePublishedAt,
+    views,
+    rating,
+    quote,
+    reason,
+    account,
+    timestamp_url: timestampUrl,
+    timestamp_seconds: timestampSeconds,
+    thumbnail_url: thumbnailUrl
+  } = payload
+
+  if (typeof id !== 'string' || id.length === 0) {
+    return null
+  }
+  if (typeof title !== 'string' || title.length === 0) {
+    return null
+  }
+  if (typeof createdAt !== 'string' || createdAt.length === 0) {
+    return null
+  }
+  if (typeof durationSeconds !== 'number') {
+    return null
+  }
+  if (typeof playbackUrl !== 'string' || playbackUrl.length === 0) {
+    return null
+  }
+  if (typeof description !== 'string') {
+    return null
+  }
+  if (typeof sourceUrl !== 'string' || sourceUrl.length === 0) {
+    return null
+  }
+  if (typeof sourceTitle !== 'string' || sourceTitle.length === 0) {
+    return null
+  }
+
+  const clip: Clip = {
+    id,
+    title,
+    channel: typeof channel === 'string' && channel.length > 0 ? channel : 'Unknown channel',
+    views: typeof views === 'number' ? views : null,
+    createdAt,
+    durationSec: durationSeconds,
+    thumbnail: typeof thumbnailUrl === 'string' && thumbnailUrl.length > 0 ? thumbnailUrl : null,
+    playbackUrl,
+    description,
+    sourceUrl,
+    sourceTitle,
+    sourcePublishedAt: typeof sourcePublishedAt === 'string' ? sourcePublishedAt : null,
+    rating: typeof rating === 'number' ? rating : rating === null ? null : undefined,
+    quote: typeof quote === 'string' ? quote : quote === null ? null : undefined,
+    reason: typeof reason === 'string' ? reason : reason === null ? null : undefined,
+    timestampUrl: typeof timestampUrl === 'string' ? timestampUrl : timestampUrl === null ? null : undefined,
+    timestampSeconds:
+      typeof timestampSeconds === 'number'
+        ? timestampSeconds
+        : timestampSeconds === null
+        ? null
+        : undefined,
+    accountId: typeof account === 'string' ? account : account === null ? null : undefined
+  }
+
+  return clip
+}
+
+const fetchAccountClipsFromApi = async (accountId: string): Promise<Clip[]> => {
+  const url = buildAccountClipsUrl(accountId)
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`)
+  }
+  const payload = (await response.json()) as unknown
+  if (!Array.isArray(payload)) {
+    return []
+  }
+  const clips = payload
+    .map((item) => (item && typeof item === 'object' ? normaliseClip(item as RawClipPayload) : null))
+    .filter((clip): clip is Clip => clip !== null)
+  return clips
 }
 
 export const listAccountClips = async (accountId: string | null): Promise<Clip[]> => {
@@ -9,17 +123,22 @@ export const listAccountClips = async (accountId: string | null): Promise<Clip[]
     return []
   }
 
-  try {
-    const api = window.api
-    if (api && typeof api.listAccountClips === 'function') {
-      const clips = await api.listAccountClips(accountId)
-      return isClipArray(clips) ? clips : []
+  if (BACKEND_MODE === 'api' || typeof window === 'undefined' || !window.api?.listAccountClips) {
+    try {
+      return await fetchAccountClipsFromApi(accountId)
+    } catch (error) {
+      console.error('Unable to load clips from API library', error)
+      return []
     }
-  } catch (error) {
-    console.error('Unable to load clips from library', error)
   }
 
-  return []
+  try {
+    const clips = await window.api.listAccountClips(accountId)
+    return isClipArray(clips) ? clips : []
+  } catch (error) {
+    console.error('Unable to load clips from library bridge', error)
+    return []
+  }
 }
 
 export default listAccountClips

--- a/desktop/src/renderer/src/services/clipLibrary.ts
+++ b/desktop/src/renderer/src/services/clipLibrary.ts
@@ -12,6 +12,8 @@ type RawClipPayload = {
   source_url?: unknown
   source_title?: unknown
   source_published_at?: unknown
+  video_id?: unknown
+  video_title?: unknown
   views?: unknown
   rating?: unknown
   quote?: unknown
@@ -38,6 +40,8 @@ const normaliseClip = (payload: RawClipPayload): Clip | null => {
     source_url: sourceUrl,
     source_title: sourceTitle,
     source_published_at: sourcePublishedAt,
+    video_id: videoId,
+    video_title: videoTitle,
     views,
     rating,
     quote,
@@ -66,12 +70,15 @@ const normaliseClip = (payload: RawClipPayload): Clip | null => {
   if (typeof description !== 'string') {
     return null
   }
-  if (typeof sourceUrl !== 'string' || sourceUrl.length === 0) {
+  if (typeof sourceUrl !== 'string') {
     return null
   }
   if (typeof sourceTitle !== 'string' || sourceTitle.length === 0) {
     return null
   }
+  const videoIdValue = typeof videoId === 'string' && videoId.length > 0 ? videoId : id
+  const videoTitleValue =
+    typeof videoTitle === 'string' && videoTitle.length > 0 ? videoTitle : sourceTitle
 
   const clip: Clip = {
     id,
@@ -86,6 +93,8 @@ const normaliseClip = (payload: RawClipPayload): Clip | null => {
     sourceUrl,
     sourceTitle,
     sourcePublishedAt: typeof sourcePublishedAt === 'string' ? sourcePublishedAt : null,
+    videoId: videoIdValue,
+    videoTitle: videoTitleValue,
     rating: typeof rating === 'number' ? rating : rating === null ? null : undefined,
     quote: typeof quote === 'string' ? quote : quote === null ? null : undefined,
     reason: typeof reason === 'string' ? reason : reason === null ? null : undefined,

--- a/desktop/src/renderer/src/tests/clipcard.test.tsx
+++ b/desktop/src/renderer/src/tests/clipcard.test.tsx
@@ -11,7 +11,14 @@ const mockClip: Clip = {
   views: 123_456,
   createdAt: '2024-10-01T10:00:00Z',
   durationSec: 75,
-  thumbnail: 'https://images.unsplash.com/photo-1517430816045-df4b7de11d1d?auto=format&fit=crop&w=800&q=80'
+  thumbnail: 'https://images.unsplash.com/photo-1517430816045-df4b7de11d1d?auto=format&fit=crop&w=800&q=80',
+  playbackUrl: 'file:///videos/test-clip.mp4',
+  description: 'Full video: https://example.com/watch?v=clip\nCredit: UI Lab',
+  sourceUrl: 'https://example.com/watch?v=clip',
+  sourceTitle: 'Testing React Components the Easy Way',
+  sourcePublishedAt: null,
+  videoId: 'video-test',
+  videoTitle: 'Testing React Components the Easy Way'
 }
 
 describe('ClipCard', () => {

--- a/desktop/src/renderer/src/tests/clipcard.test.tsx
+++ b/desktop/src/renderer/src/tests/clipcard.test.tsx
@@ -30,4 +30,15 @@ describe('ClipCard', () => {
 
     expect(handleClick).toHaveBeenCalledTimes(1)
   })
+
+  it('falls back to inline video preview when thumbnail is missing', () => {
+    const clipWithoutThumbnail: Clip = { ...mockClip, thumbnail: null }
+
+    render(<ClipCard clip={clipWithoutThumbnail} onClick={() => {}} />)
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    const video = screen.getByRole('button').querySelector('video')
+    expect(video).not.toBeNull()
+    expect(video?.getAttribute('src')).toBe(clipWithoutThumbnail.playbackUrl)
+  })
 })

--- a/desktop/src/renderer/src/tests/home.test.tsx
+++ b/desktop/src/renderer/src/tests/home.test.tsx
@@ -171,6 +171,8 @@ describe('Home account selection', () => {
       sourceUrl: 'https://example.com',
       sourceTitle: 'Example Video',
       sourcePublishedAt: null,
+      videoId: 'video-001',
+      videoTitle: 'Example Video',
       rating: 4.5,
       quote: 'Existing Clip',
       reason: null,

--- a/desktop/src/renderer/src/tests/home.test.tsx
+++ b/desktop/src/renderer/src/tests/home.test.tsx
@@ -6,7 +6,6 @@ import { createInitialPipelineSteps } from '../data/pipeline'
 import type {
   AccountPlatformConnection,
   AccountSummary,
-  Clip,
   HomePipelineState
 } from '../types'
 import type { PipelineEventHandlers } from '../services/pipelineApi'
@@ -14,10 +13,6 @@ import type { PipelineEventHandlers } from '../services/pipelineApi'
 const { startPipelineJobMock, subscribeToPipelineEventsMock } = vi.hoisted(() => ({
   startPipelineJobMock: vi.fn(),
   subscribeToPipelineEventsMock: vi.fn()
-}))
-
-const { listAccountClipsMock } = vi.hoisted(() => ({
-  listAccountClipsMock: vi.fn<[_accountId: string | null], Promise<Clip[]>>()
 }))
 
 vi.mock('../services/pipelineApi', async () => {
@@ -30,10 +25,6 @@ vi.mock('../services/pipelineApi', async () => {
     subscribeToPipelineEvents: subscribeToPipelineEventsMock
   }
 })
-
-vi.mock('../services/clipLibrary', () => ({
-  listAccountClips: listAccountClipsMock
-}))
 
 const createPlatform = (
   overrides: Partial<AccountPlatformConnection> = {}
@@ -99,11 +90,6 @@ const createInitialState = (overrides: Partial<HomePipelineState> = {}): HomePip
   ...overrides
 })
 
-beforeEach(() => {
-  listAccountClipsMock.mockReset()
-  listAccountClipsMock.mockResolvedValue([])
-})
-
 describe('Home account selection', () => {
   beforeEach(() => {
     startPipelineJobMock.mockReset()
@@ -155,53 +141,6 @@ describe('Home account selection', () => {
 
   await waitFor(() => expect(startPipelineJobMock).toHaveBeenCalledTimes(1))
   expect(startPipelineJobMock).toHaveBeenCalledWith({ account: accountId, url: videoUrl })
-  })
-
-  it('loads existing clips for the selected account', async () => {
-    const existingClip: Clip = {
-      id: 'clip-001',
-      title: 'Existing Clip',
-      channel: 'Creator',
-      views: null,
-      createdAt: new Date('2024-05-01T12:00:00Z').toISOString(),
-      durationSec: 42,
-      thumbnail: null,
-      playbackUrl: 'file:///clip.mp4',
-      description: 'Full video: https://example.com\nCredit: Creator',
-      sourceUrl: 'https://example.com',
-      sourceTitle: 'Example Video',
-      sourcePublishedAt: null,
-      videoId: 'video-001',
-      videoTitle: 'Example Video',
-      rating: 4.5,
-      quote: 'Existing Clip',
-      reason: null,
-      timestampUrl: 'https://example.com?t=12',
-      timestampSeconds: 12
-    }
-
-    listAccountClipsMock.mockResolvedValueOnce([existingClip])
-
-    render(
-      <Home
-        registerSearch={() => {}}
-        initialState={createInitialState()}
-        onStateChange={() => {}}
-        accounts={[AVAILABLE_ACCOUNT]}
-      />
-    )
-
-    const select = screen.getByLabelText(/account/i)
-    await act(async () => {
-      fireEvent.change(select, { target: { value: AVAILABLE_ACCOUNT.id } })
-    })
-    await act(async () => {})
-    expect((select as HTMLSelectElement).value).toBe(AVAILABLE_ACCOUNT.id)
-
-    await waitFor(() => expect(listAccountClipsMock).toHaveBeenCalled())
-    expect(await screen.findByText(existingClip.title)).toBeInTheDocument()
-    const [[accountUsed]] = listAccountClipsMock.mock.calls
-    expect(accountUsed).toBe(AVAILABLE_ACCOUNT.id)
   })
 
   it('filters the account dropdown to active accounts with active platforms', () => {

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -16,6 +16,7 @@ export interface Clip {
   reason?: string | null
   timestampUrl?: string | null
   timestampSeconds?: number | null
+  accountId?: string | null
 }
 
 export type SupportedPlatform = 'tiktok' | 'youtube' | 'instagram'

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -11,6 +11,8 @@ export interface Clip {
   sourceUrl: string
   sourceTitle: string
   sourcePublishedAt: string | null
+  videoId: string
+  videoTitle: string
   rating?: number | null
   quote?: string | null
   reason?: string | null

--- a/server/library.py
+++ b/server/library.py
@@ -1,0 +1,465 @@
+"""Clip library discovery and metadata utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+from fastapi import HTTPException, status
+
+from schedule_upload import get_out_root
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_ACCOUNT_PLACEHOLDER = "__default__"
+
+CLIP_FILENAME_PATTERN = re.compile(r"^clip_(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)(?:_r(\d+(?:\.\d+)?))?$")
+FULL_VIDEO_PATTERN = re.compile(r"^full video:\s*(https?://\S+)", re.IGNORECASE)
+CREDIT_PATTERN = re.compile(r"^credit:\s*(.+)$", re.IGNORECASE)
+DATE_SUFFIX_PATTERN = re.compile(r"_(\d{8})$")
+TIME_COMPONENT_PATTERN = re.compile(
+    r"^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)(?:s)?)?$", re.IGNORECASE
+)
+CANDIDATE_MANIFEST_FILES = [
+    "render_queue.json",
+    "candidates.json",
+    "candidates_top.json",
+    "candidates_all.json",
+]
+
+
+@dataclass
+class CandidateMetadata:
+    quote: Optional[str]
+    reason: Optional[str]
+    rating: Optional[float]
+
+
+@dataclass
+class DescriptionMetadata:
+    description: str
+    source_url: Optional[str]
+    timestamp_url: Optional[str]
+    timestamp_seconds: Optional[float]
+    channel: Optional[str]
+
+
+@dataclass
+class ProjectMetadata:
+    title: str
+    published_at: Optional[str]
+
+
+@dataclass
+class LibraryClip:
+    clip_id: str
+    title: str
+    channel: str
+    created_at: datetime
+    duration_seconds: float
+    description: str
+    source_url: str
+    source_title: str
+    source_published_at: Optional[str]
+    rating: Optional[float]
+    quote: Optional[str]
+    reason: Optional[str]
+    account_id: Optional[str]
+    timestamp_url: Optional[str]
+    timestamp_seconds: Optional[float]
+    thumbnail_url: Optional[str]
+    playback_path: Path
+
+    def to_payload(self, request) -> Dict[str, object]:  # type: ignore[override]
+        from fastapi import Request  # local import to avoid circular for typing
+
+        if not isinstance(request, Request):  # pragma: no cover - defensive
+            raise TypeError("Expected FastAPI Request when serialising clip payload")
+
+        playback_url = request.url_for(
+            "get_account_clip_video",
+            account_id=self.account_id or DEFAULT_ACCOUNT_PLACEHOLDER,
+            clip_id=self.clip_id,
+        )
+
+        return {
+            "id": self.clip_id,
+            "title": self.title,
+            "channel": self.channel,
+            "created_at": self.created_at,
+            "duration_seconds": self.duration_seconds,
+            "description": self.description,
+            "playback_url": str(playback_url),
+            "source_url": self.source_url,
+            "source_title": self.source_title,
+            "source_published_at": self.source_published_at,
+            "views": None,
+            "rating": self.rating,
+            "quote": self.quote,
+            "reason": self.reason,
+            "account": self.account_id,
+            "timestamp_url": self.timestamp_url,
+            "timestamp_seconds": self.timestamp_seconds,
+            "thumbnail_url": self.thumbnail_url,
+        }
+
+
+def _round_two(value: float) -> float:
+    return round(value * 100) / 100
+
+
+def _format_candidate_key(start: float, end: float) -> str:
+    return f"{_round_two(start):.2f}-{_round_two(end):.2f}"
+
+
+def _parse_clip_filename(stem: str) -> Optional[tuple[float, float, Optional[float]]]:
+    match = CLIP_FILENAME_PATTERN.match(stem)
+    if not match:
+        return None
+    start_raw, end_raw, rating_raw = match.groups()
+    try:
+        start = float(start_raw)
+        end = float(end_raw)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(start) or math.isnan(end):
+        return None
+    rating = None
+    if rating_raw:
+        try:
+            rating = float(rating_raw)
+        except ValueError:
+            rating = None
+    return start, end, rating
+
+
+def _parse_timestamp_token(token: Optional[str]) -> Optional[float]:
+    if not token:
+        return None
+    value = token.strip().lower()
+    if not value:
+        return None
+    if value.isdigit():
+        return float(value)
+    match = TIME_COMPONENT_PATTERN.match(value)
+    if match:
+        hours_raw, minutes_raw, seconds_raw = match.groups()
+        hours = int(hours_raw) if hours_raw else 0
+        minutes = int(minutes_raw) if minutes_raw else 0
+        seconds = int(seconds_raw) if seconds_raw else 0
+        return float(hours * 3600 + minutes * 60 + seconds)
+    digits = re.findall(r"\d+", value)
+    if digits:
+        try:
+            return float(digits[0])
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_timestamp_from_url(raw_url: str) -> Optional[float]:
+    try:
+        parsed = urlparse(raw_url)
+    except ValueError:
+        return None
+    query = parse_qs(parsed.query)
+    token = None
+    for key in ("t", "start"):
+        if key in query and query[key]:
+            token = query[key][0]
+            break
+    if not token and parsed.fragment:
+        frag_query = parse_qs(parsed.fragment)
+        if "t" in frag_query and frag_query["t"]:
+            token = frag_query["t"][0]
+    return _parse_timestamp_token(token)
+
+
+def _parse_description_metadata(text: str) -> DescriptionMetadata:
+    timestamp_url: Optional[str] = None
+    channel: Optional[str] = None
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        full_match = FULL_VIDEO_PATTERN.search(line)
+        if full_match:
+            candidate = (full_match.group(1) or "").strip()
+            if candidate:
+                timestamp_url = candidate
+        credit_match = CREDIT_PATTERN.search(line)
+        if credit_match and channel is None:
+            candidate = (credit_match.group(1) or "").strip()
+            if candidate:
+                channel = candidate
+    source_url: Optional[str] = None
+    if timestamp_url:
+        try:
+            parsed = urlparse(timestamp_url)
+            query = parse_qs(parsed.query)
+            query.pop("t", None)
+            query.pop("start", None)
+            cleaned = parsed._replace(query=urlencode(query, doseq=True), fragment="")
+            source_url = urlunparse(cleaned)
+            if source_url.endswith("?"):
+                source_url = source_url[:-1]
+        except ValueError:
+            source_url = timestamp_url
+    timestamp_seconds = _parse_timestamp_from_url(timestamp_url) if timestamp_url else None
+    return DescriptionMetadata(
+        description=text,
+        source_url=source_url,
+        timestamp_url=timestamp_url,
+        timestamp_seconds=timestamp_seconds,
+        channel=channel,
+    )
+
+
+def _parse_date_token(token: str) -> Optional[str]:
+    if len(token) != 8 or not token.isdigit():
+        return None
+    year = int(token[:4])
+    month = int(token[4:6])
+    day = int(token[6:8])
+    try:
+        iso = datetime(year, month, day, tzinfo=timezone.utc).isoformat()
+        return iso
+    except ValueError:
+        return None
+
+
+def _infer_project_metadata(project_name: str) -> ProjectMetadata:
+    title_source = project_name
+    published_at: Optional[str] = None
+    match = DATE_SUFFIX_PATTERN.search(project_name)
+    if match:
+        token = match.group(1) or ""
+        iso = _parse_date_token(token)
+        if iso:
+            published_at = iso
+            title_source = project_name[: -(len(token) + 1)]
+    normalised = re.sub(r"[_-]+", " ", title_source).strip()
+    title = normalised or project_name
+    return ProjectMetadata(title=title, published_at=published_at)
+
+
+def _load_candidate_metadata(project_dir: Path) -> Dict[str, CandidateMetadata]:
+    metadata: Dict[str, CandidateMetadata] = {}
+    for manifest_name in CANDIDATE_MANIFEST_FILES:
+        manifest_path = project_dir / manifest_name
+        if not manifest_path.exists():
+            continue
+        try:
+            raw = json.loads(manifest_path.read_text())
+        except Exception:  # pragma: no cover - invalid JSON
+            continue
+        if isinstance(raw, dict):
+            # Some manifests wrap candidates in a dictionary
+            if "candidates" in raw and isinstance(raw["candidates"], list):
+                entries = raw["candidates"]
+            elif "clips" in raw and isinstance(raw["clips"], list):
+                entries = raw["clips"]
+            else:
+                continue
+        elif isinstance(raw, list):
+            entries = raw
+        else:
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            start = entry.get("start")
+            end = entry.get("end")
+            if not isinstance(start, (int, float)) or not isinstance(end, (int, float)):
+                continue
+            key = _format_candidate_key(float(start), float(end))
+            quote = entry.get("quote")
+            quote_value = quote.strip() if isinstance(quote, str) and quote.strip() else None
+            reason = entry.get("reason")
+            reason_value = reason.strip() if isinstance(reason, str) and reason.strip() else None
+            rating_raw = entry.get("rating")
+            rating_value: Optional[float]
+            if isinstance(rating_raw, (int, float)):
+                rating_value = float(rating_raw)
+            else:
+                rating_value = None
+            existing = metadata.get(key)
+            if existing is None:
+                metadata[key] = CandidateMetadata(
+                    quote=quote_value, reason=reason_value, rating=rating_value
+                )
+            else:
+                if existing.quote is None and quote_value:
+                    existing.quote = quote_value
+                if existing.reason is None and reason_value:
+                    existing.reason = reason_value
+                if existing.rating is None and rating_value is not None:
+                    existing.rating = rating_value
+    return metadata
+
+
+def _find_project_directories(root_dir: Path) -> List[Path]:
+    queue: List[Path] = [root_dir]
+    visited = {root_dir}
+    projects: List[Path] = []
+    while queue:
+        current = queue.pop()
+        try:
+            entries = list(current.iterdir())
+        except OSError:
+            continue
+        has_shorts = False
+        for entry in entries:
+            if entry.name == "shorts" and entry.is_dir():
+                has_shorts = True
+                break
+        if has_shorts:
+            projects.append(current)
+            continue
+        for entry in entries:
+            if entry in visited:
+                continue
+            visited.add(entry)
+            if entry.is_dir():
+                queue.append(entry)
+    return projects
+
+
+def _encode_clip_id(relative_path: Path) -> str:
+    normalised = relative_path.as_posix()
+    token = base64.urlsafe_b64encode(normalised.encode("utf-8")).decode("ascii")
+    return token.rstrip("=")
+
+
+def _decode_clip_id(token: str) -> Path:
+    padding = "=" * (-len(token) % 4)
+    raw = base64.urlsafe_b64decode(token + padding).decode("utf-8")
+    return Path(raw)
+
+
+def _build_clip(
+    clip_path: Path,
+    project_info: ProjectMetadata,
+    candidate_map: Dict[str, CandidateMetadata],
+    account_id: Optional[str],
+    base: Path,
+) -> Optional[LibraryClip]:
+    stem = clip_path.stem
+    parsed = _parse_clip_filename(stem)
+    if not parsed:
+        return None
+    start, end, rating = parsed
+    key = _format_candidate_key(start, end)
+    candidate = candidate_map.get(key)
+    description_path = clip_path.with_suffix(".txt")
+    try:
+        description_text = description_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        description_text = ""
+    description_metadata = _parse_description_metadata(description_text)
+    try:
+        stats = clip_path.stat()
+    except OSError:
+        return None
+    duration = max(0.0, end - start)
+    title = candidate.quote or project_info.title or stem
+    timestamp_url = description_metadata.timestamp_url
+    if not timestamp_url and description_metadata.source_url and math.isfinite(start):
+        try:
+            parsed_url = urlparse(description_metadata.source_url)
+            query = parse_qs(parsed_url.query)
+            query["t"] = [str(int(round(start)))]
+            timestamp_url = urlunparse(
+                parsed_url._replace(query=urlencode(query, doseq=True))
+            )
+        except ValueError:
+            timestamp_url = None
+    timestamp_seconds = (
+        description_metadata.timestamp_seconds
+        if description_metadata.timestamp_seconds is not None
+        else (start if math.isfinite(start) else None)
+    )
+    relative_path = clip_path.relative_to(base)
+    clip_id = _encode_clip_id(relative_path)
+    created_at = datetime.fromtimestamp(stats.st_mtime, tz=timezone.utc)
+    return LibraryClip(
+        clip_id=clip_id,
+        title=title,
+        channel=description_metadata.channel or "Unknown channel",
+        created_at=created_at,
+        duration_seconds=duration,
+        description=description_text,
+        source_url=description_metadata.source_url
+        or description_metadata.timestamp_url
+        or "",
+        source_title=project_info.title,
+        source_published_at=project_info.published_at,
+        rating=candidate.rating if candidate else rating,
+        quote=candidate.quote if candidate else None,
+        reason=candidate.reason if candidate else None,
+        account_id=account_id,
+        timestamp_url=timestamp_url,
+        timestamp_seconds=timestamp_seconds,
+        thumbnail_url=None,
+        playback_path=clip_path,
+    )
+
+
+def list_account_clips_sync(account_id: Optional[str]) -> List[LibraryClip]:
+    base = get_out_root()
+    account_dir = base / account_id if account_id else base
+    if not account_dir.exists() or not account_dir.is_dir():
+        return []
+    projects = _find_project_directories(account_dir)
+    clips: List[LibraryClip] = []
+    for project_dir in projects:
+        project_info = _infer_project_metadata(project_dir.name)
+        candidate_map = _load_candidate_metadata(project_dir)
+        shorts_dir = project_dir / "shorts"
+        try:
+            short_files = list(shorts_dir.iterdir())
+        except OSError:
+            continue
+        for file_path in short_files:
+            if file_path.suffix.lower() != ".mp4":
+                continue
+            clip = _build_clip(file_path, project_info, candidate_map, account_id, base)
+            if clip is not None:
+                clips.append(clip)
+    clips.sort(key=lambda clip: clip.created_at, reverse=True)
+    return clips
+
+
+def list_account_clips(account_id: Optional[str]) -> asyncio.Future[List[LibraryClip]]:
+    return asyncio.to_thread(list_account_clips_sync, account_id)
+
+
+def resolve_clip_video_path(account_id: Optional[str], clip_id: str) -> Path:
+    base = get_out_root()
+    target_account = base / account_id if account_id else base
+    relative = _decode_clip_id(clip_id)
+    clip_path = base / relative
+    try:
+        clip_path.relative_to(target_account)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not found") from exc
+    if not clip_path.exists() or not clip_path.is_file():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not found")
+    return clip_path
+
+
+__all__ = [
+    "LibraryClip",
+    "DEFAULT_ACCOUNT_PLACEHOLDER",
+    "list_account_clips",
+    "list_account_clips_sync",
+    "resolve_clip_video_path",
+]

--- a/tests/test_library_api.py
+++ b/tests/test_library_api.py
@@ -76,6 +76,10 @@ def test_list_account_clips(monkeypatch, tmp_path):
     assert clip["source_url"] == "https://example.com/watch?v=abc123"
     assert clip["source_title"] == "Amazing Project"
     assert clip["description"].startswith("Full video:")
+    project_relative = clip_path.parent.parent.relative_to(out_root)
+    expected_video_id = base64.urlsafe_b64encode(project_relative.as_posix().encode("utf-8")).decode("ascii").rstrip("=")
+    assert clip["video_id"] == expected_video_id
+    assert clip["video_title"] == "Amazing Project"
     assert clip["playback_url"].endswith(f"/api/accounts/{account_id}/clips/{clip['id']}/video")
 
 

--- a/tests/test_library_api.py
+++ b/tests/test_library_api.py
@@ -1,0 +1,98 @@
+"""Tests for the clip library API endpoints."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from server.app import app
+
+
+def _create_clip_structure(base: Path) -> tuple[str, Path]:
+    account_id = "account-one"
+    project_dir = base / account_id / "Amazing_Project_20240101"
+    shorts_dir = project_dir / "shorts"
+    shorts_dir.mkdir(parents=True)
+
+    clip_filename = "clip_0.00-12.50_r9.0.mp4"
+    clip_path = shorts_dir / clip_filename
+    clip_path.write_bytes(b"fake-mp4-data")
+
+    description = (
+        "Full video: https://example.com/watch?v=abc123&t=15\n"
+        "Credit: Example Channel\n"
+        "Some description text.\n"
+    )
+    clip_path.with_suffix(".txt").write_text(description, encoding="utf-8")
+
+    candidates_path = project_dir / "candidates.json"
+    candidates_path.write_text(
+        json.dumps(
+          [
+              {
+                  "start": 0.0,
+                  "end": 12.5,
+                  "quote": "A memorable quote",
+                  "reason": "It was exciting",
+                  "rating": 9.0,
+              }
+          ]
+        ),
+        encoding="utf-8",
+    )
+
+    timestamp = datetime(2024, 3, 4, tzinfo=timezone.utc).timestamp()
+    os.utime(clip_path, (timestamp, timestamp))
+
+    return account_id, clip_path
+
+
+def test_list_account_clips(monkeypatch, tmp_path):
+    out_root = tmp_path / "out"
+    monkeypatch.setenv("OUT_ROOT", str(out_root))
+    account_id, clip_path = _create_clip_structure(out_root)
+
+    client = TestClient(app)
+    response = client.get(f"/api/accounts/{account_id}/clips")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    clip = payload[0]
+    assert clip["title"] == "Amazing Project"
+    assert clip["account"] == account_id
+    assert clip["quote"] == "A memorable quote"
+    assert clip["reason"] == "It was exciting"
+    assert clip["rating"] == 9.0
+    assert clip["channel"] == "Example Channel"
+    assert clip["timestamp_seconds"] == 15
+    assert clip["timestamp_url"].endswith("t=15")
+    assert clip["source_url"] == "https://example.com/watch?v=abc123"
+    assert clip["source_title"] == "Amazing Project"
+    assert clip["description"].startswith("Full video:")
+    assert clip["playback_url"].endswith(f"/api/accounts/{account_id}/clips/{clip['id']}/video")
+
+
+def test_get_account_clip_video(monkeypatch, tmp_path):
+    out_root = tmp_path / "out"
+    monkeypatch.setenv("OUT_ROOT", str(out_root))
+    account_id, clip_path = _create_clip_structure(out_root)
+
+    relative = clip_path.relative_to(out_root)
+    clip_id = base64.urlsafe_b64encode(relative.as_posix().encode("utf-8")).decode("ascii").rstrip("=")
+
+    client = TestClient(app)
+    response = client.get(f"/api/accounts/{account_id}/clips/{clip_id}/video")
+
+    assert response.status_code == 200
+    assert response.headers.get("content-type") == "video/mp4"
+    assert response.content == clip_path.read_bytes()
+
+    missing = client.get(f"/api/accounts/{account_id}/clips/unknown/video")
+    assert missing.status_code == 404


### PR DESCRIPTION
## Summary
- rename the main navigation entry to Home and introduce a dedicated Library route
- add a clip library page with account filtering, search integration, and aggregate loading
- keep the selected account in sync between the library and home pipeline views

## Testing
- pytest *(fails: missing httpx dependency and system libGL for cv2)*

------
https://chatgpt.com/codex/tasks/task_e_68ce381cbff0832383e88e709b2014b6