### PR TITLE
Add upcoming posts overview and clips folder shortcut

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -2,7 +2,7 @@ import { app, shell, BrowserWindow, ipcMain } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
-import { listAccountClips } from './clipLibrary'
+import { listAccountClips, resolveAccountClipsDirectory } from './clipLibrary'
 
 function createWindow(): void {
   // Create the browser window.
@@ -60,6 +60,23 @@ app.whenReady().then(() => {
     } catch (error) {
       console.error('Failed to list clips', error)
       return []
+    }
+  })
+  ipcMain.handle('clips:open-folder', async (_event, accountId: string) => {
+    try {
+      const paths = await resolveAccountClipsDirectory(accountId)
+      if (!paths) {
+        return false
+      }
+      const result = await shell.openPath(paths.accountDir)
+      if (typeof result === 'string' && result.length > 0) {
+        console.error('Unable to open clips folder', result)
+        return false
+      }
+      return true
+    } catch (error) {
+      console.error('Failed to open clips folder', error)
+      return false
     }
   })
 

--- a/desktop/src/preload/index.d.ts
+++ b/desktop/src/preload/index.d.ts
@@ -3,6 +3,7 @@ import type { Clip } from '../renderer/src/types'
 
 export interface ClipLibraryApi {
   listAccountClips(accountId: string | null): Promise<Clip[]>
+  openAccountClipsFolder(accountId: string): Promise<boolean>
 }
 
 declare global {

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -6,7 +6,9 @@ type Clip = import('../renderer/src/types').Clip
 
 const api = {
   listAccountClips: (accountId: string | null): Promise<Clip[]> =>
-    ipcRenderer.invoke('clips:list', accountId)
+    ipcRenderer.invoke('clips:list', accountId),
+  openAccountClipsFolder: (accountId: string): Promise<boolean> =>
+    ipcRenderer.invoke('clips:open-folder', accountId)
 }
 
 // Use `contextBridge` APIs to expose Electron APIs to

--- a/desktop/src/renderer/src/services/clipLibrary.ts
+++ b/desktop/src/renderer/src/services/clipLibrary.ts
@@ -150,4 +150,32 @@ export const listAccountClips = async (accountId: string | null): Promise<Clip[]
   }
 }
 
+const isFolderBridgeAvailable = (): boolean => {
+  return typeof window !== 'undefined' && typeof window.api?.openAccountClipsFolder === 'function'
+}
+
+export const canOpenAccountClipsFolder = (): boolean => {
+  if (BACKEND_MODE === 'api') {
+    return false
+  }
+  return isFolderBridgeAvailable()
+}
+
+export const openAccountClipsFolder = async (accountId: string): Promise<boolean> => {
+  if (!accountId) {
+    return false
+  }
+  if (BACKEND_MODE === 'api' || typeof window === 'undefined' || !window.api?.openAccountClipsFolder) {
+    console.warn('openAccountClipsFolder bridge is unavailable in API mode.')
+    return false
+  }
+
+  try {
+    return await window.api.openAccountClipsFolder(accountId)
+  } catch (error) {
+    console.error('Unable to open clips folder through bridge', error)
+    return false
+  }
+}
+
 export default listAccountClips


### PR DESCRIPTION
## Summary
- surface an upcoming posts panel on the home page with horizontal clip cards and disclaimer messaging
- expose an Electron bridge method to open the selected account's clips folder from the UI
- reuse account platform statuses to render colour-coded upload targets

## Testing
- pytest *(fails: missing optional dependencies httpx/libGL in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ced412dd4c8323b1fd6390f5d61aac