### PR TITLE
Revamp home and library layouts

### DIFF
--- a/desktop/src/renderer/src/components/ClipCard.tsx
+++ b/desktop/src/renderer/src/components/ClipCard.tsx
@@ -6,9 +6,10 @@ import { formatDuration, formatViews, timeAgo } from '../lib/format'
 type ClipCardProps = {
   clip: Clip
   onClick: () => void
+  isActive?: boolean
 }
 
-const ClipCard: FC<ClipCardProps> = ({ clip, onClick }) => {
+const ClipCard: FC<ClipCardProps> = ({ clip, onClick, isActive = false }) => {
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>): void => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
@@ -16,13 +17,18 @@ const ClipCard: FC<ClipCardProps> = ({ clip, onClick }) => {
     }
   }
 
+  const cardClassName = `group relative flex cursor-pointer flex-col overflow-hidden rounded-xl border bg-[var(--card)] shadow-sm transition hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] ${
+    isActive ? 'border-[var(--ring)] shadow-[0_0_0_1px_var(--ring)]' : 'border-white/10 hover:border-[var(--ring)]'
+  }`
+
   return (
     <article
       role="button"
       tabIndex={0}
       onClick={onClick}
       onKeyDown={handleKeyDown}
-      className="group relative flex cursor-pointer flex-col overflow-hidden rounded-xl bg-[var(--card)] shadow-sm transition hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+      aria-pressed={isActive}
+      className={cardClassName}
     >
       <div className="relative aspect-video w-full overflow-hidden">
         {clip.thumbnail ? (
@@ -51,7 +57,11 @@ const ClipCard: FC<ClipCardProps> = ({ clip, onClick }) => {
         </h3>
         <p className="text-xs font-medium text-[var(--muted)]">{clip.channel}</p>
         <p className="text-xs text-[var(--muted)]">
-          {formatViews(clip.views)} views · {timeAgo(clip.createdAt)}
+          {clip.views !== null && clip.views !== undefined
+            ? `${formatViews(clip.views)} views`
+            : 'Freshly generated'}
+          {' · '}
+          {timeAgo(clip.createdAt)}
         </p>
       </div>
     </article>

--- a/desktop/src/renderer/src/pages/Library.tsx
+++ b/desktop/src/renderer/src/pages/Library.tsx
@@ -8,6 +8,8 @@ import {
 import type { ChangeEvent, FC } from 'react'
 import { useNavigate } from 'react-router-dom'
 import ClipCard from '../components/ClipCard'
+import ClipDescription from '../components/ClipDescription'
+import { formatDuration, formatViews, timeAgo } from '../lib/format'
 import { listAccountClips } from '../services/clipLibrary'
 import type { AccountSummary, Clip, SearchBridge } from '../types'
 
@@ -35,6 +37,7 @@ const Library: FC<LibraryProps> = ({
   const [isLoadingClips, setIsLoadingClips] = useState(false)
   const [clipsError, setClipsError] = useState<string | null>(null)
   const [query, setQuery] = useState('')
+  const [selectedClipId, setSelectedClipId] = useState<string | null>(null)
   const queryRef = useRef('')
   const loadRequestRef = useRef(0)
   const navigate = useNavigate()
@@ -194,6 +197,19 @@ const Library: FC<LibraryProps> = ({
     })
   }, [clips, query])
 
+  useEffect(() => {
+    if (filteredClips.length === 0) {
+      if (selectedClipId !== null) {
+        setSelectedClipId(null)
+      }
+      return
+    }
+
+    if (!selectedClipId || !filteredClips.some((clip) => clip.id === selectedClipId)) {
+      setSelectedClipId(filteredClips[0].id)
+    }
+  }, [filteredClips, selectedClipId])
+
   const groupedClips = useMemo(() => {
     const groups = new Map<
       string,
@@ -224,6 +240,11 @@ const Library: FC<LibraryProps> = ({
       .sort((a, b) => (a.latestCreatedAt < b.latestCreatedAt ? 1 : -1))
   }, [filteredClips])
 
+  const selectedClip = useMemo(
+    () => filteredClips.find((clip) => clip.id === selectedClipId) ?? null,
+    [filteredClips, selectedClipId]
+  )
+
   const handleAccountChange = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {
       const { value } = event.target
@@ -235,6 +256,10 @@ const Library: FC<LibraryProps> = ({
     },
     [onSelectAccount]
   )
+
+  const handleClipSelect = useCallback((clip: Clip) => {
+    setSelectedClipId(clip.id)
+  }, [])
 
   const handleClipOpen = useCallback(
     (clip: Clip) => {
@@ -255,87 +280,229 @@ const Library: FC<LibraryProps> = ({
 
   return (
     <section className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-8">
-      <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-6 shadow-[0_20px_40px_-24px_rgba(15,23,42,0.6)]">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 className="text-xl font-semibold text-[var(--fg)]">Clip library</h2>
-            <p className="text-sm text-[var(--muted)]">
-              Browse generated clips by account or review everything at once.
-            </p>
-          </div>
-          <div className="flex flex-col gap-2 sm:max-w-xs">
-            <label htmlFor="library-account" className="text-xs font-semibold uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_75%,transparent)]">
-              Account
-            </label>
-            <select
-              id="library-account"
-              value={dropdownValue}
-              onChange={handleAccountChange}
-              disabled={!hasAccounts || isLoadingAccounts}
-              className="w-full rounded-lg border border-white/10 bg-[var(--card)] px-4 py-2 text-sm text-[var(--fg)] shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)] focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {!hasAccounts ? (
-                <option value="">No available accounts</option>
-              ) : null}
-              {hasMultipleAccounts ? (
-                <option value={ALL_ACCOUNTS_VALUE}>All accounts</option>
-              ) : null}
-              {availableAccounts.map((account) => (
-                <option key={account.id} value={account.id}>
-                  {account.displayName}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-        {clipsError ? (
-          <div className="rounded-lg border border-rose-400/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
-            {clipsError}
-          </div>
-        ) : null}
-        {!hasAccounts && !isLoadingAccounts ? (
-          <div className="rounded-lg border border-dashed border-white/10 bg-black/20 px-4 py-6 text-sm text-[var(--muted)]">
-            Connect an account with an active platform from your profile to start collecting clips.
-          </div>
-        ) : null}
-        {hasAccounts ? (
-          <div className="flex items-center justify-between text-xs text-[var(--muted)]">
-            <span>
-              Showing {filteredClips.length} {filteredClips.length === 1 ? 'clip' : 'clips'}
-              {selectedAccountId ? ' for the selected account.' : hasMultipleAccounts ? ' from all accounts.' : '.'}
-            </span>
-            {isLoadingClips ? <span className="text-[var(--fg)]">Loading clips…</span> : null}
-          </div>
-        ) : null}
-      </div>
-
-      {hasAccounts ? (
-        filteredClips.length > 0 ? (
-          <div className="flex flex-col gap-6">
-            {groupedClips.map((group) => (
-              <div key={group.id} className="flex flex-col gap-3">
-                <div className="flex items-baseline justify-between">
-                  <h3 className="text-lg font-semibold text-[var(--fg)]">{group.title}</h3>
-                  <span className="text-xs uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_75%,transparent)]">
-                    {group.clips.length} {group.clips.length === 1 ? 'clip' : 'clips'}
-                  </span>
-                </div>
-                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                  {group.clips.map((clip) => (
-                    <ClipCard key={clip.id} clip={clip} onClick={() => handleClipOpen(clip)} />
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.65fr)_minmax(320px,1fr)] xl:grid-cols-[minmax(0,1.8fr)_400px]">
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-6 shadow-[0_20px_40px_-24px_rgba(15,23,42,0.6)]">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold text-[var(--fg)]">Clip library</h2>
+                <p className="text-sm text-[var(--muted)]">
+                  Browse generated clips by account or review everything at once.
+                </p>
+              </div>
+              <div className="flex flex-col gap-2 sm:max-w-xs">
+                <label htmlFor="library-account" className="text-xs font-semibold uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_75%,transparent)]">
+                  Account
+                </label>
+                <select
+                  id="library-account"
+                  value={dropdownValue}
+                  onChange={handleAccountChange}
+                  disabled={!hasAccounts || isLoadingAccounts}
+                  className="w-full rounded-lg border border-white/10 bg-[var(--card)] px-4 py-2 text-sm text-[var(--fg)] shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)] focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {!hasAccounts ? (
+                    <option value="">No available accounts</option>
+                  ) : null}
+                  {hasMultipleAccounts ? (
+                    <option value={ALL_ACCOUNTS_VALUE}>All accounts</option>
+                  ) : null}
+                  {availableAccounts.map((account) => (
+                    <option key={account.id} value={account.id}>
+                      {account.displayName}
+                    </option>
                   ))}
+                </select>
+              </div>
+            </div>
+            {clipsError ? (
+              <div className="rounded-lg border border-rose-400/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+                {clipsError}
+              </div>
+            ) : null}
+            {!hasAccounts && !isLoadingAccounts ? (
+              <div className="rounded-lg border border-dashed border-white/10 bg-black/20 px-4 py-6 text-sm text-[var(--muted)]">
+                Connect an account with an active platform from your profile to start collecting clips.
+              </div>
+            ) : null}
+            {hasAccounts ? (
+              <div className="flex items-center justify-between text-xs text-[var(--muted)]">
+                <span>
+                  Showing {filteredClips.length} {filteredClips.length === 1 ? 'clip' : 'clips'}
+                  {selectedAccountId ? ' for the selected account.' : hasMultipleAccounts ? ' from all accounts.' : '.'}
+                </span>
+                {isLoadingClips ? <span className="text-[var(--fg)]">Loading clips…</span> : null}
+              </div>
+            ) : null}
+          </div>
+
+          {hasAccounts ? (
+            filteredClips.length > 0 ? (
+              <div className="flex flex-col gap-6">
+                {groupedClips.map((group) => (
+                  <div key={group.id} className="flex flex-col gap-3">
+                    <div className="flex items-baseline justify-between">
+                      <h3 className="text-lg font-semibold text-[var(--fg)]">{group.title}</h3>
+                      <span className="text-xs uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_75%,transparent)]">
+                        {group.clips.length} {group.clips.length === 1 ? 'clip' : 'clips'}
+                      </span>
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                      {group.clips.map((clip) => (
+                        <ClipCard
+                          key={clip.id}
+                          clip={clip}
+                          onClick={() => handleClipSelect(clip)}
+                          isActive={clip.id === selectedClipId}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="flex flex-1 flex-col items-center justify-center rounded-2xl border border-dashed border-white/10 bg-[color:color-mix(in_srgb,var(--card)_65%,transparent)] p-10 text-center text-sm text-[var(--muted)]">
+                {isLoadingClips
+                  ? 'Loading your clips…'
+                  : 'No clips match the current filters. Try selecting a different account or clearing your search.'}
+              </div>
+            )
+          ) : null}
+        </div>
+
+        <aside className="lg:sticky lg:top-6">
+          <div className="flex h-full flex-col gap-4 rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-6 shadow-[0_20px_40px_-24px_rgba(15,23,42,0.6)]">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-[var(--fg)]">Clip preview</h2>
+              <p className="text-sm text-[var(--muted)]">
+                {selectedClip
+                  ? 'Review the highlight before downloading or sharing it.'
+                  : hasAccounts
+                    ? 'Select a clip from the library to see its details.'
+                    : 'Connect an account to build your clip library.'}
+              </p>
+            </div>
+            {selectedClip ? (
+              <div className="flex flex-col gap-4">
+                <div className="flex w-full justify-center overflow-hidden rounded-xl bg-black/80 p-2">
+                  <video
+                    key={selectedClip.id}
+                    src={selectedClip.playbackUrl}
+                    poster={selectedClip.thumbnail ?? undefined}
+                    controls
+                    playsInline
+                    preload="metadata"
+                    className="h-full w-full max-w-sm object-contain"
+                  >
+                    Your browser does not support the video tag.
+                  </video>
+                </div>
+                <div className="space-y-4 text-sm text-[var(--muted)]">
+                  <div className="space-y-3">
+                    {selectedClip.quote ? (
+                      <p className="text-lg font-semibold text-[var(--fg)] leading-tight">“{selectedClip.quote}”</p>
+                    ) : (
+                      <p className="text-lg font-semibold text-[var(--fg)] leading-tight">{selectedClip.title}</p>
+                    )}
+                    {selectedClip.reason ? (
+                      <div className="space-y-1">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_80%,transparent)]">
+                          Reason
+                        </span>
+                        <p className="rounded-lg border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_60%,transparent)] p-3 text-sm leading-relaxed text-[var(--fg)]/80">
+                          {selectedClip.reason}
+                        </p>
+                      </div>
+                    ) : null}
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+                      <span className="font-semibold text-[var(--fg)]">{selectedClip.channel}</span>
+                      {selectedClip.views !== null ? <span>{formatViews(selectedClip.views)} views</span> : null}
+                      <span>Duration {formatDuration(selectedClip.durationSec)}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3 text-xs">
+                      <span>Generated {timeAgo(selectedClip.createdAt)}</span>
+                      {selectedClip.sourcePublishedAt ? (
+                        <span>Source uploaded {timeAgo(selectedClip.sourcePublishedAt)}</span>
+                      ) : null}
+                    </div>
+                  </div>
+                  <dl className="grid gap-3 rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_75%,transparent)] p-4 text-xs text-[var(--muted)] sm:grid-cols-[auto_1fr]">
+                    {selectedClip.rating !== null && selectedClip.rating !== undefined ? (
+                      <>
+                        <dt className="font-medium text-[var(--fg)]">Score</dt>
+                        <dd className="text-[var(--fg)]">
+                          {selectedClip.rating.toFixed(1).replace(/\.0$/, '')}
+                        </dd>
+                      </>
+                    ) : null}
+                    <dt className="font-medium text-[var(--fg)]">Clip created</dt>
+                    <dd>{new Date(selectedClip.createdAt).toLocaleString()}</dd>
+                    <dt className="font-medium text-[var(--fg)]">Source uploaded</dt>
+                    <dd>{selectedClip.sourcePublishedAt ? new Date(selectedClip.sourcePublishedAt).toLocaleString() : 'Unknown'}</dd>
+                    {selectedClip.timestampSeconds !== null && selectedClip.timestampSeconds !== undefined ? (
+                      <>
+                        <dt className="font-medium text-[var(--fg)]">Starts at</dt>
+                        <dd>{formatDuration(selectedClip.timestampSeconds)}</dd>
+                      </>
+                    ) : null}
+                  </dl>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={() => handleClipOpen(selectedClip)}
+                      className="rounded-lg border border-transparent bg-[var(--ring)] px-3 py-1.5 text-xs font-semibold text-white transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)]"
+                    >
+                      Open clip details
+                    </button>
+                    <a
+                      href={selectedClip.sourceUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-xs font-medium text-[var(--fg)] transition hover:border-[var(--ring)] hover:text-white"
+                    >
+                      View full video
+                      <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" aria-hidden="true">
+                        <path
+                          fill="currentColor"
+                          d="M13.5 2h-5a.75.75 0 0 0 0 1.5H11l-6.72 6.72a.75.75 0 0 0 1.06 1.06L12 4.56v2.5a.75.75 0 0 0 1.5 0v-5A.75.75 0 0 0 13.5 2"
+                        />
+                      </svg>
+                    </a>
+                    {selectedClip.timestampUrl ? (
+                      <a
+                        href={selectedClip.timestampUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-xs font-medium text-[var(--fg)] transition hover:border-[var(--ring)] hover:text-white"
+                      >
+                        Jump to{' '}
+                        <span className="font-semibold text-white">
+                          {selectedClip.timestampSeconds !== null && selectedClip.timestampSeconds !== undefined
+                            ? formatDuration(selectedClip.timestampSeconds)
+                            : 'timestamp'}
+                        </span>
+                      </a>
+                    ) : null}
+                  </div>
+                  <div className="space-y-2">
+                    <h4 className="text-sm font-semibold text-[var(--fg)]">Description</h4>
+                    <ClipDescription
+                      text={selectedClip.description}
+                      className="text-sm leading-relaxed text-[var(--muted)]"
+                    />
+                  </div>
                 </div>
               </div>
-            ))}
+            ) : (
+              <div className="rounded-xl border border-dashed border-white/10 bg-[color:color-mix(in_srgb,var(--card)_65%,transparent)] p-8 text-center text-sm text-[var(--muted)]">
+                {hasAccounts
+                  ? 'Select a clip from the library to see its preview on the right.'
+                  : 'Connect an account to build your clip library.'}
+              </div>
+            )}
           </div>
-        ) : (
-          <div className="flex flex-1 flex-col items-center justify-center rounded-2xl border border-dashed border-white/10 bg-[color:color-mix(in_srgb,var(--card)_65%,transparent)] p-10 text-center text-sm text-[var(--muted)]">
-            {isLoadingClips
-              ? 'Loading your clips…'
-              : 'No clips match the current filters. Try selecting a different account or clearing your search.'}
-          </div>
-        )
-      ) : null}
+        </aside>
+      </div>
     </section>
   )
 }

--- a/desktop/src/renderer/src/tests/clipcard.test.tsx
+++ b/desktop/src/renderer/src/tests/clipcard.test.tsx
@@ -32,12 +32,17 @@ describe('ClipCard', () => {
   })
 
   it('falls back to inline video preview when thumbnail is missing', () => {
-    const clipWithoutThumbnail: Clip = { ...mockClip, thumbnail: null }
+    const clipWithoutThumbnail: Clip = {
+      ...mockClip,
+      id: 'clip-without-thumbnail',
+      thumbnail: null,
+      playbackUrl: 'file:///videos/clip-without-thumbnail.mp4'
+    }
 
-    render(<ClipCard clip={clipWithoutThumbnail} onClick={() => {}} />)
+    const { container } = render(<ClipCard clip={clipWithoutThumbnail} onClick={() => {}} />)
 
-    expect(screen.queryByRole('img')).not.toBeInTheDocument()
-    const video = screen.getByRole('button').querySelector('video')
+    expect(container.querySelector('img')).toBeNull()
+    const video = container.querySelector('video')
     expect(video).not.toBeNull()
     expect(video?.getAttribute('src')).toBe(clipWithoutThumbnail.playbackUrl)
   })

--- a/desktop/src/renderer/src/tests/clipdrawer.test.tsx
+++ b/desktop/src/renderer/src/tests/clipdrawer.test.tsx
@@ -34,7 +34,7 @@ describe('ClipDrawer', () => {
       <ClipDrawer clips={sampleClips} selectedClipId={sampleClips[0].id} onSelect={onSelect} onRemove={onRemove} />
     )
 
-    expect(screen.getByRole('button', { name: /clip library/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /clips from source/i })).toBeInTheDocument()
     expect(screen.getByText(/first highlight/i)).toBeInTheDocument()
 
     fireEvent.click(screen.getByText(/second highlight/i))
@@ -43,7 +43,7 @@ describe('ClipDrawer', () => {
     fireEvent.click(screen.getByLabelText(/remove first highlight/i))
     expect(onRemove).toHaveBeenCalledWith('clip-1')
 
-    fireEvent.click(screen.getByRole('button', { name: /clip library/i }))
+    fireEvent.click(screen.getByRole('button', { name: /clips from source/i }))
     expect(screen.getByText(/drawer collapsed/i)).toBeInTheDocument()
   })
 })

--- a/desktop/src/renderer/src/tests/home.test.tsx
+++ b/desktop/src/renderer/src/tests/home.test.tsx
@@ -231,9 +231,11 @@ describe('Home pipeline events', () => {
       } as any)
     })
 
-    expect(screen.getAllByText(/space wonders/i)[0]).toBeInTheDocument()
-    expect(screen.getAllByText(/mind-blowing fact/i)[0]).toBeInTheDocument()
-    expect(screen.getByText(/#space/i)).toBeInTheDocument()
+    const timelineItem = screen.getAllByText(/space wonders/i)[0].closest('li')
+    expect(timelineItem).not.toBeNull()
+    const timelineScope = within(timelineItem as HTMLElement)
+    expect(timelineScope.getByText(/creator hub/i)).toBeInTheDocument()
+    expect(timelineScope.getByText(/duration 0:32/i)).toBeInTheDocument()
   })
 
   it('surfaces clip batch progress updates for multi-clip steps', async () => {

--- a/desktop/src/renderer/src/tests/profile.test.tsx
+++ b/desktop/src/renderer/src/tests/profile.test.tsx
@@ -91,7 +91,7 @@ describe('Profile page', () => {
     renderProfile()
 
     expect(screen.getByText('Profile')).toBeInTheDocument()
-    expect(screen.getByText(/Connected platforms:/i)).toHaveTextContent('1/1')
+    expect(screen.getByText(/Connected platforms across/i)).toHaveTextContent('1/1')
 
     const creatorCard = screen.getAllByTestId('account-card-account-1')[0]
     const scope = within(creatorCard)


### PR DESCRIPTION
## Summary
- redesign the home page to focus on processing controls and a right-aligned upload timeline
- restructure the library page with a selectable clip grid and detailed preview panel
- update clip card styling and adjust associated unit tests for the new layouts

## Testing
- npx vitest run --config src/renderer/vitest.config.ts
- pytest *(fails: missing optional dependencies `httpx` and `libGL` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf69900e1c83238550864e21247a9e