### PR TITLE
Add clip review workflow and editing UI

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import type { FC, RefObject } from 'react'
 import { NavLink, Route, Routes } from 'react-router-dom'
 import Search from './components/Search'
 import ClipPage from './pages/Clip'
+import ClipEdit from './pages/ClipEdit'
 import Home from './pages/Home'
 import Library from './pages/Library'
 import Profile from './pages/Profile'
@@ -66,7 +67,9 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
     selectedClipId: null,
     selectedAccountId: null,
     accountError: null,
-    activeJobId: null
+    activeJobId: null,
+    reviewMode: false,
+    awaitingReview: false
   }))
   const [accounts, setAccounts] = useState<AccountSummary[]>([])
   const [accountsError, setAccountsError] = useState<string | null>(null)
@@ -395,6 +398,7 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
             }
           />
           <Route path="/clip/:id" element={<ClipPage registerSearch={registerSearch} />} />
+          <Route path="/clip/:id/edit" element={<ClipEdit registerSearch={registerSearch} />} />
           <Route path="/settings" element={<Settings registerSearch={registerSearch} />} />
           <Route
             path="/profile"

--- a/desktop/src/renderer/src/pages/ClipEdit.tsx
+++ b/desktop/src/renderer/src/pages/ClipEdit.tsx
@@ -1,0 +1,376 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { FC, ChangeEvent } from 'react'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { formatDuration } from '../lib/format'
+import { adjustJobClip } from '../services/pipelineApi'
+import { adjustLibraryClip } from '../services/clipLibrary'
+import type { Clip, SearchBridge } from '../types'
+
+type ClipEditLocationState = {
+  clip?: Clip
+  jobId?: string | null
+  accountId?: string | null
+  context?: 'job' | 'library'
+}
+
+const parseClipBounds = (clipId: string): { start: number; end: number } | null => {
+  const match = clipId.match(/clip_(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)/i)
+  if (!match) {
+    return null
+  }
+  const [, startRaw, endRaw] = match
+  const start = Number.parseFloat(startRaw ?? '')
+  const end = Number.parseFloat(endRaw ?? '')
+  if (Number.isNaN(start) || Number.isNaN(end) || end <= start) {
+    return null
+  }
+  return { start, end }
+}
+
+const toSeconds = (value: number): number => Math.max(0, Number.isFinite(value) ? value : 0)
+
+const ClipEdit: FC<{ registerSearch: (bridge: SearchBridge | null) => void }> = ({ registerSearch }) => {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const state = (location.state as ClipEditLocationState | null) ?? null
+
+  const sourceClip = state?.clip && (!id || state.clip.id === id) ? state.clip : null
+
+  useEffect(() => {
+    registerSearch(null)
+    return () => registerSearch(null)
+  }, [registerSearch])
+
+  const parsedBounds = useMemo(() => (sourceClip ? parseClipBounds(sourceClip.id) : null), [sourceClip])
+  const originalStart = parsedBounds?.start ?? 0
+  const originalEnd = parsedBounds?.end ?? (sourceClip ? originalStart + sourceClip.durationSec : originalStart + 10)
+
+  const [windowPadding, setWindowPadding] = useState(5)
+  const [rangeStart, setRangeStart] = useState(originalStart)
+  const [rangeEnd, setRangeEnd] = useState(originalEnd)
+  const [clipState, setClipState] = useState(sourceClip)
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saveSuccess, setSaveSuccess] = useState<string | null>(null)
+
+  const applyUpdatedClip = useCallback(
+    (updated: Clip, fallbackStart: number, fallbackEnd: number) => {
+      setClipState(updated)
+      const bounds = parseClipBounds(updated.id)
+      if (bounds) {
+        setRangeStart(bounds.start)
+        setRangeEnd(bounds.end)
+      } else {
+        setRangeStart(fallbackStart)
+        setRangeEnd(fallbackEnd)
+      }
+    },
+    []
+  )
+
+  useEffect(() => {
+    setClipState(sourceClip)
+    if (sourceClip) {
+      const bounds = parseClipBounds(sourceClip.id)
+      if (bounds) {
+        setRangeStart(bounds.start)
+        setRangeEnd(bounds.end)
+      } else {
+        setRangeStart(0)
+        setRangeEnd(sourceClip.durationSec)
+      }
+    }
+  }, [sourceClip])
+
+  const windowStartBase = Math.min(originalStart, rangeStart)
+  const windowEndBase = Math.max(originalEnd, rangeEnd)
+  const windowStart = Math.max(0, windowStartBase - windowPadding)
+  const windowEnd = windowEndBase + windowPadding
+  const minGap = 0.25
+
+  const clampWithinWindow = useCallback(
+    (value: number, kind: 'start' | 'end'): number => {
+      if (kind === 'start') {
+        return Math.min(Math.max(windowStart, value), rangeEnd - minGap)
+      }
+      return Math.max(Math.min(windowEnd, value), rangeStart + minGap)
+    },
+    [rangeEnd, rangeStart, windowEnd, windowStart]
+  )
+
+  const handleStartChange = useCallback(
+    (value: number) => {
+      const next = clampWithinWindow(value, 'start')
+      setRangeStart(Math.min(next, rangeEnd - minGap))
+    },
+    [clampWithinWindow, rangeEnd]
+  )
+
+  const handleEndChange = useCallback(
+    (value: number) => {
+      const next = clampWithinWindow(value, 'end')
+      setRangeEnd(Math.max(next, rangeStart + minGap))
+    },
+    [clampWithinWindow, rangeStart]
+  )
+
+  const handleRangeInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>, kind: 'start' | 'end') => {
+      const value = Number.parseFloat(event.target.value)
+      if (Number.isNaN(value)) {
+        return
+      }
+      if (kind === 'start') {
+        handleStartChange(value)
+      } else {
+        handleEndChange(value)
+      }
+    },
+    [handleEndChange, handleStartChange]
+  )
+
+  const handleReset = useCallback(() => {
+    setRangeStart(originalStart)
+    setRangeEnd(originalEnd)
+    setWindowPadding(5)
+    setSaveError(null)
+    setSaveSuccess(null)
+  }, [originalEnd, originalStart])
+
+  const durationSeconds = Math.max(minGap, rangeEnd - rangeStart)
+  const context = state?.context ?? 'job'
+
+  const handleSave = useCallback(async () => {
+    if (!clipState) {
+      return
+    }
+    const adjustedStart = toSeconds(rangeStart)
+    const adjustedEnd = toSeconds(rangeEnd)
+    if (adjustedEnd - adjustedStart < minGap) {
+      setSaveError('Clip length must be at least 0.25 seconds.')
+      setSaveSuccess(null)
+      return
+    }
+
+    setIsSaving(true)
+    setSaveError(null)
+    try {
+      if (context === 'library') {
+        const accountId = state?.accountId ?? clipState.accountId
+        if (!accountId) {
+          throw new Error('Missing account information for this clip.')
+        }
+        const updated = await adjustLibraryClip(accountId, clipState.id, {
+          startSeconds: adjustedStart,
+          endSeconds: adjustedEnd
+        })
+        applyUpdatedClip(updated, adjustedStart, adjustedEnd)
+      } else {
+        const jobId = state?.jobId
+        if (!jobId) {
+          throw new Error('Missing job information for this clip.')
+        }
+        const updated = await adjustJobClip(jobId, clipState.id, {
+          startSeconds: adjustedStart,
+          endSeconds: adjustedEnd
+        })
+        applyUpdatedClip(updated, adjustedStart, adjustedEnd)
+      }
+      setSaveSuccess('Clip boundaries updated successfully.')
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unable to update the clip boundaries. Please try again.'
+      setSaveError(message)
+      setSaveSuccess(null)
+    } finally {
+      setIsSaving(false)
+    }
+  }, [
+    applyUpdatedClip,
+    clipState,
+    context,
+    rangeEnd,
+    rangeStart,
+    state?.accountId,
+    state?.jobId
+  ])
+
+  if (!clipState || !id) {
+    return (
+      <section className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-6 px-4 py-10">
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="self-start rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-[var(--fg)] transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+        >
+          Back
+        </button>
+        <div className="flex flex-1 flex-col items-center justify-center rounded-xl border border-dashed border-white/10 bg-[color:color-mix(in_srgb,var(--card)_60%,transparent)] p-10 text-center">
+          <h2 className="text-xl font-semibold text-[var(--fg)]">Clip information unavailable</h2>
+          <p className="mt-2 max-w-md text-sm text-[var(--muted)]">
+            We couldn’t find the clip details needed for editing. Return to the previous page and try opening the editor again.
+          </p>
+        </div>
+      </section>
+    )
+  }
+
+  const timelineTotal = Math.max(windowEnd - windowStart, minGap)
+  const startPercent = ((rangeStart - windowStart) / timelineTotal) * 100
+  const endPercent = ((rangeEnd - windowStart) / timelineTotal) * 100
+
+  return (
+    <section className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-8 px-4 py-10">
+      <button
+        type="button"
+        onClick={() => navigate(-1)}
+        className="self-start rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-[var(--fg)] transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+      >
+        Back
+      </button>
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <div className="flex-1 rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-4">
+          <video
+            key={`${clipState.id}-${clipState.playbackUrl}`}
+            src={clipState.playbackUrl}
+            poster={clipState.thumbnail ?? undefined}
+            controls
+            playsInline
+            preload="metadata"
+            className="h-full w-full rounded-xl bg-black/50 object-contain"
+          >
+            Your browser does not support the video tag.
+          </video>
+        </div>
+        <div className="flex w-full max-w-xl flex-col gap-6">
+          <div className="space-y-2">
+            <h1 className="text-2xl font-semibold text-[var(--fg)]">Refine clip boundaries</h1>
+            <p className="text-sm text-[var(--muted)]">
+              Drag the handles or enter precise timestamps to trim the clip before regenerating subtitles and renders.
+            </p>
+          </div>
+          <div className="space-y-3 rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-4">
+            <div className="space-y-2">
+              <div className="text-xs uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_70%,transparent)]">
+                Clip window
+              </div>
+              <div className="relative h-2 rounded-full bg-white/10">
+                <div
+                  className="absolute h-2 rounded-full bg-[var(--ring)]"
+                  style={{ left: `${startPercent}%`, right: `${100 - endPercent}%` }}
+                />
+              </div>
+              <div className="relative mt-6 flex items-center">
+                <input
+                  type="range"
+                  min={windowStart}
+                  max={windowEnd}
+                  step="0.1"
+                  value={rangeStart}
+                  onChange={(event) => handleRangeInputChange(event, 'start')}
+                  className="pointer-events-auto absolute z-20 h-2 w-full appearance-none bg-transparent"
+                />
+                <input
+                  type="range"
+                  min={windowStart}
+                  max={windowEnd}
+                  step="0.1"
+                  value={rangeEnd}
+                  onChange={(event) => handleRangeInputChange(event, 'end')}
+                  className="pointer-events-auto absolute z-10 h-2 w-full appearance-none bg-transparent"
+                />
+              </div>
+              <div className="flex justify-between text-xs text-[var(--muted)]">
+                <span>{formatDuration(windowStart)}</span>
+                <span>{formatDuration(windowEnd)}</span>
+              </div>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_70%,transparent)]">
+                Start time
+                <input
+                  type="number"
+                  step="0.1"
+                  min={windowStart}
+                  max={rangeEnd - minGap}
+                  value={rangeStart.toFixed(1)}
+                  onChange={(event) => handleRangeInputChange(event, 'start')}
+                  className="rounded-lg border border-white/10 bg-[var(--card)] px-3 py-2 text-sm text-[var(--fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_70%,transparent)]">
+                End time
+                <input
+                  type="number"
+                  step="0.1"
+                  min={rangeStart + minGap}
+                  max={windowEnd}
+                  value={rangeEnd.toFixed(1)}
+                  onChange={(event) => handleRangeInputChange(event, 'end')}
+                  className="rounded-lg border border-white/10 bg-[var(--card)] px-3 py-2 text-sm text-[var(--fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+                />
+              </label>
+            </div>
+            <div className="flex flex-col gap-2 text-sm text-[var(--muted)]">
+              <div className="flex items-center justify-between">
+                <span>Adjusted duration</span>
+                <span className="font-semibold text-[var(--fg)]">{formatDuration(durationSeconds)}</span>
+              </div>
+              <label className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_70%,transparent)]">
+                Review window
+                <input
+                  type="range"
+                  min={0}
+                  max={30}
+                  step={1}
+                  value={windowPadding}
+                  onChange={(event) => setWindowPadding(Number.parseFloat(event.target.value) || 0)}
+                  className="ml-4 flex-1"
+                />
+              </label>
+              <p className="text-xs">
+                Expanding the window gives you more room to pull the clip start earlier or extend the ending for additional context.
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={isSaving}
+              className="rounded-lg border border-transparent bg-[var(--ring)] px-3 py-2 text-sm font-semibold text-white transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSaving ? 'Saving…' : 'Save adjustments'}
+            </button>
+            <button
+              type="button"
+              onClick={handleReset}
+              className="rounded-lg border border-white/10 px-3 py-2 text-sm font-medium text-[var(--fg)] transition hover:border-[var(--ring)] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+            >
+              Reset to original
+            </button>
+          </div>
+          {saveError ? <p className="text-sm text-rose-400">{saveError}</p> : null}
+          {saveSuccess ? <p className="text-sm text-emerald-300">{saveSuccess}</p> : null}
+        </div>
+      </div>
+      <div className="grid gap-3 rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-4 text-sm text-[var(--muted)] sm:grid-cols-[auto_1fr]">
+        <span className="font-medium text-[var(--fg)]">Original start</span>
+        <span>{formatDuration(originalStart)}</span>
+        <span className="font-medium text-[var(--fg)]">Original end</span>
+        <span>{formatDuration(originalEnd)}</span>
+        <span className="font-medium text-[var(--fg)]">Current start</span>
+        <span>{formatDuration(rangeStart)}</span>
+        <span className="font-medium text-[var(--fg)]">Current end</span>
+        <span>{formatDuration(rangeEnd)}</span>
+        <span className="font-medium text-[var(--fg)]">Clip title</span>
+        <span>{clipState.title}</span>
+        <span className="font-medium text-[var(--fg)]">Channel</span>
+        <span>{clipState.channel}</span>
+      </div>
+    </section>
+  )
+}
+
+export default ClipEdit

--- a/desktop/src/renderer/src/pages/Library.tsx
+++ b/desktop/src/renderer/src/pages/Library.tsx
@@ -156,6 +156,21 @@ const Library: FC<LibraryProps> = ({
     return () => registerSearch(null)
   }, [handleQueryChange, handleQueryClear, registerSearch])
 
+  const handleAdjustClipBoundaries = useCallback(
+    (clip: Clip) => {
+      navigate(`/clip/${encodeURIComponent(clip.id)}/edit`, {
+        state: {
+          clip,
+          jobId: null,
+          accountId:
+            clip.accountId ?? (accountFilter === ALL_ACCOUNTS_VALUE ? selectedAccountId : accountFilter),
+          context: 'library'
+        }
+      })
+    },
+    [accountFilter, navigate, selectedAccountId]
+  )
+
   const targetAccountIds = useMemo(() => {
     if (!hasAccounts) {
       return []
@@ -532,6 +547,13 @@ const Library: FC<LibraryProps> = ({
                       className="rounded-lg border border-transparent bg-[var(--ring)] px-3 py-1.5 text-xs font-semibold text-white transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)]"
                     >
                       Open clip details
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleAdjustClipBoundaries(selectedClip)}
+                      className="rounded-lg border border-white/10 px-3 py-1.5 text-xs font-medium text-[var(--fg)] transition hover:border-[var(--ring)] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+                    >
+                      Adjust clip boundaries
                     </button>
                     <a
                       href={selectedClip.sourceUrl}

--- a/desktop/src/renderer/src/services/pipelineApi.ts
+++ b/desktop/src/renderer/src/services/pipelineApi.ts
@@ -1,5 +1,6 @@
-import { advanceApiBaseUrl, buildJobUrl, buildWebSocketUrl } from '../config/backend'
-import type { PipelineEventType } from '../types'
+import { advanceApiBaseUrl, buildJobUrl, buildWebSocketUrl, getApiBaseUrl } from '../config/backend'
+import { parseClipTimestamp } from '../lib/clipMetadata'
+import type { Clip, PipelineEventType } from '../types'
 
 type UnknownRecord = Record<string, unknown>
 
@@ -7,6 +8,7 @@ export type PipelineJobRequest = {
   url: string
   account?: string | null
   tone?: string | null
+  reviewMode?: boolean
 }
 
 export type PipelineJobResponse = {
@@ -45,7 +47,8 @@ export const startPipelineJob = async (request: PipelineJobRequest): Promise<Pip
         body: JSON.stringify({
           url: request.url,
           account: request.account ?? null,
-          tone: request.tone ?? null
+          tone: request.tone ?? null,
+          review_mode: request.reviewMode ?? false
         })
       })
       break
@@ -82,6 +85,105 @@ export const startPipelineJob = async (request: PipelineJobRequest): Promise<Pip
   }
 
   return { jobId }
+}
+
+export const normaliseJobClip = (payload: UnknownRecord): Clip | null => {
+  const rawId = payload.id ?? payload.clip_id
+  const id = typeof rawId === 'string' && rawId.length > 0 ? rawId : null
+  const title = typeof payload.title === 'string' && payload.title.length > 0 ? payload.title : id
+  const channel =
+    typeof payload.channel === 'string' && payload.channel.length > 0 ? payload.channel : 'Unknown channel'
+  const createdAt = typeof payload.created_at === 'string' ? payload.created_at : null
+  const durationSeconds = typeof payload.duration_seconds === 'number' ? payload.duration_seconds : null
+  const description = typeof payload.description === 'string' ? payload.description : null
+  const playbackUrl = typeof payload.playback_url === 'string' ? payload.playback_url : null
+  const sourceUrl = typeof payload.source_url === 'string' ? payload.source_url : null
+  const sourceTitle = typeof payload.source_title === 'string' ? payload.source_title : title
+  if (!id || !title || !createdAt || durationSeconds === null || !description || !playbackUrl || !sourceUrl) {
+    return null
+  }
+
+  const sourcePublishedAt =
+    typeof payload.source_published_at === 'string' ? payload.source_published_at : null
+  const views = typeof payload.views === 'number' ? payload.views : null
+  const rating = typeof payload.rating === 'number' ? payload.rating : null
+  const quote = typeof payload.quote === 'string' ? payload.quote : null
+  const reason = typeof payload.reason === 'string' ? payload.reason : null
+  const accountId = typeof payload.account === 'string' ? payload.account : null
+  const videoId = typeof payload.video_id === 'string' ? payload.video_id : id
+  const videoTitle = typeof payload.video_title === 'string' ? payload.video_title : sourceTitle
+
+  const { timestampUrl, timestampSeconds } = parseClipTimestamp(description)
+
+  const clip: Clip = {
+    id,
+    title,
+    channel,
+    views,
+    createdAt,
+    durationSec: durationSeconds,
+    thumbnail: null,
+    playbackUrl,
+    description,
+    sourceUrl,
+    sourceTitle,
+    sourcePublishedAt,
+    videoId,
+    videoTitle,
+    rating,
+    quote,
+    reason,
+    timestampUrl,
+    timestampSeconds,
+    accountId
+  }
+
+  return clip
+}
+
+export type ClipAdjustmentPayload = {
+  startSeconds: number
+  endSeconds: number
+}
+
+export const adjustJobClip = async (
+  jobId: string,
+  clipId: string,
+  adjustment: ClipAdjustmentPayload
+): Promise<Clip> => {
+  const url = new URL(
+    `/api/jobs/${encodeURIComponent(jobId)}/clips/${encodeURIComponent(clipId)}/adjust`,
+    getApiBaseUrl()
+  )
+  const response = await fetch(url.toString(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      start_seconds: adjustment.startSeconds,
+      end_seconds: adjustment.endSeconds
+    })
+  })
+
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`)
+  }
+
+  const payload = (await response.json()) as UnknownRecord
+  const clip = normaliseJobClip(payload)
+  if (!clip) {
+    throw new Error('Received malformed clip data from the server.')
+  }
+  return clip
+}
+
+export const resumePipelineJob = async (jobId: string): Promise<void> => {
+  const url = new URL(`/api/jobs/${encodeURIComponent(jobId)}/resume`, getApiBaseUrl())
+  const response = await fetch(url.toString(), { method: 'POST' })
+  if (!response.ok) {
+    throw new Error(`Unable to resume pipeline job (status ${response.status}).`)
+  }
 }
 
 export const subscribeToPipelineEvents = (

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -118,6 +118,8 @@ export interface HomePipelineState {
   selectedAccountId: string | null
   accountError: string | null
   activeJobId: string | null
+  reviewMode: boolean
+  awaitingReview: boolean
 }
 
 export type PipelineEventType =

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List
 
+import pytest
+
 from fastapi.testclient import TestClient
 
 import server.app
 import server.config as pipeline_config
+import server.library
 from interfaces.progress import PipelineEvent, PipelineEventType
 
 
@@ -24,7 +28,15 @@ def test_job_lifecycle(monkeypatch) -> None:
         ),
     ]
 
-    def _fake_process(url: str, account=None, tone=None, observer=None) -> None:
+    def _fake_process(
+        url: str,
+        account=None,
+        tone=None,
+        observer=None,
+        *,
+        pause_for_review: bool = False,
+        review_gate=None,
+    ) -> None:
         assert observer is not None
         for event in events:
             observer.handle_event(event)
@@ -56,6 +68,72 @@ def test_job_lifecycle(monkeypatch) -> None:
         server.app._jobs.clear()
 
 
+def test_job_resume_unblocks_review_mode(monkeypatch) -> None:
+    def _fake_process(
+        url: str,
+        account=None,
+        tone=None,
+        observer=None,
+        *,
+        pause_for_review: bool = False,
+        review_gate=None,
+    ) -> None:
+        assert observer is not None
+        observer.handle_event(
+            PipelineEvent(
+                type=PipelineEventType.PIPELINE_STARTED,
+                data={"url": url},
+            )
+        )
+        if pause_for_review and review_gate is not None:
+            review_gate()
+        observer.handle_event(
+            PipelineEvent(
+                type=PipelineEventType.PIPELINE_COMPLETED,
+                data={"success": True},
+            )
+        )
+
+    monkeypatch.setattr(server.app, "process_video", _fake_process)
+
+    client = TestClient(server.app.app)
+    response = client.post(
+        "/api/jobs",
+        json={"url": "https://example.com/video", "review_mode": True},
+    )
+    assert response.status_code == 202
+    job_id = response.json()["job_id"]
+
+    # Job should be waiting for resume before finishing
+    for _ in range(20):
+        status_response = client.get(f"/api/jobs/{job_id}")
+        assert status_response.status_code == 200
+        if status_response.json()["finished"]:
+            break
+        time.sleep(0.01)
+    else:
+        status_payload = status_response.json()
+        assert status_payload["finished"] is False
+
+    resume_response = client.post(f"/api/jobs/{job_id}/resume")
+    assert resume_response.status_code == 204
+
+    for _ in range(100):
+        status_response = client.get(f"/api/jobs/{job_id}")
+        assert status_response.status_code == 200
+        if status_response.json()["finished"]:
+            break
+        time.sleep(0.01)
+    else:  # pragma: no cover - defensive guard
+        raise AssertionError("Pipeline job did not finish after resume")
+
+    state = server.app._get_job(job_id)
+    if state and state.thread is not None:
+        state.thread.join(timeout=1)
+    with server.app._jobs_lock:
+        server.app._jobs.clear()
+
+
 def test_clip_endpoints_expose_rendered_clips(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -68,7 +146,15 @@ def test_clip_endpoints_expose_rendered_clips(
     description = "Full video: https://youtube.com/watch?v=abc\n#space"
     created_at = datetime(2024, 6, 1, 12, 0, tzinfo=timezone.utc)
 
-    def _fake_process(url: str, account=None, tone=None, observer=None) -> None:
+    def _fake_process(
+        url: str,
+        account=None,
+        tone=None,
+        observer=None,
+        *,
+        pause_for_review: bool = False,
+        review_gate=None,
+    ) -> None:
         assert observer is not None
         observer.handle_event(
             PipelineEvent(
@@ -147,6 +233,157 @@ def test_clip_endpoints_expose_rendered_clips(
         state.thread.join(timeout=1)
     with server.app._jobs_lock:
         server.app._jobs.clear()
+
+
+def test_adjust_job_clip_rebuilds_assets(monkeypatch, tmp_path: Path) -> None:
+    project_dir = tmp_path / "Sample_Project"
+    project_dir.mkdir()
+    shorts_dir = project_dir / "shorts"
+    clips_dir = project_dir / "clips"
+    subtitles_dir = project_dir / "subtitles"
+    shorts_dir.mkdir()
+    clips_dir.mkdir()
+    subtitles_dir.mkdir()
+
+    video_path = project_dir / "Sample_Project.mp4"
+    video_path.write_bytes(b"video")
+    transcript_path = project_dir / "Sample_Project.txt"
+    transcript_path.write_text("[0.00 -> 30.00] Hello world", encoding="utf-8")
+
+    stem = "clip_5.00-15.00_r9.0"
+    raw_clip_path = clips_dir / f"{stem}.mp4"
+    raw_clip_path.write_bytes(b"raw")
+    subtitle_path = subtitles_dir / f"{stem}.srt"
+    subtitle_path.write_text(
+        "1\n00:00:00,000 --> 00:00:02,000\nHi\n\n",
+        encoding="utf-8",
+    )
+    vertical_path = shorts_dir / f"{stem}.mp4"
+    vertical_path.write_bytes(b"vertical")
+    description_path = shorts_dir / f"{stem}.txt"
+    description_path.write_text(
+        "Full video: https://youtube.com/watch?v=abc&t=5\nCredit: Creator\nMade by Atropos",
+        encoding="utf-8",
+    )
+
+    def _fake_save_clip(*_, **__) -> bool:
+        raw_clip_path.write_bytes(b"raw-updated")
+        return True
+
+    def _fake_render_vertical(*_, **__) -> Path:
+        vertical_path.write_bytes(b"vertical-updated")
+        return vertical_path
+
+    monkeypatch.setattr(server.app, "save_clip", _fake_save_clip)
+    monkeypatch.setattr(server.app, "render_vertical_with_captions", _fake_render_vertical)
+
+    loop = asyncio.new_event_loop()
+    state = server.app.JobState(loop=loop)
+    state.project_dir = project_dir
+    clip_id = stem
+    clip = server.app.ClipArtifact(
+        clip_id=clip_id,
+        title="Highlight",
+        channel="Creator",
+        source_title="Sample Project",
+        source_url="https://youtube.com/watch?v=abc",
+        source_published_at=None,
+        created_at=datetime.now(timezone.utc),
+        duration_seconds=10.0,
+        description="Existing",
+        video_path=vertical_path,
+        account="account-1",
+        views=100,
+        rating=9.0,
+        quote="Amazing",
+        reason="High energy",
+    )
+    state.clips[clip_id] = clip
+
+    job_id = "job-test"
+    with server.app._jobs_lock:
+        server.app._jobs[job_id] = state
+
+    client = TestClient(server.app.app)
+    payload = {"start_seconds": 7.0, "end_seconds": 18.0}
+    response = client.post(
+        f"/api/jobs/{job_id}/clips/{clip_id}/adjust",
+        json=payload,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["duration_seconds"] == pytest.approx(11.0)
+    assert "t=7" in body["description"].lower()
+
+    updated_clip = server.app._get_job(job_id).clips[clip_id]
+    assert updated_clip.duration_seconds == pytest.approx(11.0)
+    assert updated_clip.description == body["description"]
+
+    loop.close()
+    with server.app._jobs_lock:
+        server.app._jobs.clear()
+
+
+def test_adjust_library_clip_updates_files(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OUT_ROOT", str(tmp_path))
+
+    project_dir = tmp_path / "account-1" / "Sample_Project"
+    shorts_dir = project_dir / "shorts"
+    clips_dir = project_dir / "clips"
+    subtitles_dir = project_dir / "subtitles"
+    project_dir.mkdir(parents=True)
+    shorts_dir.mkdir()
+    clips_dir.mkdir()
+    subtitles_dir.mkdir()
+
+    video_path = project_dir / "Sample_Project.mp4"
+    video_path.write_bytes(b"video")
+    transcript_path = project_dir / "Sample_Project.txt"
+    transcript_path.write_text("[0.00 -> 30.00] Hello world", encoding="utf-8")
+
+    stem = "clip_5.00-15.00_r9.0"
+    raw_clip_path = clips_dir / f"{stem}.mp4"
+    raw_clip_path.write_bytes(b"raw")
+    subtitle_path = subtitles_dir / f"{stem}.srt"
+    subtitle_path.write_text(
+        "1\n00:00:00,000 --> 00:00:02,000\nHi\n\n",
+        encoding="utf-8",
+    )
+    vertical_path = shorts_dir / f"{stem}.mp4"
+    vertical_path.write_bytes(b"vertical")
+    description_path = shorts_dir / f"{stem}.txt"
+    description_path.write_text(
+        "Full video: https://youtube.com/watch?v=abc&t=5\nCredit: Creator\nMade by Atropos",
+        encoding="utf-8",
+    )
+
+    def _fake_save_clip(*_, **__) -> bool:
+        raw_clip_path.write_bytes(b"raw-updated")
+        return True
+
+    def _fake_render_vertical(*_, **__) -> Path:
+        vertical_path.write_bytes(b"vertical-updated")
+        return vertical_path
+
+    monkeypatch.setattr(server.app, "save_clip", _fake_save_clip)
+    monkeypatch.setattr(server.app, "render_vertical_with_captions", _fake_render_vertical)
+
+    clips = server.library.list_account_clips_sync("account-1")
+    assert len(clips) == 1
+    clip_id = clips[0].clip_id
+
+    client = TestClient(server.app.app)
+    response = client.post(
+        f"/api/accounts/account-1/clips/{clip_id}/adjust",
+        json={"start_seconds": 6.0, "end_seconds": 20.0},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["duration_seconds"] == pytest.approx(14.0)
+    assert "t=6" in payload["description"].lower()
+
+    refreshed_description = description_path.read_text(encoding="utf-8")
+    assert "t=6" in refreshed_description.lower()
 
 
 def test_config_endpoint_lists_and_updates_values() -> None:


### PR DESCRIPTION
## Summary
- extend the FastAPI backend and pipeline runner to support review-mode pausing and clip-boundary adjustment for both in-flight jobs and the clip library
- expose new renderer services, state, and navigation so home and library views can launch a shared clip editing experience
- add a dedicated ClipEdit page with timeline controls for trimming and saving updated clip windows

## Testing
- npm run typecheck *(fails: TypeScript cannot resolve `@tailwindcss/vite` with current moduleResolution)*
- pytest *(fails: environment is missing `httpx` and system libraries for OpenCV)*

------
https://chatgpt.com/codex/tasks/task_e_68d02bc75b048323abe2f291c18f77a1