### PR TITLE
feat: adopt marble marble ui theme and persist theme choice

### DIFF
--- a/desktop/src/renderer/src/components/Search.tsx
+++ b/desktop/src/renderer/src/components/Search.tsx
@@ -96,9 +96,9 @@ const Search = forwardRef<HTMLInputElement, SearchProps>(
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           disabled={disabled}
-          className="w-full rounded-lg border border-white/10 bg-[var(--card)] px-9 py-2 text-sm text-[var(--fg)] shadow-sm placeholder:text-[var(--muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
+          className="w-full rounded-[14px] border border-[color:var(--edge-soft)] bg-[color:var(--panel)] px-9 py-2 text-sm text-[var(--fg)] shadow-[0_14px_32px_rgba(43,42,40,0.12)] placeholder:text-[var(--muted)] backdrop-blur focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--panel)] disabled:cursor-not-allowed disabled:opacity-60"
         />
-        <kbd className="pointer-events-none absolute right-3 hidden rounded border border-white/10 bg-black/20 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--muted)] sm:block">
+        <kbd className="pointer-events-none absolute right-3 hidden rounded border border-[color:var(--edge-soft)] bg-[color:color-mix(in_srgb,var(--panel)_70%,transparent)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--muted)] shadow-[0_6px_16px_rgba(43,42,40,0.12)] sm:block">
           /
         </kbd>
       </label>

--- a/desktop/src/renderer/src/index.css
+++ b/desktop/src/renderer/src/index.css
@@ -2,20 +2,54 @@
 
 :root {
   color-scheme: light;
-  --bg: #f8fafc;
-  --fg: #0f172a;
-  --muted: #475569;
-  --card: #ffffff;
-  --ring: #6366f1;
+  --bg: #f6f5f3;
+  --bg-muted: #ebe8e2;
+  --bg-vein: #e4e0d9;
+  --depth: #d9d5ce;
+  --fg: #181818;
+  --muted: #6f6f6f;
+  --card: color-mix(in srgb, #ffffff 80%, transparent);
+  --card-strong: color-mix(in srgb, #ffffff 92%, transparent);
+  --panel: color-mix(in srgb, rgba(255, 255, 255, 0.75) 100%, transparent);
+  --panel-strong: color-mix(in srgb, rgba(255, 255, 255, 0.88) 100%, transparent);
+  --edge: #e9e7e2;
+  --edge-soft: color-mix(in srgb, var(--edge) 75%, transparent);
+  --edge-strong: color-mix(in srgb, var(--edge) 85%, transparent);
+  --accent: #2b2a28;
+  --accent-contrast: #f6f5f3;
+  --ring: color-mix(in srgb, var(--accent) 65%, transparent);
+  --ring-strong: color-mix(in srgb, var(--accent) 80%, transparent);
+  --success: #2f6b3a;
+  --info: #6b5b2f;
+  --error: #7a2b2b;
+  --shadow-elevated: 0 28px 60px -32px rgba(43, 42, 40, 0.35);
+  --shadow-soft: 0 16px 32px -24px rgba(43, 42, 40, 0.25);
 }
 
 .dark {
   color-scheme: dark;
-  --bg: #0f172a;
-  --fg: #e2e8f0;
-  --muted: #94a3b8;
-  --card: #111827;
-  --ring: #38bdf8;
+  --bg: #1d1c1a;
+  --bg-muted: #242321;
+  --bg-vein: #2c2a28;
+  --depth: #3a3734;
+  --fg: #f3f2f0;
+  --muted: #b3b0aa;
+  --card: color-mix(in srgb, rgba(36, 35, 33, 0.78) 100%, transparent);
+  --card-strong: color-mix(in srgb, rgba(46, 45, 43, 0.92) 100%, transparent);
+  --panel: color-mix(in srgb, rgba(38, 37, 35, 0.8) 100%, transparent);
+  --panel-strong: color-mix(in srgb, rgba(48, 47, 45, 0.92) 100%, transparent);
+  --edge: #35322f;
+  --edge-soft: color-mix(in srgb, var(--edge) 60%, transparent);
+  --edge-strong: color-mix(in srgb, var(--edge) 90%, transparent);
+  --accent: #f0ede5;
+  --accent-contrast: #1d1c1a;
+  --ring: color-mix(in srgb, var(--accent) 45%, transparent);
+  --ring-strong: color-mix(in srgb, var(--accent) 70%, transparent);
+  --success: #60b370;
+  --info: #c9a665;
+  --error: #d27a7a;
+  --shadow-elevated: 0 28px 60px -32px rgba(0, 0, 0, 0.6);
+  --shadow-soft: 0 16px 32px -24px rgba(0, 0, 0, 0.5);
 }
 
 *,
@@ -36,17 +70,142 @@ html {
 
 body {
   margin: 0;
-  background-color: var(--bg);
+  background:
+    radial-gradient(circle at 12% 18%, color-mix(in srgb, var(--bg-muted) 70%, transparent) 0%, transparent 55%),
+    radial-gradient(circle at 82% 12%, color-mix(in srgb, var(--bg-vein) 60%, transparent) 0%, transparent 48%),
+    radial-gradient(circle at 20% 72%, color-mix(in srgb, var(--depth) 40%, transparent) 0%, transparent 50%),
+    linear-gradient(135deg, color-mix(in srgb, var(--bg) 90%, transparent), color-mix(in srgb, var(--bg-vein) 55%, transparent));
   color: var(--fg);
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
     "Helvetica Neue", sans-serif;
-  line-height: 1.5;
+  line-height: 1.6;
   -webkit-font-smoothing: antialiased;
 }
 
 #root {
   display: flex;
   flex-direction: column;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.border-white\/10,
+.hover\:border-white\/10:hover,
+.focus-visible\:border-white\/10:focus-visible {
+  border-color: var(--edge-soft) !important;
+}
+
+.border-white\/15,
+.hover\:border-white\/15:hover,
+.focus-visible\:border-white\/15:focus-visible {
+  border-color: color-mix(in srgb, var(--edge) 60%, transparent) !important;
+}
+
+.border-white\/20,
+.hover\:border-white\/20:hover,
+.focus-visible\:border-white\/20:focus-visible {
+  border-color: color-mix(in srgb, var(--edge) 45%, transparent) !important;
+}
+
+.border-white\/40,
+.hover\:border-white\/40:hover,
+.focus-visible\:border-white\/40:focus-visible {
+  border-color: color-mix(in srgb, var(--edge) 30%, transparent) !important;
+}
+
+.border-white\/5,
+.hover\:border-white\/5:hover,
+.focus-visible\:border-white\/5:focus-visible {
+  border-color: color-mix(in srgb, var(--edge) 35%, transparent) !important;
+}
+
+.bg-white\/5,
+.hover\:bg-white\/5:hover {
+  background-color: color-mix(in srgb, var(--panel) 40%, transparent) !important;
+}
+
+.bg-white\/10,
+.hover\:bg-white\/10:hover,
+.focus-visible\:bg-white\/10:focus-visible {
+  background-color: color-mix(in srgb, var(--panel-strong) 55%, transparent) !important;
+}
+
+.bg-white\/20,
+.hover\:bg-white\/20:hover {
+  background-color: color-mix(in srgb, var(--panel-strong) 65%, transparent) !important;
+}
+
+.bg-white\/30,
+.hover\:bg-white\/30:hover {
+  background-color: color-mix(in srgb, var(--panel-strong) 70%, transparent) !important;
+}
+
+.bg-black\/10,
+.hover\:bg-black\/10:hover {
+  background-color: color-mix(in srgb, var(--depth) 28%, transparent) !important;
+}
+
+.bg-black\/20,
+.hover\:bg-black\/20:hover {
+  background-color: color-mix(in srgb, var(--depth) 45%, transparent) !important;
+}
+
+.bg-black\/30,
+.hover\:bg-black\/30:hover {
+  background-color: color-mix(in srgb, var(--depth) 58%, transparent) !important;
+}
+
+.bg-black {
+  background-color: color-mix(in srgb, var(--depth) 75%, transparent) !important;
+}
+
+.bg-white\/40 {
+  background-color: color-mix(in srgb, var(--panel-strong) 78%, transparent) !important;
+}
+
+.text-white,
+.hover\:text-white:hover,
+.focus-visible\:text-white:focus-visible {
+  color: var(--accent-contrast) !important;
+}
+
+.text-white\/80 {
+  color: color-mix(in srgb, var(--accent-contrast) 80%, transparent) !important;
+}
+
+.text-amber-50 {
+  color: color-mix(in srgb, var(--accent-contrast) 90%, transparent) !important;
+}
+
+.border-dashed {
+  border-color: color-mix(in srgb, var(--edge) 50%, transparent);
+}
+
+.shadow-\[0_20px_40px_-24px_rgba\(15,23,42,0\.6\)\] {
+  box-shadow: var(--shadow-elevated) !important;
+}
+
+.shadow-\[0_10px_30px_-12px_rgba\(15,23,42,0\.45\)\] {
+  box-shadow: var(--shadow-soft) !important;
+}
+
+.rounded-lg {
+  border-radius: 14px !important;
+}
+
+.rounded-xl {
+  border-radius: 18px !important;
+}
+
+.rounded-2xl {
+  border-radius: 24px !important;
 }
 
 button,


### PR DESCRIPTION
## Summary
- refresh the renderer styling tokens to match the Atropos Marble UI palette, depth, and rounded geometry
- restyle the shell navigation and search field to use the new surfaces, borders, and shadows
- persist the user-selected dark or light theme using localStorage with a system preference fallback

## Testing
- pytest *(fails: missing httpx and libGL shared library in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d06efbce2c832396a57acd4ef963ab