### PR TITLE
Expand app layout to use full width

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -361,7 +361,7 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
   return (
     <div className="flex min-h-full flex-col bg-[var(--bg)] text-[var(--fg)]">
       <header className="border-b border-[color:var(--edge-soft)] bg-[color:color-mix(in_srgb,var(--panel)_65%,transparent)] backdrop-blur-md">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-5 py-5">
+        <div className="flex w-full flex-col gap-4 px-6 py-5 lg:px-8">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="flex flex-wrap items-center gap-3">
               <h1 className="text-3xl font-semibold tracking-tight text-[var(--fg)]">Atropos</h1>
@@ -400,7 +400,7 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
           />
         </div>
       </header>
-      <main className="flex flex-1 justify-center bg-[var(--bg)] text-[var(--fg)]">
+      <main className="flex-1 bg-[var(--bg)] text-[var(--fg)]">
         <Routes>
           <Route
             path="/"

--- a/desktop/src/renderer/src/components/Search.tsx
+++ b/desktop/src/renderer/src/components/Search.tsx
@@ -76,7 +76,7 @@ const Search = forwardRef<HTMLInputElement, SearchProps>(
     const iconClass = disabled ? 'text-[var(--muted)] opacity-60' : 'text-[var(--muted)]'
 
     return (
-      <label className="relative flex w-full max-w-xl items-center">
+      <label className="relative flex w-full items-center">
         <span className="sr-only">Search clips</span>
         <svg
           aria-hidden="true"

--- a/desktop/src/renderer/src/pages/Clip.tsx
+++ b/desktop/src/renderer/src/pages/Clip.tsx
@@ -44,7 +44,7 @@ const ClipPage: FC<ClipPageProps> = ({ registerSearch }) => {
 
   if (!clip) {
     return (
-      <section className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-6 px-4 py-10">
+      <section className="flex w-full flex-1 flex-col gap-6 px-6 py-10 lg:px-8">
         <button
           type="button"
           onClick={() => navigate(-1)}
@@ -63,7 +63,7 @@ const ClipPage: FC<ClipPageProps> = ({ registerSearch }) => {
   }
 
   return (
-    <section className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-8 px-4 py-10">
+    <section className="flex w-full flex-1 flex-col gap-8 px-6 py-10 lg:px-8">
       <button
         type="button"
         onClick={() => navigate(-1)}

--- a/desktop/src/renderer/src/pages/ClipEdit.tsx
+++ b/desktop/src/renderer/src/pages/ClipEdit.tsx
@@ -862,7 +862,7 @@ const ClipEdit: FC<{ registerSearch: (bridge: SearchBridge | null) => void }> = 
 
   if (!clipState) {
     return (
-      <section className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-6 px-4 py-10">
+      <section className="flex w-full flex-1 flex-col gap-6 px-6 py-10 lg:px-8">
         <button
           type="button"
           onClick={handleBack}
@@ -917,7 +917,7 @@ const ClipEdit: FC<{ registerSearch: (bridge: SearchBridge | null) => void }> = 
   const endOffsetTooltip = formatTooltipLabel(formattedEndOffset, endTooltipChange)
 
   return (
-    <section className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-8 px-4 py-10">
+    <section className="flex w-full flex-1 flex-col gap-8 px-6 py-10 lg:px-8">
       <button
         type="button"
         onClick={handleBack}

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -923,7 +923,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
   }, [awaitingReview, clips.length, currentStep, isProcessing, pipelineError])
 
   return (
-    <section className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-8">
+    <section className="flex w-full flex-1 flex-col gap-6 px-6 py-8 lg:px-8">
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(260px,1fr)] xl:grid-cols-[minmax(0,1.4fr)_360px]">
         <div className="flex flex-col gap-6">
           <form

--- a/desktop/src/renderer/src/pages/Library.tsx
+++ b/desktop/src/renderer/src/pages/Library.tsx
@@ -621,7 +621,7 @@ const Library: FC<LibraryProps> = ({
   }, [availableAccounts, hasAccounts, hasMultipleAccounts])
 
   return (
-    <section className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-8">
+    <section className="flex w-full flex-1 flex-col gap-6 px-6 py-8 lg:px-8">
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.65fr)_minmax(320px,1fr)] xl:grid-cols-[minmax(0,1.8fr)_400px]">
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-6 shadow-[0_20px_40px_-24px_rgba(15,23,42,0.6)]">

--- a/desktop/src/renderer/src/pages/Profile.tsx
+++ b/desktop/src/renderer/src/pages/Profile.tsx
@@ -780,7 +780,7 @@ const Profile: FC<ProfileProps> = ({
   const authStatusDot = authStatusVariant?.dot ?? 'status-pill__dot status-pill__dot--muted'
 
   return (
-    <section className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-4 py-10">
+    <section className="flex w-full flex-1 flex-col gap-8 px-6 py-10 lg:px-8">
       <header className="flex flex-col gap-2">
         <h1 className="text-3xl font-semibold text-[var(--fg)]">Profile</h1>
         <p className="text-sm text-[var(--muted)]">

--- a/desktop/src/renderer/src/pages/Settings.tsx
+++ b/desktop/src/renderer/src/pages/Settings.tsx
@@ -290,7 +290,7 @@ const Settings: FC<SettingsProps> = ({ registerSearch }) => {
   )
 
   return (
-    <div className="w-full max-w-5xl px-4 py-8">
+    <div className="w-full px-6 py-8 lg:px-8">
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between gap-4">
           <div>


### PR DESCRIPTION
## Summary
- remove the hard max-width container from the header and let content span the viewport with lighter horizontal padding
- let primary pages render at full width with consistent side padding so the app fills the screen
- allow the search bar to stretch with the wider layout

## Testing
- pytest *(fails: missing httpx dependency and libGL for cv2)*

------
https://chatgpt.com/codex/tasks/task_e_68d08c0693b08323a2abf87898887430