### PR TITLE
Enable mouse buttons for navigation

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -23,6 +23,27 @@ function createWindow(): void {
     mainWindow.show()
   })
 
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'mouseDown') {
+      return
+    }
+
+    if (input.button === 'back') {
+      if (mainWindow.webContents.canGoBack()) {
+        mainWindow.webContents.goBack()
+        event.preventDefault()
+      }
+      return
+    }
+
+    if (input.button === 'forward') {
+      if (mainWindow.webContents.canGoForward()) {
+        mainWindow.webContents.goForward()
+        event.preventDefault()
+      }
+    }
+  })
+
   mainWindow.webContents.setWindowOpenHandler((details) => {
     shell.openExternal(details.url)
     return { action: 'deny' }


### PR DESCRIPTION
## Summary
- listen for mouse back and forward button presses in the main window
- trigger in-app navigation using goBack/goForward when history is available

## Testing
- `pytest` *(fails: missing httpx dependency and libGL.so.1 for cv2)*

------
https://chatgpt.com/codex/tasks/task_e_68d08d8194d083238ff37e61dec32a34