### PR TITLE
Move account dropdown to global header and adjust library search

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -501,8 +501,6 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
               <Library
                 registerSearch={registerSearch}
                 accounts={accounts}
-                selectedAccountId={homeState.selectedAccountId}
-                onSelectAccount={handleSelectAccount}
                 isLoadingAccounts={isLoadingAccounts}
               />
             }

--- a/desktop/src/renderer/src/components/ClipCard.tsx
+++ b/desktop/src/renderer/src/components/ClipCard.tsx
@@ -51,12 +51,12 @@ const ClipCard: FC<ClipCardProps> = ({ clip, onClick, isActive = false }) => {
           className={`absolute left-2 top-2 rounded-md px-2 py-0.5 text-xs font-semibold ${
             clip.hasAdjustments
               ? 'bg-[var(--ring)] text-[color:var(--accent-contrast)] shadow-[0_4px_12px_rgba(15,23,42,0.45)]'
-              : 'bg-black/70 text-[color:var(--fg-inverse-soft)]'
+              : 'bg-black/75 text-white shadow-[0_4px_12px_rgba(15,23,42,0.35)]'
           }`}
         >
           {clip.hasAdjustments ? 'Adjusted' : 'Original'}
         </span>
-        <span className="absolute bottom-2 right-2 rounded-md bg-black/70 px-2 py-0.5 text-xs font-medium text-[color:var(--fg-inverse)]">
+        <span className="absolute bottom-2 right-2 rounded-md bg-black/80 px-2 py-0.5 text-xs font-medium text-white shadow-[0_4px_12px_rgba(15,23,42,0.35)]">
           {formatDuration(clip.durationSec)}
         </span>
       </div>

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -10,7 +10,6 @@ import {
 import type { FC } from 'react'
 import { useNavigate } from 'react-router-dom'
 import PipelineProgress from '../components/PipelineProgress'
-import MarbleSelect from '../components/MarbleSelect'
 import { BACKEND_MODE, buildJobClipVideoUrl } from '../config/backend'
 import {
   createInitialPipelineSteps,
@@ -593,11 +592,6 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
     [cleanupConnection, updateState]
   )
 
-  const accountOptions = useMemo(
-    () => availableAccounts.map((account) => ({ value: account.id, label: account.displayName })),
-    [availableAccounts]
-  )
-
   const startRealProcessing = useCallback(
     async (urlToProcess: string, accountId: string, shouldPauseForReview: boolean) => {
       updateState((prev) => ({
@@ -685,19 +679,6 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
     [updateState]
   )
 
-  const handleAccountChange = useCallback(
-    (nextValue: string) => {
-      updateState((prev) => ({
-        ...prev,
-        selectedAccountId: nextValue.length > 0 ? nextValue : null,
-        accountError: prev.accountError ? null : prev.accountError,
-        clips: [],
-        selectedClipId: null
-      }))
-    },
-    [updateState]
-  )
-
   const handleReviewModeChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const { checked } = event.target
@@ -720,9 +701,9 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
         updateState((prev) => ({
           ...prev,
           accountError:
-            accountOptions.length === 0
+            availableAccounts.length === 0
               ? 'Enable an account with an active platform before starting the pipeline.'
-              : 'Select an account to start processing.'
+              : 'Select an account from the top navigation to start processing.'
         }))
       }
 
@@ -768,7 +749,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
       void startRealProcessing(trimmed, accountId, reviewMode)
     },
     [
-      accountOptions.length,
+      availableAccounts.length,
       cleanupConnection,
       clearTimers,
       isMockBackend,
@@ -806,7 +787,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
     }
 
     if (!selectedAccountId) {
-      setFolderErrorMessage('Select an account to open its clips folder.')
+      setFolderErrorMessage('Select an account from the top navigation to open its clips folder.')
       setFolderMessage(null)
       return
     }
@@ -933,26 +914,27 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
             <div className="flex flex-col gap-1">
               <h2 className="text-lg font-semibold text-[var(--fg)]">Process a new video</h2>
               <p className="text-sm text-[var(--muted)]">
-                Select an account, paste a link, and start the pipeline when you are ready.
+                Select an account from the top navigation, paste a link, and start the pipeline when you are ready.
               </p>
             </div>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
               <div className="flex w-full flex-col gap-2 sm:max-w-xs">
-                <label className="sr-only" htmlFor="processing-account">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_75%,transparent)]">
                   Account
-                </label>
-                <MarbleSelect
-                  id="processing-account"
-                  name="processing-account"
-                  value={selectedAccountId}
-                  options={accountOptions}
-                  onChange={(value) => handleAccountChange(value)}
-                  placeholder="Select an account"
-                  disabled={accountOptions.length === 0}
-                  error={Boolean(accountError)}
-                  aria-describedby={accountError ? 'account-error' : undefined}
-                />
-                {accountOptions.length === 0 && !accountError ? (
+                </span>
+                <div
+                  className={`rounded-[14px] border border-[color:var(--edge-soft)] bg-[color:color-mix(in_srgb,var(--panel)_65%,transparent)] px-4 py-2 text-sm text-[var(--fg)] shadow-[0_12px_22px_rgba(43,42,40,0.12)] ${
+                    accountError ? 'ring-2 ring-[var(--ring-strong)] ring-offset-2 ring-offset-[color:var(--panel)]' : ''
+                  }`}
+                  aria-live="polite"
+                >
+                  {selectedAccount
+                    ? `Processing as ${selectedAccount.displayName}.`
+                    : availableAccounts.length === 0
+                      ? 'No active accounts available.'
+                      : 'Select an account from the top navigation before starting.'}
+                </div>
+                {availableAccounts.length === 0 ? (
                   <p className="text-xs text-amber-300">
                     Enable an account with an active platform from your profile before starting the pipeline.
                   </p>

--- a/desktop/src/renderer/src/tests/home.test.tsx
+++ b/desktop/src/renderer/src/tests/home.test.tsx
@@ -111,12 +111,13 @@ describe('Home account selection', () => {
     fireEvent.change(screen.getByLabelText(/video url/i), {
       target: { value: 'https://www.youtube.com/watch?v=example' }
     })
-    const form = screen.getByLabelText(/account/i).closest('form')
+    const form = screen.getByText(/process a new video/i).closest('form')
     expect(form).not.toBeNull()
     fireEvent.submit(form as HTMLFormElement)
 
-    expect(screen.getByText(/select an account to start processing/i)).toBeInTheDocument()
-    expect(screen.getByLabelText(/account/i)).toHaveAttribute('aria-invalid', 'true')
+    expect(
+      screen.getByText(/select an account from the top navigation to start processing/i)
+    ).toBeInTheDocument()
     expect(startPipelineJobMock).not.toHaveBeenCalled()
   })
 
@@ -124,7 +125,7 @@ describe('Home account selection', () => {
     render(
       <Home
         registerSearch={() => {}}
-        initialState={createInitialState()}
+        initialState={createInitialState({ selectedAccountId: AVAILABLE_ACCOUNT.id })}
         onStateChange={() => {}}
         accounts={[AVAILABLE_ACCOUNT]}
       />
@@ -133,9 +134,8 @@ describe('Home account selection', () => {
     const videoUrl = 'https://www.youtube.com/watch?v=another'
     const accountId = AVAILABLE_ACCOUNT.id
 
-    fireEvent.change(screen.getByLabelText(/account/i), { target: { value: accountId } })
     fireEvent.change(screen.getByLabelText(/video url/i), { target: { value: videoUrl } })
-    const form = screen.getByLabelText(/account/i).closest('form')
+    const form = screen.getByText(/process a new video/i).closest('form')
     expect(form).not.toBeNull()
     fireEvent.submit(form as HTMLFormElement)
 
@@ -143,14 +143,13 @@ describe('Home account selection', () => {
   expect(startPipelineJobMock).toHaveBeenCalledWith({ account: accountId, url: videoUrl })
   })
 
-  it('filters the account dropdown to active accounts with active platforms', () => {
+  it('surfaces guidance when no active accounts are available', () => {
     render(
       <Home
         registerSearch={() => {}}
         initialState={createInitialState()}
         onStateChange={() => {}}
         accounts={[
-          AVAILABLE_ACCOUNT,
           INACTIVE_ACCOUNT,
           ACCOUNT_WITHOUT_PLATFORMS,
           ACCOUNT_WITH_DISABLED_PLATFORM
@@ -158,10 +157,10 @@ describe('Home account selection', () => {
       />
     )
 
-    const select = screen.getByLabelText(/account/i)
-    const options = within(select).getAllByRole('option')
-    const optionValues = options.map((option) => (option as HTMLOptionElement).value)
-    expect(optionValues).toEqual(['', AVAILABLE_ACCOUNT.id])
+    expect(screen.getByText(/no active accounts available/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/enable an account with an active platform from your profile/i)
+    ).toBeInTheDocument()
   })
 })
 
@@ -184,18 +183,16 @@ describe('Home pipeline events', () => {
     render(
       <Home
         registerSearch={() => {}}
-        initialState={createInitialState()}
+        initialState={createInitialState({ selectedAccountId: AVAILABLE_ACCOUNT.id })}
         onStateChange={() => {}}
         accounts={[AVAILABLE_ACCOUNT]}
       />
     )
 
-    const accountSelect = screen.getByLabelText(/account/i)
-    fireEvent.change(accountSelect, { target: { value: AVAILABLE_ACCOUNT.id } })
     fireEvent.change(screen.getByLabelText(/video url/i), {
       target: { value: 'https://www.youtube.com/watch?v=example' }
     })
-    const form = accountSelect.closest('form')
+    const form = screen.getByText(/process a new video/i).closest('form')
     expect(form).not.toBeNull()
     fireEvent.submit(form as HTMLFormElement)
 
@@ -250,21 +247,17 @@ describe('Home pipeline events', () => {
     render(
       <Home
         registerSearch={() => {}}
-        initialState={createInitialState()}
+        initialState={createInitialState({ selectedAccountId: AVAILABLE_ACCOUNT.id })}
         onStateChange={() => {}}
         accounts={[AVAILABLE_ACCOUNT]}
       />
     )
 
-    const accountSelect = screen.getByLabelText(/account/i)
-    fireEvent.change(accountSelect, {
-      target: { value: AVAILABLE_ACCOUNT.id }
-    })
     fireEvent.change(screen.getByLabelText(/video url/i), {
       target: { value: 'https://www.youtube.com/watch?v=example' }
     })
 
-    const form = accountSelect.closest('form')
+    const form = screen.getByText(/process a new video/i).closest('form')
     expect(form).not.toBeNull()
     fireEvent.submit(form as HTMLFormElement)
 


### PR DESCRIPTION
## Summary
- move the connected account dropdown into the sticky top navigation next to the theme switcher and add an "All accounts" option when browsing the library
- limit the clip search input to the library view and surface account-selection guidance in the Home and Library pages now that the picker lives in the header
- update Home tests to reflect the relocated account control and new messaging for unavailable accounts

## Testing
- pytest *(fails: missing optional dependencies httpx and OpenCV in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0981df4c8832398f0f7981b33cc96