### PR TITLE
Implement account-level tone overrides

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -8,7 +8,7 @@ import ClipEdit from './pages/ClipEdit'
 import Home from './pages/Home'
 import Library from './pages/Library'
 import Profile from './pages/Profile'
-import Settings from './pages/Settings'
+import Settings, { type SettingsHeaderAction } from './pages/Settings'
 import { createInitialPipelineSteps } from './data/pipeline'
 import useNavigationHistory from './hooks/useNavigationHistory'
 import type {
@@ -81,6 +81,7 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
   const [authStatus, setAuthStatus] = useState<AuthPingSummary | null>(null)
   const [authError, setAuthError] = useState<string | null>(null)
   const [isDark, setIsDark] = useState(false)
+  const [settingsHeaderAction, setSettingsHeaderAction] = useState<SettingsHeaderAction | null>(null)
   const location = useLocation()
   const navigate = useNavigate()
 
@@ -368,6 +369,7 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
   )
 
   const isLibraryRoute = location.pathname.startsWith('/library')
+  const isSettingsRoute = location.pathname.startsWith('/settings')
   const showBackButton = location.pathname.startsWith('/clip/')
 
   const accountSelectOptions = useMemo(() => {
@@ -433,11 +435,11 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
                 <NavLink to="/library" className={navLinkClassName}>
                   {({ isActive }) => <NavItemLabel label="Library" isActive={isActive} />}
                 </NavLink>
-                <NavLink to="/settings" className={navLinkClassName}>
-                  {({ isActive }) => <NavItemLabel label="Settings" isActive={isActive} />}
-                </NavLink>
                 <NavLink to="/profile" className={navLinkClassName}>
                   {({ isActive }) => <NavItemLabel label="Profile" isActive={isActive} />}
+                </NavLink>
+                <NavLink to="/settings" className={navLinkClassName}>
+                  {({ isActive }) => <NavItemLabel label="Settings" isActive={isActive} />}
                 </NavLink>
               </nav>
             </div>
@@ -453,6 +455,20 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
                 </div>
               ) : null}
               <div className="flex flex-wrap items-center gap-3">
+                {isSettingsRoute && settingsHeaderAction ? (
+                  <button
+                    type="button"
+                    onClick={settingsHeaderAction.onSave}
+                    className="inline-flex items-center justify-center rounded-[14px] bg-[color:var(--accent)] px-4 py-2 text-sm font-semibold text-[color:var(--accent-contrast)] shadow-[0_12px_22px_rgba(43,42,40,0.14)] transition hover:-translate-y-0.5 hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--panel)] disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={settingsHeaderAction.isSaving || settingsHeaderAction.dirtyCount === 0}
+                  >
+                    {settingsHeaderAction.isSaving
+                      ? 'Saving…'
+                      : settingsHeaderAction.dirtyCount > 0
+                        ? `Save changes (${settingsHeaderAction.dirtyCount})`
+                        : 'Save changes'}
+                  </button>
+                ) : null}
                 <div className="min-w-[200px] sm:min-w-[220px]">
                   <MarbleSelect
                     aria-label="Account selection"
@@ -509,7 +525,13 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
           <Route path="/clip/:id/edit" element={<ClipEdit registerSearch={registerSearch} />} />
           <Route
             path="/settings"
-            element={<Settings registerSearch={registerSearch} accounts={accounts} />}
+            element={
+              <Settings
+                registerSearch={registerSearch}
+                accounts={accounts}
+                onRegisterHeaderAction={setSettingsHeaderAction}
+              />
+            }
           />
           <Route
             path="/profile"

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -255,7 +255,10 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
   )
 
   const handleUpdateAccount = useCallback(
-    async (accountId: string, payload: { active?: boolean }) => {
+    async (
+      accountId: string,
+      payload: { active?: boolean; tone?: string | null }
+    ) => {
       try {
         const account = await updateAccountApi(accountId, payload)
         setAccounts((prev) => sortAccounts(prev.map((item) => (item.id === account.id ? account : item))))
@@ -504,7 +507,10 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
           />
           <Route path="/clip/:id" element={<ClipPage registerSearch={registerSearch} />} />
           <Route path="/clip/:id/edit" element={<ClipEdit registerSearch={registerSearch} />} />
-          <Route path="/settings" element={<Settings registerSearch={registerSearch} />} />
+          <Route
+            path="/settings"
+            element={<Settings registerSearch={registerSearch} accounts={accounts} />}
+          />
           <Route
             path="/profile"
             element={

--- a/desktop/src/renderer/src/components/PipelineProgress.tsx
+++ b/desktop/src/renderer/src/components/PipelineProgress.tsx
@@ -17,16 +17,17 @@ const statusLabels: Record<PipelineStepStatus, string> = {
 
 const segmentClasses: Record<PipelineStepStatus, string> = {
   pending: 'bg-transparent',
-  running: 'bg-sky-400',
-  completed: 'bg-emerald-500',
-  failed: 'bg-rose-500'
+  running: 'bg-[color:var(--info-strong)]',
+  completed: 'bg-[color:var(--success-strong)]',
+  failed: 'bg-[color:var(--error-strong)]'
 }
 
 const indicatorClasses: Record<PipelineStepStatus, string> = {
-  pending: 'border border-white/40 bg-transparent',
-  running: 'bg-sky-400 shadow-[0_0_0_2px_rgba(56,189,248,0.3)]',
-  completed: 'bg-emerald-500',
-  failed: 'bg-rose-500'
+  pending: 'border border-[color:color-mix(in_srgb,var(--edge)_65%,transparent)] bg-transparent',
+  running:
+    'bg-[color:var(--info-strong)] shadow-[0_0_0_2px_color-mix(in_srgb,var(--info-strong)_35%,transparent)]',
+  completed: 'bg-[color:var(--success-strong)]',
+  failed: 'bg-[color:var(--error-strong)]'
 }
 
 const multiStepBadgeBaseClasses =
@@ -274,10 +275,13 @@ const PipelineProgress: FC<PipelineProgressProps> = ({ steps, className }) => {
   }, [activeStep])
 
 const clipBadgeStateClasses: Record<PipelineStepStatus, string> = {
-  pending: 'border-white/10 text-[var(--muted)] bg-white/5',
-  running: 'border-sky-400/40 bg-sky-400/10 text-sky-200',
-  completed: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
-  failed: 'border-rose-400/40 bg-rose-500/10 text-rose-200'
+  pending: 'border-[color:var(--edge-soft)] text-[var(--muted)] bg-white/5',
+  running:
+    'border-[color:color-mix(in_srgb,var(--info-strong)_45%,var(--edge))] bg-[color:var(--info-soft)] text-[color:color-mix(in_srgb,var(--info-strong)_82%,var(--accent-contrast))]',
+  completed:
+    'border-[color:color-mix(in_srgb,var(--success-strong)_45%,var(--edge))] bg-[color:var(--success-soft)] text-[color:color-mix(in_srgb,var(--success-strong)_82%,var(--accent-contrast))]',
+  failed:
+    'border-[color:color-mix(in_srgb,var(--error-strong)_45%,var(--edge))] bg-[color:var(--error-soft)] text-[color:color-mix(in_srgb,var(--error-strong)_85%,var(--accent-contrast))]'
 }
 
 const getSubstepLabel = (index: number): string => {
@@ -326,11 +330,11 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
       step.status === 'running' && step.etaSeconds !== null ? formatEta(step.etaSeconds) : null
     const progressColor =
       step.status === 'failed'
-        ? 'bg-rose-500'
+        ? 'bg-[color:var(--error-strong)]'
         : step.status === 'completed'
-          ? 'bg-emerald-500'
+          ? 'bg-[color:var(--success-strong)]'
           : step.status === 'running'
-            ? 'bg-sky-400'
+            ? 'bg-[color:var(--info-strong)]'
             : 'bg-white/30'
 
     return (
@@ -382,11 +386,11 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
   ) => {
     const progressColor =
       substep.status === 'failed'
-        ? 'bg-rose-500'
+        ? 'bg-[color:var(--error-strong)]'
         : substep.status === 'completed'
-          ? 'bg-emerald-500'
+          ? 'bg-[color:var(--success-strong)]'
           : substep.status === 'running'
-            ? 'bg-sky-400'
+            ? 'bg-[color:var(--info-strong)]'
             : 'bg-white/40'
     const clipLabel = getSubstepClipLabel(substep)
     const completedSummary = getSubstepCompletedSummary(substep)
@@ -396,7 +400,7 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
         <button
           type="button"
           onClick={() => toggleSubstep(step.id, substep.id)}
-          className="group flex h-full w-full min-w-0 max-w-full flex-col gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-left text-[11px] transition hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          className="group flex h-full w-full min-w-0 max-w-full flex-col gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-left text-[11px] transition hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
           aria-expanded={false}
           aria-controls={`substep-${step.id}-${substep.id}`}
         >
@@ -439,11 +443,11 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
   ) => {
     const progressColor =
       substep.status === 'failed'
-        ? 'bg-rose-500'
+        ? 'bg-[color:var(--error-strong)]'
         : substep.status === 'completed'
-          ? 'bg-emerald-500'
+          ? 'bg-[color:var(--success-strong)]'
           : substep.status === 'running'
-            ? 'bg-sky-400'
+            ? 'bg-[color:var(--info-strong)]'
             : 'bg-white/40'
     const clipLabel = getSubstepClipLabel(substep)
     const completedSummary = getSubstepCompletedSummary(substep)
@@ -499,7 +503,9 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
               {completedSummary ? <span>{completedSummary}</span> : null}
             </div>
             {substep.status === 'failed' ? (
-              <p className="text-[var(--danger)] font-semibold">Review server logs to retry this step.</p>
+              <p className="font-semibold text-[color:var(--error-strong)]">
+                Review server logs to retry this step.
+              </p>
             ) : null}
           </div>
         </div>
@@ -550,7 +556,9 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
       <li
         key={step.id}
         className={`col-span-full rounded-xl border ${
-          isActive ? 'border-sky-400 shadow-[0_14px_28px_-20px_rgba(56,189,248,0.35)]' : 'border-white/10'
+          isActive
+            ? 'border-[color:color-mix(in_srgb,var(--info-strong)_55%,transparent)] shadow-[0_14px_28px_-20px_color-mix(in_srgb,var(--info-strong)_45%,transparent)]'
+            : 'border-white/10'
         } bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)]`}
       >
         <button
@@ -598,7 +606,7 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
             <p>{step.description}</p>
             {renderStepProgress(step)}
             {step.status === 'failed' ? (
-              <p className="text-xs font-semibold text-rose-400">
+              <p className="text-xs font-semibold text-[color:var(--error-strong)]">
                 Check the server logs to resolve the failure before retrying.
               </p>
             ) : null}
@@ -636,7 +644,7 @@ const renderClipBadge = (step: PipelineStep, variant: 'default' | 'compact' = 'd
         <button
           type="button"
           onClick={() => toggleStep(step.id)}
-          className={`group flex w-full flex-col gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-left text-[11px] transition hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 ${
+          className={`group flex w-full flex-col gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-left text-[11px] transition hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] ${
             step.status === 'completed' ? 'opacity-85' : ''
           }`}
           aria-expanded={false}

--- a/desktop/src/renderer/src/constants/tone.ts
+++ b/desktop/src/renderer/src/constants/tone.ts
@@ -1,0 +1,26 @@
+export type ToneValue =
+  | 'funny'
+  | 'science'
+  | 'history'
+  | 'tech'
+  | 'health'
+  | 'conspiracy'
+  | 'politics'
+
+export const TONE_OPTIONS: Array<{ value: ToneValue; label: string }> = [
+  { value: 'funny', label: 'Funny' },
+  { value: 'science', label: 'Science' },
+  { value: 'history', label: 'History' },
+  { value: 'tech', label: 'Tech' },
+  { value: 'health', label: 'Health' },
+  { value: 'conspiracy', label: 'Conspiracy' },
+  { value: 'politics', label: 'Politics' }
+]
+
+export const TONE_LABELS: Record<string, string> = TONE_OPTIONS.reduce(
+  (labels, option) => ({
+    ...labels,
+    [option.value]: option.label
+  }),
+  {}
+)

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -603,9 +603,12 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
       cleanupConnection()
 
       try {
+        const toneOverride =
+          availableAccounts.find((account) => account.id === accountId)?.tone ?? null
         const { jobId } = await startPipelineJob({
           url: urlToProcess,
           account: accountId,
+          tone: toneOverride,
           reviewMode: shouldPauseForReview
         })
         activeJobIdRef.current = jobId
@@ -644,7 +647,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
         }))
       }
     },
-    [cleanupConnection, handlePipelineEvent, updateState]
+    [availableAccounts, cleanupConnection, handlePipelineEvent, updateState]
   )
 
   useEffect(() => {

--- a/desktop/src/renderer/src/pages/Profile.tsx
+++ b/desktop/src/renderer/src/pages/Profile.tsx
@@ -522,7 +522,7 @@ const AccountCard: FC<AccountCardProps> = ({
     )
   }
 
-  const toneControls = (
+  const renderToneControls = () => (
     <div className="flex flex-col gap-2 rounded-xl border border-white/10 bg-black/20 p-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <h4 className="text-sm font-semibold text-[var(--fg)]">Account tone</h4>
@@ -615,6 +615,7 @@ const AccountCard: FC<AccountCardProps> = ({
               Enable this account to resume authentication.
             </p>
           ) : null}
+          {renderToneControls()}
           {account.platforms.length > 0 ? (
             <ul className="flex flex-wrap gap-2">
               {account.platforms.map((platform) => (
@@ -640,7 +641,7 @@ const AccountCard: FC<AccountCardProps> = ({
         </div>
       ) : (
         <div id={detailsId} className="flex flex-col gap-4">
-          {toneControls}
+          {renderToneControls()}
           <div className="flex flex-wrap items-center gap-2">
             <button
               type="button"

--- a/desktop/src/renderer/src/pages/Profile.tsx
+++ b/desktop/src/renderer/src/pages/Profile.tsx
@@ -530,20 +530,20 @@ const AccountCard: FC<AccountCardProps> = ({
       <div className="flex flex-col gap-3">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="flex flex-col gap-2">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="status-pill status-pill--neutral text-xs">
-              {account.platforms.length} platform{account.platforms.length === 1 ? '' : 's'}
-            </span>
-            {account.effectiveTone || account.tone ? (
-              <span className="status-pill status-pill--neutral text-xs" title={toneBadgeTitle}>
-                Tone: {effectiveToneLabel}
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="status-pill status-pill--neutral text-xs">
+                {account.platforms.length} platform{account.platforms.length === 1 ? '' : 's'}
               </span>
-            ) : null}
-            {!isAccountActive ? (
-              <span className="status-pill status-pill--warning text-xs font-semibold">
-                Disabled
-              </span>
-            ) : null}
+              {account.effectiveTone || account.tone ? (
+                <span className="status-pill status-pill--neutral text-xs" title={toneBadgeTitle}>
+                  Tone: {effectiveToneLabel}
+                </span>
+              ) : null}
+              {!isAccountActive ? (
+                <span className="status-pill status-pill--warning text-xs font-semibold">
+                  Disabled
+                </span>
+              ) : null}
             </div>
             <div>
               <h3 className="text-xl font-semibold text-[var(--fg)]">{account.displayName}</h3>
@@ -567,6 +567,41 @@ const AccountCard: FC<AccountCardProps> = ({
             {isCollapsed ? 'Expand' : 'Collapse'}
           </button>
         </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 rounded-xl border border-white/10 bg-black/20 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h4 className="text-sm font-semibold text-[var(--fg)]">Account tone</h4>
+            <span className="text-xs text-[var(--muted)]">
+              {overrideToneLabel
+                ? `Override: ${overrideToneLabel}`
+                : `Using default: ${effectiveToneLabel}`}
+            </span>
+          </div>
+          <label className="flex flex-col gap-1 text-xs font-medium text-[var(--muted)]">
+            Tone
+            <MarbleSelect
+              id={`tone-${account.id}`}
+              name="tone"
+              value={toneSelectValue}
+              options={toneSelectOptions}
+              onChange={handleToneChange}
+              placeholder="Select a tone"
+              disabled={isUpdatingTone}
+            />
+          </label>
+          <p className="text-xs text-[var(--muted)]">
+            Selecting a tone here overrides the global clip tone for this account. Choose 'Use
+            default tone' to inherit the Settings value.
+          </p>
+        </div>
+        {success ? (
+          <p className="text-xs font-medium text-[color:var(--success-strong)]">{success}</p>
+        ) : null}
+        {error ? (
+          <p className="text-xs font-medium text-[color:var(--error-strong)]">{error}</p>
+        ) : null}
       </div>
 
       {isCollapsed ? (
@@ -628,33 +663,6 @@ const AccountCard: FC<AccountCardProps> = ({
             >
               {isDeletingAccount ? 'Removing…' : 'Remove account'}
             </button>
-          </div>
-
-          <div className="flex flex-col gap-2 rounded-xl border border-white/10 bg-black/20 p-4">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <h4 className="text-sm font-semibold text-[var(--fg)]">Account tone</h4>
-              <span className="text-xs text-[var(--muted)]">
-                {overrideToneLabel
-                  ? `Override: ${overrideToneLabel}`
-                  : `Using default: ${effectiveToneLabel}`}
-              </span>
-            </div>
-            <label className="flex flex-col gap-1 text-xs font-medium text-[var(--muted)]">
-              Tone
-              <MarbleSelect
-                id={`tone-${account.id}`}
-                name="tone"
-                value={toneSelectValue}
-                options={toneSelectOptions}
-                onChange={handleToneChange}
-                placeholder="Select a tone"
-                disabled={isUpdatingTone}
-              />
-            </label>
-            <p className="text-xs text-[var(--muted)]">
-              Selecting a tone here overrides the global clip tone for this account. Choose 'Use
-              default tone' to inherit the Settings value.
-            </p>
           </div>
 
           {!isAccountActive ? (
@@ -772,12 +780,6 @@ const AccountCard: FC<AccountCardProps> = ({
             <p className="text-xs text-[color:var(--info-strong)]">
               Enable this account to connect new platforms.
             </p>
-          ) : null}
-          {error ? (
-            <p className="text-xs font-medium text-[color:var(--error-strong)]">{error}</p>
-          ) : null}
-          {success ? (
-            <p className="text-xs font-medium text-[color:var(--success-strong)]">{success}</p>
           ) : null}
           <div className="flex items-center justify-end gap-2">
             <button

--- a/desktop/src/renderer/src/pages/Profile.tsx
+++ b/desktop/src/renderer/src/pages/Profile.tsx
@@ -9,6 +9,7 @@ import {
   type SearchBridge,
   type SupportedPlatform
 } from '../types'
+import { TONE_LABELS, TONE_OPTIONS } from '../constants/tone'
 import { timeAgo } from '../lib/format'
 import MarbleSelect from '../components/MarbleSelect'
 
@@ -49,7 +50,10 @@ type ProfileProps = {
       credentials?: Record<string, unknown>
     }
   ) => Promise<AccountSummary>
-  onUpdateAccount: (accountId: string, payload: { active?: boolean }) => Promise<AccountSummary>
+  onUpdateAccount: (
+    accountId: string,
+    payload: { active?: boolean; tone?: string | null }
+  ) => Promise<AccountSummary>
   onDeleteAccount: (accountId: string) => Promise<void>
   onUpdatePlatform: (
     accountId: string,
@@ -118,6 +122,7 @@ const AccountCard: FC<AccountCardProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isTogglingAccount, setIsTogglingAccount] = useState(false)
   const [isDeletingAccount, setIsDeletingAccount] = useState(false)
+  const [isUpdatingTone, setIsUpdatingTone] = useState(false)
   const [updatingPlatform, setUpdatingPlatform] = useState<SupportedPlatform | null>(null)
   const [removingPlatform, setRemovingPlatform] = useState<SupportedPlatform | null>(null)
   const [isCollapsed, setIsCollapsed] = useState(true)
@@ -131,6 +136,23 @@ const AccountCard: FC<AccountCardProps> = ({
   }, [])
 
   const isAccountActive = account.active
+
+  const toneSelectOptions = useMemo(
+    () => [
+      { value: '', label: 'Use default tone' },
+      ...TONE_OPTIONS.map((option) => ({ value: option.value, label: option.label }))
+    ],
+    []
+  )
+
+  const toneSelectValue = account.tone ?? ''
+  const effectiveToneLabel = account.effectiveTone
+    ? TONE_LABELS[account.effectiveTone] ?? account.effectiveTone
+    : 'Default'
+  const overrideToneLabel = account.tone ? TONE_LABELS[account.tone] ?? account.tone : null
+  const toneBadgeTitle = account.tone
+    ? 'Account-specific tone override'
+    : 'Using the global clip tone'
 
   const availablePlatforms = useMemo(
     () =>
@@ -148,7 +170,7 @@ const AccountCard: FC<AccountCardProps> = ({
   useEffect(() => {
     setSuccess(null)
     setError(null)
-  }, [account.platforms.length, account.active])
+  }, [account.platforms.length, account.active, account.tone])
 
   const detailsId = `account-${account.id}-details`
 
@@ -295,6 +317,46 @@ const AccountCard: FC<AccountCardProps> = ({
       }
     }
   }, [account.displayName, account.id, onDeleteAccount])
+
+  const handleToneChange = useCallback(
+    async (nextValue: string) => {
+      const normalised = nextValue === '' ? null : nextValue
+      const current = account.tone ?? null
+      if (normalised === current) {
+        return
+      }
+
+      setError(null)
+      setSuccess(null)
+      setIsUpdatingTone(true)
+      try {
+        const updated = await onUpdateAccount(account.id, { tone: normalised })
+        if (isMounted.current) {
+          const updatedLabel = updated.tone
+            ? TONE_LABELS[updated.tone] ?? updated.tone
+            : null
+          setSuccess(
+            updatedLabel
+              ? `Tone set to ${updatedLabel}.`
+              : 'Tone override cleared. Using the default setting.'
+          )
+        }
+      } catch (toneError) {
+        const message =
+          toneError instanceof Error
+            ? toneError.message
+            : 'Unable to update the tone. Please try again.'
+        if (isMounted.current) {
+          setError(message)
+        }
+      } finally {
+        if (isMounted.current) {
+          setIsUpdatingTone(false)
+        }
+      }
+    },
+    [account.id, account.tone, onUpdateAccount]
+  )
 
   const handleTogglePlatformActive = useCallback(
     async (platformId: SupportedPlatform, nextActive: boolean) => {
@@ -468,15 +530,20 @@ const AccountCard: FC<AccountCardProps> = ({
       <div className="flex flex-col gap-3">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="flex flex-col gap-2">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="status-pill status-pill--neutral text-xs">
-                {account.platforms.length} platform{account.platforms.length === 1 ? '' : 's'}
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="status-pill status-pill--neutral text-xs">
+              {account.platforms.length} platform{account.platforms.length === 1 ? '' : 's'}
+            </span>
+            {account.effectiveTone || account.tone ? (
+              <span className="status-pill status-pill--neutral text-xs" title={toneBadgeTitle}>
+                Tone: {effectiveToneLabel}
               </span>
-              {!isAccountActive ? (
-                <span className="status-pill status-pill--warning text-xs font-semibold">
-                  Disabled
-                </span>
-              ) : null}
+            ) : null}
+            {!isAccountActive ? (
+              <span className="status-pill status-pill--warning text-xs font-semibold">
+                Disabled
+              </span>
+            ) : null}
             </div>
             <div>
               <h3 className="text-xl font-semibold text-[var(--fg)]">{account.displayName}</h3>
@@ -563,6 +630,33 @@ const AccountCard: FC<AccountCardProps> = ({
             </button>
           </div>
 
+          <div className="flex flex-col gap-2 rounded-xl border border-white/10 bg-black/20 p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h4 className="text-sm font-semibold text-[var(--fg)]">Account tone</h4>
+              <span className="text-xs text-[var(--muted)]">
+                {overrideToneLabel
+                  ? `Override: ${overrideToneLabel}`
+                  : `Using default: ${effectiveToneLabel}`}
+              </span>
+            </div>
+            <label className="flex flex-col gap-1 text-xs font-medium text-[var(--muted)]">
+              Tone
+              <MarbleSelect
+                id={`tone-${account.id}`}
+                name="tone"
+                value={toneSelectValue}
+                options={toneSelectOptions}
+                onChange={handleToneChange}
+                placeholder="Select a tone"
+                disabled={isUpdatingTone}
+              />
+            </label>
+            <p className="text-xs text-[var(--muted)]">
+              Selecting a tone here overrides the global clip tone for this account. Choose 'Use
+              default tone' to inherit the Settings value.
+            </p>
+          </div>
+
           {!isAccountActive ? (
             <p className="rounded-lg border border-dashed border-[color:color-mix(in_srgb,var(--info)_35%,var(--edge))] bg-[color:var(--info-soft)] p-3 text-xs text-[color:var(--info-strong)]">
               This account is disabled. Enable it to resume authentication and publishing.
@@ -635,70 +729,70 @@ const AccountCard: FC<AccountCardProps> = ({
               No platforms are connected yet. Use the form below to authenticate a platform.
             </p>
           )}
-
-          {availablePlatforms.length > 0 ? (
-            <form
-              onSubmit={handleSubmit}
-              className="flex flex-col gap-3 rounded-xl border border-white/10 bg-black/20 p-4"
-            >
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <h4 className="text-sm font-semibold text-[var(--fg)]">Add a platform</h4>
-                {selectedPlatform ? (
-                  <span className="status-pill status-pill--neutral text-xs">
-                    Authenticating {PLATFORM_LABELS[selectedPlatform]}
-                  </span>
-                ) : null}
-              </div>
-              <label className="flex flex-col gap-1 text-xs font-medium text-[var(--muted)]">
-                Platform
-                <MarbleSelect
-                  id={`platform-${account.id}`}
-                  name="platform"
-                  value={selectedPlatform || null}
-                  options={platformOptions}
-                  onChange={handlePlatformChange}
-                  placeholder="Select a platform"
-                  disabled={!isAccountActive || isSubmitting}
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-xs font-medium text-[var(--muted)]">
-                Label (optional)
-                <input
-                  value={label}
-                  onChange={(event) => setLabel(event.target.value)}
-                  placeholder="e.g. Brand TikTok"
-                  disabled={!isAccountActive || isSubmitting}
-                  className="rounded-lg border border-white/10 bg-[var(--card)] px-3 py-2 text-sm text-[var(--fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
-                />
-              </label>
-              {renderPlatformFields()}
-              {!isAccountActive ? (
-                <p className="text-xs text-[color:var(--info-strong)]">
-                  Enable this account to connect new platforms.
-                </p>
-              ) : null}
-              {error ? (
-                <p className="text-xs font-medium text-[color:var(--error-strong)]">{error}</p>
-              ) : null}
-              {success ? (
-                <p className="text-xs font-medium text-[color:var(--success-strong)]">{success}</p>
-              ) : null}
-              <div className="flex items-center justify-end gap-2">
-                <button
-                  type="submit"
-                  disabled={isSubmitting || !isAccountActive}
-                  className="marble-button marble-button--primary px-4 py-2 text-sm font-semibold"
-                >
-                  {isSubmitting ? 'Connecting…' : 'Connect platform'}
-                </button>
-              </div>
-            </form>
-          ) : (
-            <p className="text-xs text-[var(--muted)]">
-              All supported platforms are connected for this account.
-            </p>
-          )}
         </div>
+      )}
+
+      {availablePlatforms.length > 0 ? (
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-3 rounded-xl border border-white/10 bg-black/20 p-4"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h4 className="text-sm font-semibold text-[var(--fg)]">Add a platform</h4>
+            {selectedPlatform ? (
+              <span className="status-pill status-pill--neutral text-xs">
+                Authenticating {PLATFORM_LABELS[selectedPlatform]}
+              </span>
+            ) : null}
+          </div>
+          <label className="flex flex-col gap-1 text-xs font-medium text-[var(--muted)]">
+            Platform
+            <MarbleSelect
+              id={`platform-${account.id}`}
+              name="platform"
+              value={selectedPlatform || null}
+              options={platformOptions}
+              onChange={handlePlatformChange}
+              placeholder="Select a platform"
+              disabled={!isAccountActive || isSubmitting}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium text-[var(--muted)]">
+            Label (optional)
+            <input
+              value={label}
+              onChange={(event) => setLabel(event.target.value)}
+              placeholder="e.g. Brand TikTok"
+              disabled={!isAccountActive || isSubmitting}
+              className="rounded-lg border border-white/10 bg-[var(--card)] px-3 py-2 text-sm text-[var(--fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
+            />
+          </label>
+          {renderPlatformFields()}
+          {!isAccountActive ? (
+            <p className="text-xs text-[color:var(--info-strong)]">
+              Enable this account to connect new platforms.
+            </p>
+          ) : null}
+          {error ? (
+            <p className="text-xs font-medium text-[color:var(--error-strong)]">{error}</p>
+          ) : null}
+          {success ? (
+            <p className="text-xs font-medium text-[color:var(--success-strong)]">{success}</p>
+          ) : null}
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="submit"
+              disabled={isSubmitting || !isAccountActive}
+              className="marble-button marble-button--primary px-4 py-2 text-sm font-semibold"
+            >
+              {isSubmitting ? 'Connecting…' : 'Connect platform'}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <p className="text-xs text-[var(--muted)]">
+          All supported platforms are connected for this account.
+        </p>
       )}
     </div>
   )

--- a/desktop/src/renderer/src/pages/Profile.tsx
+++ b/desktop/src/renderer/src/pages/Profile.tsx
@@ -522,6 +522,43 @@ const AccountCard: FC<AccountCardProps> = ({
     )
   }
 
+  const toneControls = (
+    <div className="flex flex-col gap-2 rounded-xl border border-white/10 bg-black/20 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h4 className="text-sm font-semibold text-[var(--fg)]">Account tone</h4>
+        <span className="text-xs text-[var(--muted)]">
+          {overrideToneLabel ? `Override: ${overrideToneLabel}` : `Using default: ${effectiveToneLabel}`}
+        </span>
+      </div>
+      <label className="flex flex-col gap-1 text-xs font-medium text-[var(--muted)]">
+        Tone
+        <MarbleSelect
+          id={`tone-${account.id}`}
+          name="tone"
+          value={toneSelectValue}
+          options={toneSelectOptions}
+          onChange={handleToneChange}
+          placeholder="Select a tone"
+          disabled={isUpdatingTone}
+        />
+      </label>
+      <p className="text-xs text-[var(--muted)]">
+        Selecting a tone here overrides the global clip tone for this account. Choose 'Use default tone' to inherit the Settings value.
+      </p>
+    </div>
+  )
+
+  const feedbackMessage = success || error ? (
+    <div className="flex flex-col gap-2">
+      {success ? (
+        <p className="text-xs font-medium text-[color:var(--success-strong)]">{success}</p>
+      ) : null}
+      {error ? (
+        <p className="text-xs font-medium text-[color:var(--error-strong)]">{error}</p>
+      ) : null}
+    </div>
+  ) : null
+
   return (
     <div
       data-testid={`account-card-${account.id}`}
@@ -569,40 +606,7 @@ const AccountCard: FC<AccountCardProps> = ({
         </div>
       </div>
 
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-col gap-2 rounded-xl border border-white/10 bg-black/20 p-4">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <h4 className="text-sm font-semibold text-[var(--fg)]">Account tone</h4>
-            <span className="text-xs text-[var(--muted)]">
-              {overrideToneLabel
-                ? `Override: ${overrideToneLabel}`
-                : `Using default: ${effectiveToneLabel}`}
-            </span>
-          </div>
-          <label className="flex flex-col gap-1 text-xs font-medium text-[var(--muted)]">
-            Tone
-            <MarbleSelect
-              id={`tone-${account.id}`}
-              name="tone"
-              value={toneSelectValue}
-              options={toneSelectOptions}
-              onChange={handleToneChange}
-              placeholder="Select a tone"
-              disabled={isUpdatingTone}
-            />
-          </label>
-          <p className="text-xs text-[var(--muted)]">
-            Selecting a tone here overrides the global clip tone for this account. Choose 'Use
-            default tone' to inherit the Settings value.
-          </p>
-        </div>
-        {success ? (
-          <p className="text-xs font-medium text-[color:var(--success-strong)]">{success}</p>
-        ) : null}
-        {error ? (
-          <p className="text-xs font-medium text-[color:var(--error-strong)]">{error}</p>
-        ) : null}
-      </div>
+      {feedbackMessage}
 
       {isCollapsed ? (
         <div id={detailsId} className="flex flex-col gap-3">
@@ -636,6 +640,7 @@ const AccountCard: FC<AccountCardProps> = ({
         </div>
       ) : (
         <div id={detailsId} className="flex flex-col gap-4">
+          {toneControls}
           <div className="flex flex-wrap items-center gap-2">
             <button
               type="button"

--- a/desktop/src/renderer/src/services/accountsApi.ts
+++ b/desktop/src/renderer/src/services/accountsApi.ts
@@ -75,12 +75,19 @@ export const addPlatformToAccount = async (
 
 export const updateAccount = async (
   accountId: string,
-  payload: { active?: boolean }
+  payload: { active?: boolean; tone?: string | null }
 ): Promise<AccountSummary> => {
+  const body: Record<string, unknown> = {}
+  if (payload.active !== undefined) {
+    body.active = payload.active
+  }
+  if (payload.tone !== undefined) {
+    body.tone = payload.tone
+  }
   const response = await requestWithFallback(() => buildAccountUrl(accountId), {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ active: payload.active })
+    body: JSON.stringify(body)
   })
   if (!response.ok) {
     throw new Error(await extractErrorMessage(response))

--- a/desktop/src/renderer/src/tests/profile.test.tsx
+++ b/desktop/src/renderer/src/tests/profile.test.tsx
@@ -247,9 +247,7 @@ describe('Profile page', () => {
     const brandCard = screen.getAllByTestId('account-card-account-2')[0]
     const scope = within(brandCard)
 
-    fireEvent.click(scope.getByRole('button', { name: /Expand|Collapse/i }))
-
-    const toneSelect = await scope.findByLabelText(/^Tone$/i)
+    const toneSelect = scope.getByLabelText(/^Tone$/i)
     fireEvent.change(toneSelect, { target: { value: 'science' } })
 
     await waitFor(() => expect(updateAccountMock).toHaveBeenCalledTimes(1))

--- a/desktop/src/renderer/src/tests/profile.test.tsx
+++ b/desktop/src/renderer/src/tests/profile.test.tsx
@@ -247,7 +247,10 @@ describe('Profile page', () => {
     const brandCard = screen.getAllByTestId('account-card-account-2')[0]
     const scope = within(brandCard)
 
-    fireEvent.change(scope.getByLabelText(/^Tone$/i), { target: { value: 'science' } })
+    fireEvent.click(scope.getByRole('button', { name: /Expand|Collapse/i }))
+
+    const toneSelect = await scope.findByLabelText(/^Tone$/i)
+    fireEvent.change(toneSelect, { target: { value: 'science' } })
 
     await waitFor(() => expect(updateAccountMock).toHaveBeenCalledTimes(1))
     expect(updateAccountMock).toHaveBeenCalledWith('account-2', { tone: 'science' })

--- a/desktop/src/renderer/src/tests/profile.test.tsx
+++ b/desktop/src/renderer/src/tests/profile.test.tsx
@@ -247,8 +247,6 @@ describe('Profile page', () => {
     const brandCard = screen.getAllByTestId('account-card-account-2')[0]
     const scope = within(brandCard)
 
-    fireEvent.click(scope.getByRole('button', { name: /Expand/i }))
-
     fireEvent.change(scope.getByLabelText(/^Tone$/i), { target: { value: 'science' } })
 
     await waitFor(() => expect(updateAccountMock).toHaveBeenCalledTimes(1))

--- a/desktop/src/renderer/src/tests/profile.test.tsx
+++ b/desktop/src/renderer/src/tests/profile.test.tsx
@@ -1,9 +1,42 @@
 import '@testing-library/jest-dom/vitest'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import type { ComponentProps } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import Profile from '../pages/Profile'
 import type { AccountPlatformConnection, AccountSummary, AuthPingSummary } from '../types'
+
+vi.mock('../components/MarbleSelect', () => {
+  return {
+    default: ({
+      options,
+      value,
+      onChange,
+      id,
+      name
+    }: {
+      options: Array<{ value: string; label: string }>
+      value: string | null
+      onChange: (value: string) => void
+      id?: string
+      name?: string
+    }) => (
+      <select
+        data-testid={id ?? name ?? 'marble-select'}
+        value={value ?? ''}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        <option value="" disabled>
+          Select option
+        </option>
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    )
+  }
+})
 
 const createPlatform = (
   overrides: Partial<AccountPlatformConnection> = {}
@@ -26,7 +59,9 @@ const sampleAccounts: AccountSummary[] = [
     description: 'Primary publishing account',
     createdAt: '2025-05-01T12:00:00Z',
     platforms: [createPlatform()],
-    active: true
+    active: true,
+    tone: null,
+    effectiveTone: 'funny'
   },
   {
     id: 'account-2',
@@ -34,7 +69,9 @@ const sampleAccounts: AccountSummary[] = [
     description: null,
     createdAt: '2025-05-01T12:00:00Z',
     platforms: [],
-    active: true
+    active: true,
+    tone: 'tech',
+    effectiveTone: 'tech'
   }
 ]
 
@@ -55,6 +92,10 @@ describe('Profile page', () => {
   const deleteAccountMock = vi.fn()
   const updatePlatformMock = vi.fn()
   const deletePlatformMock = vi.fn()
+
+  afterEach(() => {
+    cleanup()
+  })
 
   beforeEach(() => {
     createAccountMock.mockReset()
@@ -97,6 +138,7 @@ describe('Profile page', () => {
     const scope = within(creatorCard)
     expect(scope.getByText('YouTube Channel')).toBeVisible()
     expect(scope.getByText(/Authenticated/i)).toBeVisible()
+    expect(scope.getByText('Tone: Funny')).toBeVisible()
   })
 
   it('submits a new account with trimmed values', async () => {
@@ -132,7 +174,8 @@ describe('Profile page', () => {
 
     const brandCard = screen.getAllByTestId('account-card-account-2')[0]
     const scope = within(brandCard)
-    fireEvent.change(scope.getByLabelText(/Platform/i), { target: { value: 'instagram' } })
+    const [platformSelect] = scope.getAllByLabelText(/Platform/i)
+    fireEvent.change(platformSelect, { target: { value: 'instagram' } })
     fireEvent.change(scope.getByLabelText(/Label \(optional\)/i), {
       target: { value: 'Brand Instagram' }
     })
@@ -155,7 +198,8 @@ describe('Profile page', () => {
 
     const brandCard = screen.getAllByTestId('account-card-account-2')[0]
     const scope = within(brandCard)
-    fireEvent.change(scope.getByLabelText(/Platform/i), { target: { value: 'instagram' } })
+    const [platformSelect] = scope.getAllByLabelText(/Platform/i)
+    fireEvent.change(platformSelect, { target: { value: 'instagram' } })
 
     const connectButton = scope.getByRole('button', { name: /Connect platform/i })
     fireEvent.click(connectButton)
@@ -181,12 +225,35 @@ describe('Profile page', () => {
 
     const creatorCard = screen.getAllByTestId('account-card-account-1')[0]
     const scope = within(creatorCard)
+    fireEvent.click(scope.getByRole('button', { name: /Expand|Collapse/i }))
     const toggleButton = scope.getByRole('button', { name: /Disable account/i })
     fireEvent.click(toggleButton)
 
     await waitFor(() => expect(updateAccountMock).toHaveBeenCalledTimes(1))
     expect(updateAccountMock).toHaveBeenCalledWith('account-1', { active: false })
     expect(await scope.findByText(/Account disabled successfully/i)).toBeInTheDocument()
+  })
+
+  it('updates the account tone override', async () => {
+    const updatedAccount: AccountSummary = {
+      ...sampleAccounts[1],
+      tone: 'science',
+      effectiveTone: 'science'
+    }
+    updateAccountMock.mockResolvedValueOnce(updatedAccount)
+
+    renderProfile()
+
+    const brandCard = screen.getAllByTestId('account-card-account-2')[0]
+    const scope = within(brandCard)
+
+    fireEvent.click(scope.getByRole('button', { name: /Expand/i }))
+
+    fireEvent.change(scope.getByLabelText(/^Tone$/i), { target: { value: 'science' } })
+
+    await waitFor(() => expect(updateAccountMock).toHaveBeenCalledTimes(1))
+    expect(updateAccountMock).toHaveBeenCalledWith('account-2', { tone: 'science' })
+    expect(await scope.findByText(/Tone set to Science/i)).toBeInTheDocument()
   })
 
   it('disables and removes a platform connection', async () => {
@@ -214,14 +281,16 @@ describe('Profile page', () => {
       const creatorCard = screen.getAllByTestId('account-card-account-1')[0]
       const scope = within(creatorCard)
 
-      const disableButton = scope.getByRole('button', { name: /^Disable$/i })
+      fireEvent.click(scope.getByRole('button', { name: /Expand|Collapse/i }))
+
+      const disableButton = await scope.findByRole('button', { name: /^Disable$/i })
       fireEvent.click(disableButton)
 
       await waitFor(() => expect(updatePlatformMock).toHaveBeenCalledTimes(1))
       expect(updatePlatformMock).toHaveBeenCalledWith('account-1', 'youtube', { active: false })
       expect(await scope.findByText(/YouTube disabled successfully/i)).toBeInTheDocument()
 
-      const removeButton = scope.getByRole('button', { name: /^Remove$/i })
+      const removeButton = await scope.findByRole('button', { name: /^Remove$/i })
       fireEvent.click(removeButton)
 
       await waitFor(() => expect(deletePlatformMock).toHaveBeenCalledTimes(1))

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -57,6 +57,8 @@ export interface AccountSummary {
   createdAt: string
   platforms: AccountPlatformConnection[]
   active: boolean
+  tone: string | null
+  effectiveTone: string | null
 }
 
 export interface AuthPingSummary {

--- a/server/app.py
+++ b/server/app.py
@@ -900,15 +900,23 @@ async def start_job(payload: RunRequest) -> RunResponse:
         state.resume_event = threading.Event()
     observer = BroadcastObserver(state)
 
+    account_details: AccountResponse | None = None
     if payload.account:
-        ensure_account_available(payload.account)
+        account_details = ensure_account_available(payload.account)
 
     def runner() -> None:
         try:
+            selected_tone = payload.tone
+            if (
+                selected_tone is None
+                and account_details is not None
+                and account_details.tone is not None
+            ):
+                selected_tone = account_details.tone
             process_video(
                 payload.url,
                 account=payload.account,
-                tone=payload.tone,
+                tone=selected_tone,
                 observer=observer,
                 pause_for_review=payload.review_mode,
                 review_gate=state.wait_for_resume if payload.review_mode else None,


### PR DESCRIPTION
## Summary
- add shared tone constants and plumb tone metadata through account types, backend responses, and pipeline job requests
- surface account tone badges and selectors in the profile alongside override messaging in settings, and reorder the navigation tabs
- update renderer tests to cover tone overrides and stabilise account selection flows with a MarbleSelect mock

## Testing
- npm test -- --run
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0b9abdc488323b30fc2ba5a65e0e5