### PR TITLE
Enhance clip editing guardrails and align theme colors

### DIFF
--- a/desktop/src/renderer/src/index.css
+++ b/desktop/src/renderer/src/index.css
@@ -235,38 +235,6 @@ body {
   color: var(--fg-inverse-soft) !important;
 }
 
-.text-amber-50 {
-  color: color-mix(in srgb, var(--accent-contrast) 90%, transparent) !important;
-}
-
-.text-amber-100 {
-  color: color-mix(in srgb, var(--warning) 46%, var(--fg)) !important;
-}
-
-.text-amber-200\/90 {
-  color: color-mix(in srgb, var(--warning) 58%, var(--fg)) !important;
-}
-
-.text-amber-300 {
-  color: color-mix(in srgb, var(--warning) 62%, var(--fg)) !important;
-}
-
-.bg-amber-500\/10,
-.hover\:bg-amber-500\/10:hover {
-  background-color: color-mix(in srgb, var(--warning) 26%, var(--panel)) !important;
-}
-
-.bg-amber-500\/20,
-.hover\:bg-amber-500\/20:hover {
-  background-color: color-mix(in srgb, var(--warning) 38%, var(--panel)) !important;
-}
-
-.border-amber-400\/40,
-.hover\:border-amber-400\/40:hover,
-.focus-visible\:border-amber-400\/40:focus-visible {
-  border-color: color-mix(in srgb, var(--warning) 48%, var(--edge)) !important;
-}
-
 .border-dashed {
   border-color: color-mix(in srgb, var(--edge) 50%, transparent);
 }

--- a/desktop/src/renderer/src/pages/ClipEdit.tsx
+++ b/desktop/src/renderer/src/pages/ClipEdit.tsx
@@ -23,6 +23,11 @@ const toSeconds = (value: number): number => Math.max(0, Number.isFinite(value) 
 const MIN_CLIP_GAP = 0.25
 const MIN_PREVIEW_DURATION = 0.05
 const DEFAULT_EXPAND_SECONDS = 10
+// Keep duration guardrails aligned with the backend defaults in server/config.py.
+const MIN_CLIP_DURATION_SECONDS = 10
+const MAX_CLIP_DURATION_SECONDS = 85
+const SWEET_SPOT_MIN_SECONDS = 25
+const SWEET_SPOT_MAX_SECONDS = 60
 
 const getDefaultPreviewMode = (clip: Clip | null): 'adjusted' | 'rendered' =>
   clip && clip.previewUrl === clip.playbackUrl ? 'rendered' : 'adjusted'
@@ -414,12 +419,18 @@ const ClipEdit: FC<{ registerSearch: (bridge: SearchBridge | null) => void }> = 
         return
       }
       if (kind === 'start') {
-        handleStartChange(offsetReference.startBase + value)
+        snapRangeToValues(offsetReference.startBase + value, rangeEnd)
       } else {
-        handleEndChange(offsetReference.endBase + value)
+        snapRangeToValues(rangeStart, offsetReference.endBase + value)
       }
     },
-    [handleEndChange, handleStartChange, offsetReference.endBase, offsetReference.startBase]
+    [
+      offsetReference.endBase,
+      offsetReference.startBase,
+      rangeEnd,
+      rangeStart,
+      snapRangeToValues
+    ]
   )
 
   const handleRangeInputKeyDown = useCallback(
@@ -625,6 +636,13 @@ const ClipEdit: FC<{ registerSearch: (bridge: SearchBridge | null) => void }> = 
   }, [clipState, minGap])
 
   const durationSeconds = Math.max(minGap, rangeEnd - rangeStart)
+  const durationEpsilon = 0.0005
+  const durationBelowMin = durationSeconds < MIN_CLIP_DURATION_SECONDS - durationEpsilon
+  const durationAboveMax = durationSeconds > MAX_CLIP_DURATION_SECONDS + durationEpsilon
+  const durationWithinLimits = !durationBelowMin && !durationAboveMax
+  const durationWithinSweetSpot =
+    durationSeconds >= SWEET_SPOT_MIN_SECONDS - durationEpsilon &&
+    durationSeconds <= SWEET_SPOT_MAX_SECONDS + durationEpsilon
   const startOffsetSeconds = rangeStart - offsetReference.startBase
   const endOffsetSeconds = rangeEnd - offsetReference.endBase
   const formattedStartOffset = formatRelativeSeconds(startOffsetSeconds)
@@ -1164,7 +1182,7 @@ const ClipEdit: FC<{ registerSearch: (bridge: SearchBridge | null) => void }> = 
                       : 'Previewing the adjusted range directly from the source video without captions or layout.'}
               </p>
               {renderedOutOfSync ? (
-                <p className="text-xs font-medium text-amber-200/90">
+                <p className="text-xs font-medium text-[color:color-mix(in_srgb,var(--warning-strong)_80%,var(--accent-contrast))]">
                   The rendered output does not yet reflect these boundaries. Save the clip to rerun
                   step 7 and refresh the export.
                 </p>
@@ -1373,6 +1391,39 @@ const ClipEdit: FC<{ registerSearch: (bridge: SearchBridge | null) => void }> = 
                   {formatDuration(durationSeconds)}
                 </span>
               </div>
+              {!durationWithinLimits ? (
+                <div className="flex items-start gap-2 rounded-lg border border-[color:color-mix(in_srgb,var(--error-strong)_45%,var(--edge))] bg-[color:var(--error-soft)] px-3 py-2 text-xs text-[color:color-mix(in_srgb,var(--error-strong)_85%,var(--accent-contrast))]">
+                  <span
+                    className="mt-0.5 h-2 w-2 flex-shrink-0 rounded-full bg-[color:var(--error-strong)]"
+                    aria-hidden="true"
+                  />
+                  <div className="space-y-1">
+                    <p className="font-semibold uppercase tracking-wide">Outside clip limits</p>
+                    <p>
+                      Clips must stay between {MIN_CLIP_DURATION_SECONDS.toFixed(0)}s and{' '}
+                      {MAX_CLIP_DURATION_SECONDS.toFixed(0)}s. Adjust the boundaries to bring
+                      this clip back in range. Current duration: {formatDuration(durationSeconds)}.
+                    </p>
+                  </div>
+                </div>
+              ) : null}
+              {durationWithinLimits && !durationWithinSweetSpot ? (
+                <div className="flex items-start gap-2 rounded-lg border border-[color:color-mix(in_srgb,var(--warning-strong)_45%,var(--edge))] bg-[color:var(--warning-soft)] px-3 py-2 text-xs text-[color:var(--warning-contrast)]">
+                  <span
+                    className="mt-0.5 h-2 w-2 flex-shrink-0 rounded-full bg-[color:var(--warning-strong)]"
+                    aria-hidden="true"
+                  />
+                  <div className="space-y-1">
+                    <p className="font-semibold uppercase tracking-wide">Outside sweet spot</p>
+                    <p>
+                      The recommended sweet spot is {SWEET_SPOT_MIN_SECONDS.toFixed(0)}–
+                      {SWEET_SPOT_MAX_SECONDS.toFixed(0)} seconds. Tweaking the boundaries can help
+                      this clip land inside the preferred window. Current duration:{' '}
+                      {formatDuration(durationSeconds)}.
+                    </p>
+                  </div>
+                </div>
+              ) : null}
               <div className="flex flex-wrap items-center gap-3 text-xs font-medium uppercase tracking-wide text-[color:color-mix(in_srgb,var(--muted)_70%,transparent)]">
                 <label className="flex items-center gap-2">
                   Expand window (seconds)
@@ -1436,7 +1487,7 @@ const ClipEdit: FC<{ registerSearch: (bridge: SearchBridge | null) => void }> = 
                   const indicatorClasses = isCompleted
                     ? 'border-[color:color-mix(in_srgb,var(--success-strong)_45%,var(--edge))] bg-[color:var(--success-soft)] text-[color:color-mix(in_srgb,var(--success-strong)_85%,var(--accent-contrast))]'
                     : isFailed
-                      ? 'bg-rose-500/10 text-rose-200 border border-rose-500/40'
+                      ? 'border-[color:color-mix(in_srgb,var(--error-strong)_45%,var(--edge))] bg-[color:var(--error-soft)] text-[color:color-mix(in_srgb,var(--error-strong)_85%,var(--accent-contrast))]'
                       : isRunning
                         ? 'border-[var(--ring)] text-[var(--ring)]'
                         : 'border-white/15 text-[var(--muted)]'
@@ -1466,7 +1517,11 @@ const ClipEdit: FC<{ registerSearch: (bridge: SearchBridge | null) => void }> = 
               </ol>
             </div>
           ) : null}
-          {saveError ? <p className="text-sm text-rose-400">{saveError}</p> : null}
+          {saveError ? (
+            <p className="text-sm text-[color:color-mix(in_srgb,var(--error-strong)_82%,var(--accent-contrast))]">
+              {saveError}
+            </p>
+          ) : null}
           {saveSuccess ? (
             <p className="text-sm text-[color:color-mix(in_srgb,var(--success-strong)_82%,var(--accent-contrast))]">
               {saveSuccess}

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -963,7 +963,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
                       : 'Select an account from the top navigation before starting.'}
                 </div>
                 {availableAccounts.length === 0 ? (
-                  <p className="text-xs text-amber-300">
+                  <p className="text-xs text-[color:color-mix(in_srgb,var(--warning-strong)_72%,var(--accent-contrast))]">
                     Enable an account with an active platform from your profile before starting the pipeline.
                   </p>
                 ) : null}
@@ -1018,11 +1018,18 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
                 : 'against the backend API for live progress updates.'}
             </div>
             {accountError ? (
-              <p id="account-error" className="text-xs font-medium text-rose-400">
+              <p
+                id="account-error"
+                className="text-xs font-medium text-[color:color-mix(in_srgb,var(--error-strong)_82%,var(--accent-contrast))]"
+              >
                 {accountError}
               </p>
             ) : null}
-            {urlError ? <p className="text-xs font-medium text-rose-400">{urlError}</p> : null}
+            {urlError ? (
+              <p className="text-xs font-medium text-[color:color-mix(in_srgb,var(--error-strong)_82%,var(--accent-contrast))]">
+                {urlError}
+              </p>
+            ) : null}
           </form>
 
           <div className="rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--card)_70%,transparent)] p-6 shadow-[0_20px_40px_-24px_rgba(15,23,42,0.6)]">
@@ -1034,13 +1041,13 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
               <PipelineProgress steps={steps} />
             </div>
             {awaitingReview ? (
-              <div className="mt-4 rounded-lg border border-amber-400/40 bg-[color:color-mix(in_srgb,var(--card)_75%,transparent)] p-4 text-sm text-amber-200">
+              <div className="mt-4 rounded-lg border border-[color:color-mix(in_srgb,var(--warning-strong)_45%,var(--edge))] bg-[color:var(--warning-soft)] p-4 text-sm text-[color:var(--warning-contrast)]">
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                   <span>Review the clips below and resume the pipeline once you&apos;re happy with the trims.</span>
                   <button
                     type="button"
                     onClick={handleResumePipeline}
-                    className="inline-flex items-center justify-center rounded-lg border border-white/20 bg-amber-500/20 px-3 py-1.5 text-xs font-semibold text-amber-50 transition hover:bg-amber-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+                    className="inline-flex items-center justify-center rounded-lg border border-[color:color-mix(in_srgb,var(--warning-strong)_45%,var(--edge))] bg-[color:color-mix(in_srgb,var(--warning-strong)_38%,transparent)] px-3 py-1.5 text-xs font-semibold text-[color:var(--warning-contrast)] transition hover:bg-[color:color-mix(in_srgb,var(--warning-strong)_48%,transparent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_srgb,var(--warning-strong)_70%,transparent)]"
                   >
                     Resume pipeline
                   </button>
@@ -1122,8 +1129,16 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
                 {isOpeningFolder ? 'Opening…' : 'Open clips folder'}
               </button>
             </div>
-            {folderMessage ? <p className="text-sm text-emerald-300">{folderMessage}</p> : null}
-            {folderErrorMessage ? <p className="text-sm text-rose-400">{folderErrorMessage}</p> : null}
+            {folderMessage ? (
+              <p className="text-sm text-[color:color-mix(in_srgb,var(--success-strong)_78%,var(--accent-contrast))]">
+                {folderMessage}
+              </p>
+            ) : null}
+            {folderErrorMessage ? (
+              <p className="text-sm text-[color:color-mix(in_srgb,var(--error-strong)_82%,var(--accent-contrast))]">
+                {folderErrorMessage}
+              </p>
+            ) : null}
             {timelineClips.length > 0 ? (
               <div className="relative mt-2">
                 <div className="absolute left-3 top-0 bottom-0 w-px bg-white/10" aria-hidden="true" />

--- a/desktop/src/renderer/src/pages/Library.tsx
+++ b/desktop/src/renderer/src/pages/Library.tsx
@@ -504,7 +504,7 @@ const Library: FC<LibraryProps> = ({
               </div>
             </div>
             {clipsError ? (
-              <div className="rounded-lg border border-rose-400/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+              <div className="rounded-lg border border-[color:color-mix(in_srgb,var(--error-strong)_45%,var(--edge))] bg-[color:var(--error-soft)] px-4 py-3 text-sm text-[color:color-mix(in_srgb,var(--error-strong)_85%,var(--accent-contrast))]">
                 {clipsError}
               </div>
             ) : null}

--- a/desktop/src/renderer/src/pages/Settings.tsx
+++ b/desktop/src/renderer/src/pages/Settings.tsx
@@ -972,12 +972,12 @@ const Settings: FC<SettingsProps> = ({ registerSearch, accounts, onRegisterHeade
           </div>
         </div>
         {error && (
-          <div className="rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-100">
+          <div className="rounded-md border border-[color:color-mix(in_srgb,var(--error-strong)_45%,var(--edge))] bg-[color:var(--error-soft)] px-3 py-2 text-sm text-[color:color-mix(in_srgb,var(--error-strong)_85%,var(--accent-contrast))]">
             {error}
           </div>
         )}
         {success && (
-          <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100">
+          <div className="rounded-md border border-[color:color-mix(in_srgb,var(--success-strong)_45%,var(--edge))] bg-[color:var(--success-soft)] px-3 py-2 text-sm text-[color:color-mix(in_srgb,var(--success-strong)_85%,var(--accent-contrast))]">
             {success}
           </div>
         )}


### PR DESCRIPTION
## Summary
- auto-expand manual clip edits beyond the current window and surface duration guardrails in the editor
- add sweet spot and hard limit callouts that use the neutral palette
- replace legacy amber/rose/emerald utility colors in desktop surfaces with theme variables

## Testing
- PYTHONPATH=.:server pytest --maxfail=1 *(fails: local test data and auth fixtures expected empty state)*

------
https://chatgpt.com/codex/tasks/task_e_68d1adc217988323b3fccf38d66deadf