### PR TITLE
Configure billing API defaults for dev and production

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -37,7 +37,13 @@ URL:
 
 ```env
 VITE_API_BASE_URL=http://localhost:8000
+VITE_BILLING_API_BASE_URL=https://dev.api.atropos-video.com
 ```
+
+If not specified, the billing endpoints target `https://dev.api.atropos-video.com`
+during development and `https://api.atropos-video.com` for packaged builds.
+Override `VITE_BILLING_API_BASE_URL` when you need to point at a different
+environment.
 
 Set `VITE_BACKEND_MODE=mock` to explore the UI with simulated pipeline events
 when the Python server is unavailable. Remove the variable (or set it to `api`)

--- a/desktop/src/renderer/src/config/backend.ts
+++ b/desktop/src/renderer/src/config/backend.ts
@@ -64,10 +64,29 @@ const buildDefaultBaseUrls = (): string[] => {
 const explicitBase = normaliseBaseUrl(import.meta.env.VITE_API_BASE_URL)
 const apiBaseCandidates = explicitBase ? [explicitBase] : buildDefaultBaseUrls()
 
+const DEFAULT_BILLING_DEV_BASE_URL = 'https://dev.api.atropos-video.com'
+const DEFAULT_BILLING_PROD_BASE_URL = 'https://api.atropos-video.com'
+
+const resolveBillingBaseUrl = (): string => {
+  const explicitBillingBase = normaliseBaseUrl(import.meta.env.VITE_BILLING_API_BASE_URL)
+  if (explicitBillingBase) {
+    return explicitBillingBase
+  }
+
+  const defaultBillingBase = import.meta.env.PROD
+    ? DEFAULT_BILLING_PROD_BASE_URL
+    : DEFAULT_BILLING_DEV_BASE_URL
+  return defaultBillingBase
+}
+
+const billingBaseUrl = resolveBillingBaseUrl()
+
 let candidateIndex = 0
 let currentBaseUrl = apiBaseCandidates[candidateIndex]
 
 export const getApiBaseUrl = (): string => currentBaseUrl
+
+export const getBillingApiBaseUrl = (): string => billingBaseUrl
 
 export const advanceApiBaseUrl = (): string | null => {
   if (candidateIndex + 1 < apiBaseCandidates.length) {
@@ -149,17 +168,17 @@ export const buildAuthPingUrl = (): string => {
 }
 
 export const buildSubscriptionStatusUrl = (): string => {
-  const url = new URL('/api/billing/subscription', getApiBaseUrl())
+  const url = new URL('/api/billing/subscription', getBillingApiBaseUrl())
   return url.toString()
 }
 
 export const buildCheckoutSessionUrl = (): string => {
-  const url = new URL('/api/billing/checkout', getApiBaseUrl())
+  const url = new URL('/api/billing/checkout', getBillingApiBaseUrl())
   return url.toString()
 }
 
 export const buildBillingPortalUrl = (): string => {
-  const url = new URL('/api/billing/portal', getApiBaseUrl())
+  const url = new URL('/api/billing/portal', getBillingApiBaseUrl())
   return url.toString()
 }
 

--- a/desktop/src/renderer/src/env.d.ts
+++ b/desktop/src/renderer/src/env.d.ts
@@ -5,6 +5,7 @@ declare global {
   interface ImportMetaEnv {
     readonly VITE_BACKEND_MODE?: 'mock' | 'api'
     readonly VITE_API_BASE_URL?: string
+    readonly VITE_BILLING_API_BASE_URL?: string
     readonly VITE_ACCESS_API_URL?: string
     readonly VITE_ACCESS_CLIENT_ID?: string
     readonly VITE_ACCESS_AUDIENCE?: string


### PR DESCRIPTION
## Summary
- add a dedicated billing API base URL that defaults to the dev domain during development and the production domain for packaged builds
- expose a VITE_BILLING_API_BASE_URL override and document the new configuration option

## Testing
- PYTHONPATH=. pytest *(fails: ModuleNotFoundError: No module named 'custom_types')*

------
https://chatgpt.com/codex/tasks/task_e_68d47d6d6478832388855818198e0b23