### PR TITLE
Fix Stripe success redirect and customer persistence

### DIFF
--- a/services/licensing/src/stripe.ts
+++ b/services/licensing/src/stripe.ts
@@ -72,8 +72,14 @@ export async function createCheckoutSession(
   params.set("line_items[0][price]", payload.priceId);
   params.set("line_items[0][quantity]", "1");
   params.set("allow_promotion_codes", "true");
-  params.set("success_url", payload.successUrl ?? env.RETURN_URL_SUCCESS ?? "https://atropos.video/billing/success");
-  params.set("cancel_url", payload.cancelUrl ?? env.RETURN_URL_CANCEL ?? "https://atropos.video/billing/cancel");
+  params.set(
+    "success_url",
+    payload.successUrl ?? env.RETURN_URL_SUCCESS ?? "https://atropos.video/"
+  );
+  params.set(
+    "cancel_url",
+    payload.cancelUrl ?? env.RETURN_URL_CANCEL ?? "https://atropos.video/"
+  );
   params.set("subscription_data[metadata][user_id]", payload.userId);
   params.set("metadata[user_id]", payload.userId);
   params.set("metadata[price_id]", payload.priceId);


### PR DESCRIPTION
## Summary
- update the default Stripe checkout redirect URLs to point at the public site instead of a missing billing page
- normalize Stripe customer identifiers from webhook payloads so we persist the correct Stripe user IDs

## Testing
- pytest *(fails: missing httpx and libGL runtime dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d494fb6c508323956417144f8ef88a