### PR TITLE
Handle Stripe subscription cancellations

### DIFF
--- a/services/licensing/src/kv.ts
+++ b/services/licensing/src/kv.ts
@@ -6,6 +6,7 @@ export interface UserRecord {
   status: string;
   current_period_end?: number;
   plan_price_id?: string;
+  cancel_at_period_end?: boolean;
   updated_at: number;
 }
 
@@ -13,6 +14,7 @@ export interface SubscriptionRecord {
   user_id: string;
   status: string;
   current_period_end?: number;
+  cancel_at_period_end?: boolean;
   updated_at: number;
 }
 


### PR DESCRIPTION
## Summary
- persist Stripe subscription cancellation details in KV records
- capture cancel-at-period-end and updated metadata during subscription updates
- normalize subscription lookup responses with cancelation state

## Testing
- pytest *(fails: missing optional dependencies `httpx` and `cv2` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ca926cf48323a0452222b9001ccc