### PR TITLE
Poll desktop subscription access and update billing CTA

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -38,6 +38,7 @@ type PlatformPayload = {
 }
 
 const THEME_STORAGE_KEY = 'atropos:theme'
+const ACCESS_REFRESH_INTERVAL_MS = 60_000
 
 const sortAccounts = (items: AccountSummary[]): AccountSummary[] =>
   [...items].sort((a, b) => a.displayName.localeCompare(b.displayName))
@@ -199,7 +200,20 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
   }, [])
 
   useEffect(() => {
+    let intervalId: number | null = null
     void refreshAccessStatus()
+
+    if (typeof window !== 'undefined') {
+      intervalId = window.setInterval(() => {
+        void refreshAccessStatus()
+      }, ACCESS_REFRESH_INTERVAL_MS)
+    }
+
+    return () => {
+      if (intervalId !== null && typeof window !== 'undefined') {
+        window.clearInterval(intervalId)
+      }
+    }
   }, [refreshAccessStatus])
 
   useEffect(() => {

--- a/desktop/src/renderer/src/config/accessControl.ts
+++ b/desktop/src/renderer/src/config/accessControl.ts
@@ -29,8 +29,29 @@ const parseNumber = (value: string | undefined, fallback: number): number => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
+const parseBoolean = (value: string | undefined, fallback = false): boolean => {
+  if (!value) {
+    return fallback
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (normalized.length === 0) {
+    return fallback
+  }
+
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+    return true
+  }
+
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+    return false
+  }
+
+  return fallback
+}
+
 const apiUrl = parseUrl(import.meta.env.VITE_ACCESS_API_URL)
-const useMock = apiUrl === null
+const useMock = parseBoolean(import.meta.env.VITE_ACCESS_USE_MOCK, false)
 
 const config: AccessControlConfig = {
   apiUrl,

--- a/desktop/src/renderer/src/services/accessControl.ts
+++ b/desktop/src/renderer/src/services/accessControl.ts
@@ -1,7 +1,160 @@
 import { getAccessControlConfig } from '../config/accessControl'
-import type { AccessCheckResult, AccessJwtPayload } from '../types'
+import type {
+  AccessCheckResult,
+  AccessJwtPayload,
+  SubscriptionLifecycleStatus
+} from '../types'
+
+type LicenseCacheEntry = {
+  token: string
+  exp: number
+}
+
+type SubscriptionApiResponse = {
+  status?: string | null
+  entitled?: boolean
+  current_period_end?: number | null
+  cancel_at_period_end?: boolean | null
+}
+
+type LicenseIssueResponse = {
+  token?: string
+  exp?: number
+}
+
+const DEVICE_HASH_STORAGE_KEY = 'atropos:device-hash'
+const LICENSE_STORAGE_KEY = 'atropos:license-token'
+
+const allowedStatuses: SubscriptionLifecycleStatus[] = [
+  'inactive',
+  'active',
+  'trialing',
+  'grace_period',
+  'past_due',
+  'canceled',
+  'incomplete',
+  'incomplete_expired',
+  'unpaid',
+  'paused'
+]
+
+let cachedLicense: LicenseCacheEntry | null = null
 
 const textEncoder = new TextEncoder()
+
+const isWindowAvailable = (): boolean => typeof window !== 'undefined'
+
+const readStorageValue = (key: string): string | null => {
+  if (!isWindowAvailable()) {
+    return null
+  }
+  try {
+    return window.localStorage.getItem(key)
+  } catch (error) {
+    console.warn('Failed to read from localStorage.', error)
+    return null
+  }
+}
+
+const writeStorageValue = (key: string, value: string | null): void => {
+  if (!isWindowAvailable()) {
+    return
+  }
+  try {
+    if (value === null) {
+      window.localStorage.removeItem(key)
+    } else {
+      window.localStorage.setItem(key, value)
+    }
+  } catch (error) {
+    console.warn('Failed to write to localStorage.', error)
+  }
+}
+
+const generateDeviceHash = (): string => {
+  if (typeof crypto !== 'undefined') {
+    if (typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID().replace(/-/gu, '')
+    }
+    if (typeof crypto.getRandomValues === 'function') {
+      const buffer = new Uint8Array(16)
+      crypto.getRandomValues(buffer)
+      return Array.from(buffer)
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('')
+    }
+  }
+  return Math.random().toString(36).slice(2, 18)
+}
+
+let deviceHashCache: string | null = null
+
+const getOrCreateDeviceHash = (): string => {
+  if (deviceHashCache) {
+    return deviceHashCache
+  }
+
+  const stored = readStorageValue(DEVICE_HASH_STORAGE_KEY)
+  if (stored && stored.trim().length > 0) {
+    deviceHashCache = stored.trim()
+    return deviceHashCache
+  }
+
+  const generated = generateDeviceHash()
+  deviceHashCache = generated
+  writeStorageValue(DEVICE_HASH_STORAGE_KEY, generated)
+  return generated
+}
+
+const isLicenseEntryValid = (entry: LicenseCacheEntry | null): entry is LicenseCacheEntry => {
+  if (!entry) {
+    return false
+  }
+  return entry.exp * 1000 > Date.now() + 5000
+}
+
+const loadLicenseCache = (): LicenseCacheEntry | null => {
+  if (cachedLicense && isLicenseEntryValid(cachedLicense)) {
+    return cachedLicense
+  }
+
+  const raw = readStorageValue(LICENSE_STORAGE_KEY)
+  if (!raw) {
+    cachedLicense = null
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as LicenseCacheEntry
+    if (isLicenseEntryValid(parsed)) {
+      cachedLicense = parsed
+      return parsed
+    }
+  } catch (error) {
+    console.warn('Unable to parse cached license token.', error)
+  }
+
+  cachedLicense = null
+  writeStorageValue(LICENSE_STORAGE_KEY, null)
+  return null
+}
+
+const storeLicenseCache = (entry: LicenseCacheEntry | null): void => {
+  cachedLicense = entry
+  if (entry) {
+    writeStorageValue(LICENSE_STORAGE_KEY, JSON.stringify(entry))
+  } else {
+    writeStorageValue(LICENSE_STORAGE_KEY, null)
+  }
+}
+
+const normalizeStatus = (value: string | null | undefined): SubscriptionLifecycleStatus => {
+  if (!value) {
+    return 'inactive'
+  }
+  const lower = value.toLowerCase() as SubscriptionLifecycleStatus
+  return allowedStatuses.includes(lower) ? lower : 'inactive'
+}
 
 const toBase64Url = (input: Uint8Array | ArrayBuffer): string => {
   const bytes = input instanceof ArrayBuffer ? new Uint8Array(input) : input
@@ -22,6 +175,18 @@ const toBase64Url = (input: Uint8Array | ArrayBuffer): string => {
 const encodeSegment = (value: unknown): string => {
   const json = JSON.stringify(value)
   return toBase64Url(textEncoder.encode(json))
+}
+
+const extractApiError = async (response: Response): Promise<string> => {
+  try {
+    const payload = (await response.json()) as { detail?: string }
+    if (payload && typeof payload.detail === 'string' && payload.detail.trim().length > 0) {
+      return payload.detail
+    }
+  } catch (error) {
+    // Ignore parse errors and fall back to status text
+  }
+  return response.statusText || `Request failed with status ${response.status}`
 }
 
 const getSubtleCrypto = (): SubtleCrypto => {
@@ -91,35 +256,86 @@ export const verifyDesktopAccess = async (): Promise<AccessCheckResult> => {
     return mockAccessResponse(payload)
   }
 
-  const token = await createAccessJwt(payload, config.sharedSecret)
+  const baseUrl = new URL(config.apiUrl)
 
-  const response = await fetch(config.apiUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`
-    },
-    body: JSON.stringify({
-      clientId: config.clientId,
-      clientVersion: config.clientVersion
-    })
+  const subscriptionUrl = new URL('/billing/subscription', baseUrl)
+  subscriptionUrl.searchParams.set('user_id', config.clientId)
+
+  const subscriptionResponse = await fetch(subscriptionUrl.toString(), {
+    headers: { Accept: 'application/json' }
   })
 
-  if (!response.ok) {
-    throw new Error(response.statusText || 'Failed to verify access permissions.')
+  if (!subscriptionResponse.ok) {
+    throw new Error(await extractApiError(subscriptionResponse))
   }
 
-  const body = (await response.json()) as Partial<AccessCheckResult>
+  const subscriptionBody = (await subscriptionResponse.json()) as SubscriptionApiResponse
+  const subscriptionStatus = normalizeStatus(subscriptionBody.status ?? 'inactive')
+  const entitled = Boolean(subscriptionBody.entitled)
+  const currentPeriodEndSeconds =
+    typeof subscriptionBody.current_period_end === 'number'
+      ? subscriptionBody.current_period_end
+      : null
+  const currentPeriodEndIso =
+    currentPeriodEndSeconds && Number.isFinite(currentPeriodEndSeconds)
+      ? new Date(currentPeriodEndSeconds * 1000).toISOString()
+      : null
+
+  if (!entitled) {
+    storeLicenseCache(null)
+    return {
+      allowed: false,
+      status: subscriptionStatus,
+      reason: 'Active subscription required to continue using Atropos.',
+      checkedAt: new Date().toISOString(),
+      expiresAt: currentPeriodEndIso,
+      customerEmail: null,
+      subscriptionPlan: null,
+      subscriptionStatus
+    }
+  }
+
+  let license = loadLicenseCache()
+
+  if (!license) {
+    const deviceHash = getOrCreateDeviceHash()
+    const licenseUrl = new URL('/license/issue', baseUrl)
+    const issueResponse = await fetch(licenseUrl.toString(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: config.clientId, device_hash: deviceHash })
+    })
+
+    if (!issueResponse.ok) {
+      throw new Error(await extractApiError(issueResponse))
+    }
+
+    const licenseBody = (await issueResponse.json()) as LicenseIssueResponse
+    const token = typeof licenseBody.token === 'string' ? licenseBody.token : null
+    const exp =
+      typeof licenseBody.exp === 'number' && Number.isFinite(licenseBody.exp)
+        ? licenseBody.exp
+        : null
+
+    if (!token || !exp) {
+      throw new Error('License issue response was missing required fields.')
+    }
+
+    license = { token, exp }
+    storeLicenseCache(license)
+  }
+
+  const licenseExpiryIso = new Date(license.exp * 1000).toISOString()
 
   return {
-    allowed: Boolean(body.allowed),
-    status: body.status ?? 'inactive',
-    reason: body.reason ?? null,
-    checkedAt: body.checkedAt ?? new Date().toISOString(),
-    expiresAt: body.expiresAt ?? null,
-    customerEmail: body.customerEmail ?? null,
-    subscriptionPlan: body.subscriptionPlan ?? null,
-    subscriptionStatus: body.subscriptionStatus ?? 'inactive'
+    allowed: true,
+    status: subscriptionStatus,
+    reason: null,
+    checkedAt: new Date().toISOString(),
+    expiresAt: currentPeriodEndIso ?? licenseExpiryIso,
+    customerEmail: null,
+    subscriptionPlan: null,
+    subscriptionStatus
   }
 }
 

--- a/desktop/src/renderer/src/services/accessControl.ts
+++ b/desktop/src/renderer/src/services/accessControl.ts
@@ -251,9 +251,13 @@ export const verifyDesktopAccess = async (): Promise<AccessCheckResult> => {
     exp: nowSeconds + config.tokenTtlSeconds
   }
 
-  if (config.useMock || !config.apiUrl) {
+  if (config.useMock) {
     await new Promise((resolve) => setTimeout(resolve, 120))
     return mockAccessResponse(payload)
+  }
+
+  if (!config.apiUrl) {
+    throw new Error('Access control API URL is not configured.')
   }
 
   const baseUrl = new URL(config.apiUrl)

--- a/desktop/src/renderer/src/tests/accessControl.test.ts
+++ b/desktop/src/renderer/src/tests/accessControl.test.ts
@@ -1,9 +1,9 @@
 import { webcrypto } from 'node:crypto'
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AccessJwtPayload } from '../types'
 
 const mockConfig = {
-  apiUrl: null,
+  apiUrl: null as string | null,
   audience: 'atropos-access',
   clientId: 'test-client',
   clientVersion: '1.0.0',
@@ -26,6 +26,11 @@ describe('access control service', () => {
       configurable: true,
       value: webcrypto
     })
+  })
+
+  beforeEach(() => {
+    mockConfig.useMock = true
+    mockConfig.apiUrl = null
   })
 
   afterAll(() => {
@@ -62,6 +67,15 @@ describe('access control service', () => {
     expect(result.allowed).toBe(true)
     expect(result.subscriptionStatus).toBe('active')
     expect(result.customerEmail).toBe('demo-user@example.com')
+  })
+
+  it('fails when the access API URL is missing and mocks are disabled', async () => {
+    mockConfig.useMock = false
+    mockConfig.apiUrl = null
+
+    await expect(verifyDesktopAccess()).rejects.toThrow(
+      'Access control API URL is not configured.'
+    )
   })
 
   it('throws when the shared secret is missing', async () => {

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -151,6 +151,7 @@ export type SubscriptionLifecycleStatus =
   | 'incomplete'
   | 'incomplete_expired'
   | 'unpaid'
+  | 'paused'
 
 export interface SubscriptionStatus {
   status: SubscriptionLifecycleStatus


### PR DESCRIPTION
## Summary
- poll the licensing API for subscription entitlement, cache issued license tokens, and persist the device hash for reuse
- refresh desktop access checks on a 60s interval and toggle the profile billing CTA between checkout and portal actions with focus-based refresh
- extend subscription status typing and update profile tests for the new billing flow

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'server')*

------
https://chatgpt.com/codex/tasks/task_e_68d5efa7ee848323bf305fe4dff99678