### PR TITLE
Improve licensing API CORS handling

### DIFF
--- a/services/licensing/wrangler.toml
+++ b/services/licensing/wrangler.toml
@@ -14,6 +14,7 @@ custom_domain = true
 
 [env.dev.vars]
 TIER = "pro"
+CORS_ALLOW_ORIGINS = "http://localhost:5173,http://localhost:3000"
 
 [env.prod]
 zone_id = "06ff1a42b61b530829c3877a31a39c7b2"
@@ -25,6 +26,7 @@ custom_domain = true
 
 [env.prod.vars]
 TIER = "pro"
+CORS_ALLOW_ORIGINS = "https://atropos-video.com"
 
 # KV namespace bindings are populated after Terraform outputs the namespace id.
 # Replace the placeholder ids below with the values from Terraform outputs.


### PR DESCRIPTION
## Summary
- add reusable helpers that set Access-Control headers for all licensing API responses
- update the OPTIONS preflight handler to return the required CORS headers
- configure explicit development and production origins in wrangler.toml

## Testing
- pytest *(fails: missing httpx and libGL shared library)*

------
https://chatgpt.com/codex/tasks/task_e_68d5fd39bb8c8323983723bf7ed891d4