### PR TITLE
Add dev-only force refresh for subscription endpoint

### DIFF
--- a/services/licensing/src/stripe.ts
+++ b/services/licensing/src/stripe.ts
@@ -163,6 +163,9 @@ export async function createCustomer(
 export interface StripeSubscriptionSummary {
   id: string;
   status?: string | null;
+  current_period_end?: number | null;
+  cancel_at_period_end?: boolean | null;
+  metadata?: Record<string, string> | null;
 }
 
 interface StripeSubscriptionListResponse {


### PR DESCRIPTION
## Summary
- allow the /billing/subscription endpoint to accept a dev-only `force=true` query
- refresh subscription details from Stripe and persist the status flags in KV when forced

## Testing
- pytest *(fails: missing httpx dependency and libGL shared library in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ffeedf9c8323ac0f94299e03d0a0