### PR TITLE
Add trial licensing support across services and desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ emits real-time progress updates over WebSockets. Start the server with:
 uvicorn server.app:app --reload
 ```
 
+Set the licensing service endpoint before starting the API server:
+
+```env
+# Base URL for the licensing Cloudflare Worker (required)
+LICENSING_API_BASE_URL=https://licensing.example.workers.dev
+# Optional timeout (seconds) for requests to the licensing service
+LICENSING_API_TIMEOUT=10
+```
+
+The server validates active subscriptions or one-time trials by calling this
+licensing service before starting each render job.
+
 Submit jobs via `POST /api/jobs` with JSON payloads containing the `url`,
 optional `account`, and optional `tone`. Subscribe to
 `ws://<host>/ws/jobs/<job_id>` to receive step-by-step events without polling.

--- a/desktop/src/renderer/src/config/backend.ts
+++ b/desktop/src/renderer/src/config/backend.ts
@@ -173,6 +173,16 @@ export const buildSubscriptionStatusUrl = (userId: string): string => {
   return url.toString()
 }
 
+export const buildTrialClaimUrl = (): string => {
+  const url = new URL('/trial/claim', getBillingApiBaseUrl())
+  return url.toString()
+}
+
+export const buildTrialConsumeUrl = (): string => {
+  const url = new URL('/trial/consume', getBillingApiBaseUrl())
+  return url.toString()
+}
+
 export const buildCheckoutSessionUrl = (): string => {
   const url = new URL('/billing/checkout', getBillingApiBaseUrl())
   return url.toString()

--- a/desktop/src/renderer/src/services/pipelineApi.ts
+++ b/desktop/src/renderer/src/services/pipelineApi.ts
@@ -9,6 +9,9 @@ export type PipelineJobRequest = {
   account?: string | null
   tone?: string | null
   reviewMode?: boolean
+  userId?: string | null
+  licenseToken?: string | null
+  trialToken?: string | null
 }
 
 export type PipelineJobResponse = {
@@ -39,17 +42,31 @@ export const startPipelineJob = async (request: PipelineJobRequest): Promise<Pip
   while (true) {
     const url = buildJobUrl()
     try {
+      const payload: Record<string, unknown> = {
+        url: request.url,
+        account: request.account ?? null,
+        tone: request.tone ?? null,
+        review_mode: request.reviewMode ?? false
+      }
+
+      if (request.userId && request.userId.trim().length > 0) {
+        payload.user_id = request.userId.trim()
+      }
+
+      if (request.licenseToken && request.licenseToken.trim().length > 0) {
+        payload.license_token = request.licenseToken.trim()
+      }
+
+      if (request.trialToken && request.trialToken.trim().length > 0) {
+        payload.trial_token = request.trialToken.trim()
+      }
+
       response = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({
-          url: request.url,
-          account: request.account ?? null,
-          tone: request.tone ?? null,
-          review_mode: request.reviewMode ?? false
-        })
+        body: JSON.stringify(payload)
       })
       break
     } catch (error) {

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -153,6 +153,13 @@ export type SubscriptionLifecycleStatus =
   | 'unpaid'
   | 'paused'
 
+export interface TrialStatus {
+  allowed: boolean
+  used: boolean
+  usedAt: number | null
+  exp: number | null
+}
+
 export interface SubscriptionStatus {
   status: SubscriptionLifecycleStatus
   planId: string | null
@@ -161,6 +168,8 @@ export interface SubscriptionStatus {
   cancelAt: string | null
   trialEndsAt: string | null
   latestInvoiceUrl: string | null
+  entitled: boolean
+  trial: TrialStatus
 }
 
 export interface CheckoutSession {


### PR DESCRIPTION
## Summary
- extend the licensing worker with trial state storage, JWT helpers, and claim/consume endpoints while exposing trial data in subscription responses
- gate server-side renders on either subscription licenses or verified trial tokens and document the new licensing service configuration
- wire the desktop renderer for trial-aware billing flows, token storage, and CTA updates across payments, pipeline, and UI modules

## Testing
- pytest *(fails: missing httpx dependency and libGL runtime in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6010216288323a111c5ad5a8a9bb4