### PR TITLE
Add three-video trial support and UI integration

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -618,6 +618,7 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
                 initialState={homeState}
                 onStateChange={setHomeState}
                 accounts={accounts}
+                onTrialConsumed={refreshAccessStatus}
               />
             }
           />
@@ -675,6 +676,7 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
                 initialState={homeState}
                 onStateChange={setHomeState}
                 accounts={accounts}
+                onTrialConsumed={refreshAccessStatus}
               />
             }
           />

--- a/desktop/src/renderer/src/config/backend.ts
+++ b/desktop/src/renderer/src/config/backend.ts
@@ -183,6 +183,21 @@ export const buildBillingPortalUrl = (): string => {
   return url.toString()
 }
 
+export const buildTrialStartUrl = (): string => {
+  const url = new URL('/trial/start', getBillingApiBaseUrl())
+  return url.toString()
+}
+
+export const buildTrialClaimUrl = (): string => {
+  const url = new URL('/trial/claim', getBillingApiBaseUrl())
+  return url.toString()
+}
+
+export const buildTrialConsumeUrl = (): string => {
+  const url = new URL('/trial/consume', getBillingApiBaseUrl())
+  return url.toString()
+}
+
 export const buildConfigUrl = (): string => {
   const url = new URL('/api/config', getApiBaseUrl())
   return url.toString()

--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -11,6 +11,7 @@ import type { FC } from 'react'
 import { useNavigate } from 'react-router-dom'
 import PipelineProgress from '../components/PipelineProgress'
 import { BACKEND_MODE, buildJobClipVideoUrl } from '../config/backend'
+import { getAccessControlConfig } from '../config/accessControl'
 import {
   createInitialPipelineSteps,
   PIPELINE_STEP_DEFINITIONS,
@@ -23,6 +24,8 @@ import {
   subscribeToPipelineEvents,
   type PipelineEventMessage
 } from '../services/pipelineApi'
+import { consumeTrial, getActiveTrialToken } from '../services/trialAccess'
+import type { TrialTokenCacheEntry } from '../services/accessControl'
 import { formatDuration, timeAgo } from '../lib/format'
 import { canOpenAccountClipsFolder, openAccountClipsFolder } from '../services/clipLibrary'
 import type { AccountSummary, HomePipelineState, SearchBridge } from '../types'
@@ -46,15 +49,43 @@ type HomeProps = {
   initialState: HomePipelineState
   onStateChange: (state: HomePipelineState) => void
   accounts: AccountSummary[]
+  onTrialConsumed?: () => Promise<void> | void
 }
 
-const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, accounts }) => {
+const Home: FC<HomeProps> = ({
+  registerSearch,
+  initialState,
+  onStateChange,
+  accounts,
+  onTrialConsumed
+}) => {
   const navigate = useNavigate()
   const [state, setState] = useState<HomePipelineState>(initialState)
   const [folderMessage, setFolderMessage] = useState<string | null>(null)
   const [folderErrorMessage, setFolderErrorMessage] = useState<string | null>(null)
   const [isOpeningFolder, setIsOpeningFolder] = useState(false)
   const canAttemptToOpenFolder = useMemo(() => canOpenAccountClipsFolder(), [])
+  const billingUserId = useMemo(() => getAccessControlConfig().clientId.trim(), [])
+  const pendingTrialTokenRef = useRef<TrialTokenCacheEntry | null>(null)
+
+  const consumePendingTrial = useCallback(async () => {
+    const pending = pendingTrialTokenRef.current
+    if (!pending || !billingUserId) {
+      pendingTrialTokenRef.current = null
+      return
+    }
+
+    try {
+      await consumeTrial(billingUserId, pending.token)
+      if (onTrialConsumed) {
+        await Promise.resolve(onTrialConsumed())
+      }
+    } catch (error) {
+      console.warn('Failed to consume trial token after pipeline completion.', error)
+    } finally {
+      pendingTrialTokenRef.current = null
+    }
+  }, [billingUserId, onTrialConsumed])
 
   useEffect(() => {
     setState(initialState)
@@ -593,6 +624,8 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
         const errorMessage =
           typeof errorValue === 'string' ? errorValue : typeof event.message === 'string' ? event.message : null
 
+        void consumePendingTrial()
+
         updateState((prev) => ({
           ...prev,
           pipelineError: success ? null : errorMessage ?? 'Pipeline failed.',
@@ -614,7 +647,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
         cleanupConnection()
       }
     },
-    [cleanupConnection, updateState]
+    [cleanupConnection, consumePendingTrial, updateState]
   )
 
   const startRealProcessing = useCallback(
@@ -628,6 +661,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
       cleanupConnection()
 
       try {
+        const trialToken = getActiveTrialToken()
         const toneOverride =
           availableAccounts.find((account) => account.id === accountId)?.tone ?? null
         const { jobId } = await startPipelineJob({
@@ -636,6 +670,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
           tone: toneOverride,
           reviewMode: shouldPauseForReview
         })
+        pendingTrialTokenRef.current = trialToken ?? null
         activeJobIdRef.current = jobId
         let unsubscribe: (() => void) | null = null
         const cleanup = () => {
@@ -664,6 +699,7 @@ const Home: FC<HomeProps> = ({ registerSearch, initialState, onStateChange, acco
         })
         updateState((prev) => ({ ...prev, activeJobId: jobId, awaitingReview: false }))
       } catch (error) {
+        pendingTrialTokenRef.current = null
         updateState((prev) => ({
           ...prev,
           pipelineError:

--- a/desktop/src/renderer/src/services/accessControl.ts
+++ b/desktop/src/renderer/src/services/accessControl.ts
@@ -15,6 +15,13 @@ type SubscriptionApiResponse = {
   entitled?: boolean
   current_period_end?: number | null
   cancel_at_period_end?: boolean | null
+  trial?: {
+    started?: boolean
+    total?: number
+    remaining?: number
+    used_at?: number | null
+    device_hash?: string | null
+  } | null
 }
 
 type LicenseIssueResponse = {
@@ -24,6 +31,27 @@ type LicenseIssueResponse = {
 
 const DEVICE_HASH_STORAGE_KEY = 'atropos:device-hash'
 const LICENSE_STORAGE_KEY = 'atropos:license-token'
+const TRIAL_TOKEN_STORAGE_KEY = 'atropos:trial-token'
+const TRIAL_STATE_STORAGE_KEY = 'atropos:trial-state'
+
+export type TrialTokenCacheEntry = {
+  token: string
+  exp: number
+}
+
+export type TrialStateSnapshot = {
+  started: boolean
+  total: number
+  remaining: number
+  usedAt: number | null
+  deviceHash: string | null
+}
+
+type TrialStateCacheEntry = TrialStateSnapshot & {
+  updatedAt: number
+}
+
+const TRIAL_DEFAULT_TOTAL = 3
 
 const allowedStatuses: SubscriptionLifecycleStatus[] = [
   'inactive',
@@ -39,6 +67,8 @@ const allowedStatuses: SubscriptionLifecycleStatus[] = [
 ]
 
 let cachedLicense: LicenseCacheEntry | null = null
+let cachedTrialToken: TrialTokenCacheEntry | null = null
+let cachedTrialState: TrialStateCacheEntry | null = null
 
 const textEncoder = new TextEncoder()
 
@@ -147,6 +177,209 @@ const storeLicenseCache = (entry: LicenseCacheEntry | null): void => {
     writeStorageValue(LICENSE_STORAGE_KEY, null)
   }
 }
+
+const isTrialTokenEntryValid = (
+  entry: TrialTokenCacheEntry | null
+): entry is TrialTokenCacheEntry => {
+  if (!entry) {
+    return false
+  }
+  return entry.exp * 1000 > Date.now() + 5000
+}
+
+const loadTrialTokenCache = (): TrialTokenCacheEntry | null => {
+  if (cachedTrialToken && isTrialTokenEntryValid(cachedTrialToken)) {
+    return cachedTrialToken
+  }
+
+  const raw = readStorageValue(TRIAL_TOKEN_STORAGE_KEY)
+  if (!raw) {
+    cachedTrialToken = null
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as TrialTokenCacheEntry
+    if (isTrialTokenEntryValid(parsed)) {
+      cachedTrialToken = parsed
+      return parsed
+    }
+  } catch (error) {
+    console.warn('Unable to parse cached trial token.', error)
+  }
+
+  cachedTrialToken = null
+  writeStorageValue(TRIAL_TOKEN_STORAGE_KEY, null)
+  return null
+}
+
+const storeTrialTokenCache = (entry: TrialTokenCacheEntry | null): void => {
+  cachedTrialToken = entry
+  if (entry) {
+    writeStorageValue(TRIAL_TOKEN_STORAGE_KEY, JSON.stringify(entry))
+  } else {
+    writeStorageValue(TRIAL_TOKEN_STORAGE_KEY, null)
+  }
+}
+
+const normalizeTrialSnapshot = (input: unknown): TrialStateSnapshot => {
+  const snapshot: TrialStateSnapshot = {
+    started: false,
+    total: TRIAL_DEFAULT_TOTAL,
+    remaining: TRIAL_DEFAULT_TOTAL,
+    usedAt: null,
+    deviceHash: null
+  }
+
+  if (!input || typeof input !== 'object') {
+    return snapshot
+  }
+
+  const record = input as Record<string, unknown>
+
+  if (typeof record.started === 'boolean') {
+    snapshot.started = record.started
+  }
+
+  const rawTotal = record.total
+  if (typeof rawTotal === 'number' && Number.isFinite(rawTotal) && rawTotal > 0) {
+    snapshot.total = Math.max(1, Math.floor(rawTotal))
+  }
+
+  const rawRemaining = record.remaining
+  if (typeof rawRemaining === 'number' && Number.isFinite(rawRemaining)) {
+    snapshot.remaining = Math.max(0, Math.floor(rawRemaining))
+  } else {
+    snapshot.remaining = snapshot.total
+  }
+
+  if (!snapshot.started) {
+    snapshot.remaining = snapshot.total
+  } else {
+    snapshot.remaining = Math.max(0, Math.min(snapshot.total, snapshot.remaining))
+  }
+
+  const rawUsedAt = (record.used_at ?? record.usedAt) as unknown
+  if (typeof rawUsedAt === 'number' && Number.isFinite(rawUsedAt)) {
+    snapshot.usedAt = rawUsedAt
+  } else if (rawUsedAt === null) {
+    snapshot.usedAt = null
+  }
+
+  const rawDevice = record.device_hash ?? record.deviceHash
+  if (typeof rawDevice === 'string' && rawDevice.trim().length > 0) {
+    snapshot.deviceHash = rawDevice.trim()
+  }
+
+  return snapshot
+}
+
+const loadTrialStateCache = (): TrialStateCacheEntry | null => {
+  if (cachedTrialState) {
+    return cachedTrialState
+  }
+
+  const raw = readStorageValue(TRIAL_STATE_STORAGE_KEY)
+  if (!raw) {
+    cachedTrialState = null
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<TrialStateCacheEntry>
+    const normalizedSnapshot = normalizeTrialSnapshot(parsed)
+    const updatedAt =
+      typeof parsed.updatedAt === 'number' && Number.isFinite(parsed.updatedAt)
+        ? parsed.updatedAt
+        : Date.now()
+    const normalized: TrialStateCacheEntry = { ...normalizedSnapshot, updatedAt }
+    cachedTrialState = normalized
+    return normalized
+  } catch (error) {
+    console.warn('Unable to parse cached trial state.', error)
+  }
+
+  cachedTrialState = null
+  writeStorageValue(TRIAL_STATE_STORAGE_KEY, null)
+  return null
+}
+
+const storeTrialStateCache = (entry: TrialStateCacheEntry | null): void => {
+  cachedTrialState = entry
+  if (entry) {
+    writeStorageValue(TRIAL_STATE_STORAGE_KEY, JSON.stringify(entry))
+  } else {
+    writeStorageValue(TRIAL_STATE_STORAGE_KEY, null)
+  }
+}
+
+export const getDeviceHash = (): string => getOrCreateDeviceHash()
+
+const trialStateFromCache = (entry: TrialStateCacheEntry | null): TrialStateSnapshot | null => {
+  if (!entry) {
+    return null
+  }
+  return {
+    started: entry.started,
+    total: entry.total,
+    remaining: entry.remaining,
+    usedAt: entry.usedAt,
+    deviceHash: entry.deviceHash
+  }
+}
+
+const writeTrialStateSnapshot = (
+  snapshot: TrialStateSnapshot | null
+): TrialStateSnapshot | null => {
+  if (!snapshot) {
+    storeTrialStateCache(null)
+    return null
+  }
+  const normalized = normalizeTrialSnapshot(snapshot)
+  const entry: TrialStateCacheEntry = { ...normalized, updatedAt: Date.now() }
+  storeTrialStateCache(entry)
+  return normalized
+}
+
+export const normalizeTrialFromResponse = (trial: unknown): TrialStateSnapshot =>
+  normalizeTrialSnapshot(trial)
+
+export const updateTrialStateFromApi = (trial: unknown): TrialStateSnapshot => {
+  const normalized = normalizeTrialSnapshot(trial)
+  storeTrialStateCache({ ...normalized, updatedAt: Date.now() })
+  return normalized
+}
+
+export const getCachedTrialState = (): TrialStateSnapshot | null =>
+  trialStateFromCache(loadTrialStateCache())
+
+export const storeTrialState = (snapshot: TrialStateSnapshot | null): TrialStateSnapshot | null =>
+  writeTrialStateSnapshot(snapshot)
+
+export const getCachedTrialToken = (): TrialTokenCacheEntry | null => {
+  const entry = loadTrialTokenCache()
+  if (!isTrialTokenEntryValid(entry)) {
+    storeTrialTokenCache(null)
+    return null
+  }
+  return entry
+}
+
+export const storeTrialToken = (entry: TrialTokenCacheEntry | null): void => {
+  if (entry) {
+    storeTrialTokenCache({ token: entry.token, exp: entry.exp })
+  } else {
+    storeTrialTokenCache(null)
+  }
+}
+
+export const clearTrialToken = (): void => {
+  storeTrialTokenCache(null)
+}
+
+export const isTrialTokenActive = (
+  entry: TrialTokenCacheEntry | null
+): entry is TrialTokenCacheEntry => isTrialTokenEntryValid(entry)
 
 const normalizeStatus = (value: string | null | undefined): SubscriptionLifecycleStatus => {
   if (!value) {
@@ -265,15 +498,51 @@ export const verifyDesktopAccess = async (): Promise<AccessCheckResult> => {
   const subscriptionUrl = new URL('/billing/subscription', baseUrl)
   subscriptionUrl.searchParams.set('user_id', config.clientId)
 
-  const subscriptionResponse = await fetch(subscriptionUrl.toString(), {
-    headers: { Accept: 'application/json' }
-  })
+  const trialAccessFromCache = (): AccessCheckResult | null => {
+    const trialToken = getCachedTrialToken()
+    const trialState = getCachedTrialState()
+    if (
+      trialState &&
+      trialState.started &&
+      trialState.remaining > 0 &&
+      isTrialTokenActive(trialToken)
+    ) {
+      const expiresAtIso = new Date(trialToken.exp * 1000).toISOString()
+      return {
+        allowed: true,
+        status: 'trialing',
+        reason: null,
+        checkedAt: new Date().toISOString(),
+        expiresAt: expiresAtIso,
+        customerEmail: null,
+        subscriptionPlan: 'trial',
+        subscriptionStatus: 'trialing'
+      }
+    }
+    return null
+  }
+
+  let subscriptionResponse: Response
+  try {
+    subscriptionResponse = await fetch(subscriptionUrl.toString(), {
+      headers: { Accept: 'application/json' }
+    })
+  } catch (error) {
+    const cachedTrial = trialAccessFromCache()
+    if (cachedTrial) {
+      return cachedTrial
+    }
+    const detail = error instanceof Error && error.message ? ` (${error.message})` : ''
+    throw new Error(`Unable to verify subscription status${detail}.`)
+  }
 
   if (!subscriptionResponse.ok) {
     throw new Error(await extractApiError(subscriptionResponse))
   }
 
   const subscriptionBody = (await subscriptionResponse.json()) as SubscriptionApiResponse
+  const trialSnapshot = updateTrialStateFromApi(subscriptionBody.trial ?? null)
+  const trialToken = getCachedTrialToken()
   const subscriptionStatus = normalizeStatus(subscriptionBody.status ?? 'inactive')
   const entitled = Boolean(subscriptionBody.entitled)
   const currentPeriodEndSeconds =
@@ -287,10 +556,29 @@ export const verifyDesktopAccess = async (): Promise<AccessCheckResult> => {
 
   if (!entitled) {
     storeLicenseCache(null)
+
+    if (trialSnapshot.started && trialSnapshot.remaining > 0 && isTrialTokenActive(trialToken)) {
+      const expiresAtIso = new Date(trialToken.exp * 1000).toISOString()
+      return {
+        allowed: true,
+        status: 'trialing',
+        reason: null,
+        checkedAt: new Date().toISOString(),
+        expiresAt: expiresAtIso,
+        customerEmail: null,
+        subscriptionPlan: 'trial',
+        subscriptionStatus: 'trialing'
+      }
+    }
+
+    const reason = trialSnapshot.started
+      ? `Trial remaining: ${trialSnapshot.remaining} of ${trialSnapshot.total}. Claim a trial render from your profile to continue.`
+      : 'Active subscription required to continue using Atropos.'
+
     return {
       allowed: false,
       status: subscriptionStatus,
-      reason: 'Active subscription required to continue using Atropos.',
+      reason,
       checkedAt: new Date().toISOString(),
       expiresAt: currentPeriodEndIso,
       customerEmail: null,

--- a/desktop/src/renderer/src/services/trialAccess.ts
+++ b/desktop/src/renderer/src/services/trialAccess.ts
@@ -1,0 +1,156 @@
+import {
+  buildTrialClaimUrl,
+  buildTrialConsumeUrl,
+  buildTrialStartUrl
+} from '../config/backend'
+import {
+  clearTrialToken,
+  getCachedTrialState,
+  getCachedTrialToken,
+  getDeviceHash,
+  isTrialTokenActive,
+  normalizeTrialFromResponse,
+  storeTrialState,
+  storeTrialToken,
+  TrialStateSnapshot,
+  TrialTokenCacheEntry
+} from './accessControl'
+import { extractErrorMessage } from './http'
+
+const normalizeUserId = (userId: string, action: string): string => {
+  const normalized = userId.trim()
+  if (!normalized) {
+    throw new Error(`A billing user ID is required to ${action}.`)
+  }
+  return normalized
+}
+
+const normalizeToken = (token: string, action: string): string => {
+  const trimmed = token.trim()
+  if (!trimmed) {
+    throw new Error(`A trial token is required to ${action}.`)
+  }
+  return trimmed
+}
+
+export const startTrial = async (userId: string): Promise<TrialStateSnapshot> => {
+  const normalizedUserId = normalizeUserId(userId, 'start the trial')
+  const deviceHash = getDeviceHash()
+  const response = await fetch(buildTrialStartUrl(), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: normalizedUserId, device_hash: deviceHash })
+  })
+
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response))
+  }
+
+  const body = (await response.json()) as {
+    started?: boolean
+    total?: number
+    remaining?: number
+  }
+
+  const snapshot = storeTrialState(
+    normalizeTrialFromResponse({
+      started: body.started ?? true,
+      total: body.total,
+      remaining: body.remaining,
+      device_hash: deviceHash,
+      used_at: null
+    })
+  ) ?? normalizeTrialFromResponse({ started: true, device_hash: deviceHash })
+
+  clearTrialToken()
+  return snapshot
+}
+
+export const claimTrial = async (
+  userId: string
+): Promise<{ token: TrialTokenCacheEntry; snapshot: TrialStateSnapshot }> => {
+  const normalizedUserId = normalizeUserId(userId, 'claim a trial token')
+  const deviceHash = getDeviceHash()
+  const response = await fetch(buildTrialClaimUrl(), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: normalizedUserId, device_hash: deviceHash })
+  })
+
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response))
+  }
+
+  const body = (await response.json()) as {
+    token?: string
+    exp?: number
+    remaining?: number
+  }
+
+  if (typeof body.token !== 'string' || typeof body.exp !== 'number') {
+    throw new Error('The trial claim response was missing required fields.')
+  }
+
+  const token: TrialTokenCacheEntry = { token: body.token, exp: body.exp }
+  storeTrialToken(token)
+
+  const currentState = getCachedTrialState() ?? normalizeTrialFromResponse(null)
+  const remaining =
+    typeof body.remaining === 'number' && Number.isFinite(body.remaining)
+      ? Math.max(0, Math.floor(body.remaining))
+      : currentState.remaining
+
+  const snapshot =
+    storeTrialState({
+      ...currentState,
+      started: true,
+      remaining,
+      deviceHash
+    }) ?? normalizeTrialFromResponse({ started: true, remaining, device_hash: deviceHash })
+
+  return { token, snapshot }
+}
+
+export const consumeTrial = async (
+  userId: string,
+  token: string
+): Promise<{ remaining: number }> => {
+  const normalizedUserId = normalizeUserId(userId, 'consume a trial render')
+  const normalizedToken = normalizeToken(token, 'consume a trial render')
+  const deviceHash = getDeviceHash()
+
+  const response = await fetch(buildTrialConsumeUrl(), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: normalizedUserId, token: normalizedToken, device_hash: deviceHash })
+  })
+
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response))
+  }
+
+  const body = (await response.json()) as { remaining?: number }
+  const remaining =
+    typeof body.remaining === 'number' && Number.isFinite(body.remaining)
+      ? Math.max(0, Math.floor(body.remaining))
+      : 0
+
+  const currentState = getCachedTrialState() ?? normalizeTrialFromResponse(null)
+  storeTrialState({
+    ...currentState,
+    started: true,
+    remaining,
+    usedAt: Date.now(),
+    deviceHash
+  })
+  clearTrialToken()
+  return { remaining }
+}
+
+export const getActiveTrialToken = (): TrialTokenCacheEntry | null => {
+  const entry = getCachedTrialToken()
+  if (!entry) {
+    return null
+  }
+  return isTrialTokenActive(entry) ? entry : null
+}

--- a/desktop/src/renderer/src/tests/accessControl.test.ts
+++ b/desktop/src/renderer/src/tests/accessControl.test.ts
@@ -1,6 +1,22 @@
 import { webcrypto } from 'node:crypto'
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AccessJwtPayload } from '../types'
+
+const createLocalStorageMock = () => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    }
+  }
+}
 
 const mockConfig = {
   apiUrl: null as string | null,
@@ -16,21 +32,67 @@ vi.mock('../config/accessControl', () => ({
   getAccessControlConfig: () => ({ ...mockConfig })
 }))
 
-const { createAccessJwt, verifyDesktopAccess } = await import('../services/accessControl')
+const {
+  createAccessJwt,
+  verifyDesktopAccess,
+  storeTrialState,
+  storeTrialToken,
+  clearTrialToken,
+  getCachedTrialState,
+  getCachedTrialToken
+} = await import('../services/accessControl')
 
 describe('access control service', () => {
   const originalCrypto = globalThis.crypto
+  const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+  const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage')
+  const originalGlobalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'localStorage'
+  )
+
+  let localStorageMock: ReturnType<typeof createLocalStorageMock>
+
+  const applyLocalStorageMock = (): void => {
+    localStorageMock = createLocalStorageMock()
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: localStorageMock
+    })
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: localStorageMock
+    })
+  }
 
   beforeAll(() => {
     Object.defineProperty(globalThis, 'crypto', {
       configurable: true,
       value: webcrypto
     })
+    if (!originalWindowDescriptor) {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: globalThis
+      })
+    }
+    applyLocalStorageMock()
   })
 
   beforeEach(() => {
     mockConfig.useMock = true
     mockConfig.apiUrl = null
+    applyLocalStorageMock()
+    storeTrialState(null)
+    storeTrialToken(null)
+    clearTrialToken()
+  })
+
+  afterEach(() => {
+    localStorageMock.clear()
+    storeTrialState(null)
+    storeTrialToken(null)
+    clearTrialToken()
   })
 
   afterAll(() => {
@@ -38,6 +100,19 @@ describe('access control service', () => {
       configurable: true,
       value: originalCrypto
     })
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(window, 'localStorage', originalLocalStorageDescriptor)
+    } else {
+      Reflect.deleteProperty(window, 'localStorage')
+    }
+    if (originalGlobalLocalStorageDescriptor) {
+      Object.defineProperty(globalThis, 'localStorage', originalGlobalLocalStorageDescriptor)
+    } else {
+      Reflect.deleteProperty(globalThis, 'localStorage')
+    }
+    if (originalWindowDescriptor) {
+      Object.defineProperty(globalThis, 'window', originalWindowDescriptor)
+    }
   })
 
   it('creates a signed JWT with the expected payload', async () => {
@@ -92,6 +167,67 @@ describe('access control service', () => {
         ''
       )
     ).rejects.toThrow('Access control secret is not configured.')
+  })
+
+  it('persists trial state snapshots to localStorage', () => {
+    const snapshot = storeTrialState({
+      started: true,
+      total: 5,
+      remaining: 4,
+      usedAt: 1_700_000_000_000,
+      deviceHash: 'device-123'
+    })
+
+    expect(snapshot).toEqual({
+      started: true,
+      total: 5,
+      remaining: 4,
+      usedAt: 1_700_000_000_000,
+      deviceHash: 'device-123'
+    })
+
+    const cached = getCachedTrialState()
+    expect(cached).toEqual({
+      started: true,
+      total: 5,
+      remaining: 4,
+      usedAt: 1_700_000_000_000,
+      deviceHash: 'device-123'
+    })
+
+    const storedValue = window.localStorage.getItem('atropos:trial-state')
+    expect(storedValue).not.toBeNull()
+    expect(JSON.parse(storedValue ?? '{}')).toMatchObject({ started: true, remaining: 4 })
+  })
+
+  it('clears stored trial state when null is provided', () => {
+    storeTrialState({
+      started: true,
+      total: 3,
+      remaining: 1,
+      usedAt: null,
+      deviceHash: 'device-123'
+    })
+
+    storeTrialState(null)
+
+    expect(window.localStorage.getItem('atropos:trial-state')).toBeNull()
+    expect(getCachedTrialState()).toBeNull()
+  })
+
+  it('stores and clears trial tokens', () => {
+    const exp = Math.floor(Date.now() / 1000) + 900
+    storeTrialToken({ token: 'trial-token', exp })
+
+    expect(getCachedTrialToken()).toEqual({ token: 'trial-token', exp })
+    expect(JSON.parse(window.localStorage.getItem('atropos:trial-token') ?? '{}')).toEqual({
+      token: 'trial-token',
+      exp
+    })
+
+    clearTrialToken()
+    expect(window.localStorage.getItem('atropos:trial-token')).toBeNull()
+    expect(getCachedTrialToken()).toBeNull()
   })
 })
 

--- a/desktop/src/renderer/src/tests/appAccessOverlay.test.tsx
+++ b/desktop/src/renderer/src/tests/appAccessOverlay.test.tsx
@@ -127,4 +127,23 @@ describe('App access overlay behaviour', () => {
       screen.queryByRole('button', { name: /Open billing settings/i })
     ).not.toBeInTheDocument()
   })
+
+  it('surfaces trial guidance when renders remain', async () => {
+    verifyDesktopAccessMock.mockResolvedValueOnce({
+      allowed: false,
+      status: 'inactive',
+      reason: 'Trial remaining: 2 of 3. Claim a trial render from your profile to continue.'
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/']}> 
+        <App searchInputRef={{ current: null }} />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => expect(verifyDesktopAccessMock).toHaveBeenCalled())
+    expect(
+      await screen.findByText(/Trial remaining: 2 of 3/i)
+    ).toBeInTheDocument()
+  })
 })

--- a/desktop/src/renderer/src/tests/paymentsApi.test.ts
+++ b/desktop/src/renderer/src/tests/paymentsApi.test.ts
@@ -26,6 +26,8 @@ describe('paymentsApi mock mode', () => {
     expect(status.status).toBe('trialing')
     expect(status.planName).toContain('Mock')
     expect(status.latestInvoiceUrl).toBe('https://stripe.test/invoice/mock')
+    expect(status.trial?.remaining).toBe(3)
+    expect(status.trial?.total).toBe(3)
     expect(httpMocks.requestWithFallback).not.toHaveBeenCalled()
   })
 

--- a/desktop/src/renderer/src/types.ts
+++ b/desktop/src/renderer/src/types.ts
@@ -161,6 +161,15 @@ export interface SubscriptionStatus {
   cancelAt: string | null
   trialEndsAt: string | null
   latestInvoiceUrl: string | null
+  trial: SubscriptionTrialState | null
+}
+
+export interface SubscriptionTrialState {
+  started: boolean
+  total: number
+  remaining: number
+  usedAt: string | null
+  deviceHash: string | null
 }
 
 export interface CheckoutSession {

--- a/services/licensing/src/index.ts
+++ b/services/licensing/src/index.ts
@@ -18,9 +18,18 @@ import type { StripeSubscriptionSummary } from "./stripe";
 import {
   findUserByStripeCustomerId,
   getUserRecord,
+  normalizeTrialState,
   putUserRecord,
+  TrialState,
+  UserRecord,
 } from "./kv";
-import { derivePublicKey, issueLicenseToken, verifyLicenseToken } from "./jwt";
+import {
+  derivePublicKey,
+  issueLicenseToken,
+  issueTrialToken,
+  verifyLicenseToken,
+  verifyTrialToken,
+} from "./jwt";
 
 interface StripeEvent {
   id: string;
@@ -49,6 +58,22 @@ interface CheckoutRequestBody {
 
 interface LicenseIssueBody {
   user_id: string;
+  device_hash: string;
+}
+
+interface TrialStartRequestBody {
+  user_id: string;
+  device_hash: string;
+}
+
+interface TrialClaimRequestBody {
+  user_id: string;
+  device_hash: string;
+}
+
+interface TrialConsumeRequestBody {
+  user_id: string;
+  token: string;
   device_hash: string;
 }
 
@@ -111,6 +136,32 @@ function extractStripeId(value: unknown): string | null {
   }
 
   return null;
+}
+
+function mergeUserRecord(
+  existing: UserRecord | null,
+  updates: Partial<UserRecord> & { trial?: TrialState }
+): UserRecord {
+  const base: UserRecord = existing
+    ? { ...existing, trial: normalizeTrialState(existing.trial) }
+    : {
+        email: "",
+        stripe_customer_id: "",
+        status: "inactive",
+        current_period_end: undefined,
+        plan_price_id: undefined,
+        cancel_at_period_end: false,
+        updated_at: Date.now(),
+        epoch: 0,
+        device_hash: undefined,
+        trial: normalizeTrialState(null),
+      };
+
+  return {
+    ...base,
+    ...updates,
+    trial: updates.trial ?? base.trial,
+  };
 }
 
 async function handleCheckout(
@@ -218,7 +269,7 @@ async function handleCheckout(
     idempotencyKey: checkoutIdempotencyKey,
   });
 
-  const updated = {
+  const updated = mergeUserRecord(userRecord, {
     email,
     stripe_customer_id: stripeCustomerId,
     status: userRecord?.status ?? "pending",
@@ -228,7 +279,7 @@ async function handleCheckout(
     cancel_at_period_end: userRecord?.cancel_at_period_end ?? false,
     epoch: userRecord?.epoch ?? 0,
     device_hash: userRecord?.device_hash,
-  };
+  });
   await putUserRecord(env, userId, updated);
 
   console.log(
@@ -335,6 +386,7 @@ async function handleSubscription(
   const isDevEnvironment = env.STRIPE_SECRET_KEY.startsWith("sk_test");
 
   let record = await getUserRecord(env, userId);
+  let trial = normalizeTrialState(record?.trial);
 
   if (shouldForce && !isDevEnvironment) {
     console.warn(
@@ -385,12 +437,20 @@ async function handleSubscription(
   }
 
   if (!record) {
+    trial = normalizeTrialState(null);
     return jsonResponse(
       {
         status: "inactive",
         entitled: false,
         current_period_end: null,
         cancel_at_period_end: false,
+        trial: {
+          started: trial.started,
+          total: trial.total,
+          remaining: trial.remaining,
+          used_at: trial.used_at,
+          device_hash: trial.device_hash,
+        },
       },
       200,
       corsHeaders
@@ -400,6 +460,7 @@ async function handleSubscription(
   const status = normalizeStatus(record.status);
   const currentPeriodEnd = record.current_period_end ?? null;
   const cancelAtPeriodEnd = record.cancel_at_period_end ?? false;
+  trial = normalizeTrialState(record.trial);
 
   return jsonResponse(
     {
@@ -407,10 +468,255 @@ async function handleSubscription(
       entitled: isEntitled(status, currentPeriodEnd ?? undefined),
       current_period_end: currentPeriodEnd,
       cancel_at_period_end: cancelAtPeriodEnd,
+      trial: {
+        started: trial.started,
+        total: trial.total,
+        remaining: trial.remaining,
+        used_at: trial.used_at,
+        device_hash: trial.device_hash,
+      },
     },
     200,
     corsHeaders
   );
+}
+
+async function handleTrialStart(
+  env: Env,
+  request: Request,
+  corsHeaders: HeadersInit,
+  context: RequestContext
+): Promise<Response> {
+  const body = await request.json().catch(() => {
+    throw new HttpError(400, "invalid_request", "Body must be valid JSON");
+  });
+
+  if (typeof body !== "object" || body === null) {
+    throw new HttpError(400, "invalid_request", "Body must be an object");
+  }
+
+  const { user_id: userIdRaw, device_hash: deviceHashRaw } =
+    body as TrialStartRequestBody;
+
+  if (typeof userIdRaw !== "string" || userIdRaw.trim().length === 0) {
+    throw new HttpError(400, "invalid_request", "user_id is required");
+  }
+  if (typeof deviceHashRaw !== "string" || deviceHashRaw.trim().length === 0) {
+    throw new HttpError(400, "invalid_request", "device_hash is required");
+  }
+
+  const userId = userIdRaw.trim();
+  const deviceHash = deviceHashRaw.trim();
+
+  const record = await getUserRecord(env, userId);
+  if (record && isEntitled(record.status, record.current_period_end)) {
+    throw new HttpError(409, "already_subscribed", "User already subscribed");
+  }
+
+  const trial = normalizeTrialState(record?.trial);
+  if (!trial.allowed) {
+    throw new HttpError(403, "trial_not_allowed", "Trial is not permitted");
+  }
+
+  if (
+    trial.started &&
+    trial.device_hash &&
+    trial.device_hash !== deviceHash
+  ) {
+    throw new HttpError(
+      409,
+      "trial_already_started_on_other_device",
+      "Trial already started on another device",
+    );
+  }
+
+  const now = Date.now();
+  const updatedTrial = normalizeTrialState({
+    ...trial,
+    started: true,
+    total: trial.total,
+    remaining:
+      trial.started && trial.device_hash === deviceHash
+        ? trial.remaining
+        : trial.total,
+    device_hash: trial.device_hash ?? deviceHash,
+    jti: null,
+    exp: null,
+  });
+
+  const updatedRecord = mergeUserRecord(record, {
+    updated_at: now,
+    status: record?.status ?? "inactive",
+    trial: updatedTrial,
+  });
+  await putUserRecord(env, userId, updatedRecord);
+
+  console.log(
+    `[${context.requestId}] Trial started for ${userId} remaining=${updatedTrial.remaining}`,
+  );
+
+  return jsonResponse(
+    {
+      started: true,
+      total: updatedTrial.total,
+      remaining: updatedTrial.remaining,
+    },
+    200,
+    corsHeaders,
+  );
+}
+
+async function handleTrialClaim(
+  env: Env,
+  request: Request,
+  corsHeaders: HeadersInit,
+  context: RequestContext
+): Promise<Response> {
+  const body = await request.json().catch(() => {
+    throw new HttpError(400, "invalid_request", "Body must be valid JSON");
+  });
+
+  if (typeof body !== "object" || body === null) {
+    throw new HttpError(400, "invalid_request", "Body must be an object");
+  }
+
+  const { user_id: userIdRaw, device_hash: deviceHashRaw } =
+    body as TrialClaimRequestBody;
+
+  if (typeof userIdRaw !== "string" || userIdRaw.trim().length === 0) {
+    throw new HttpError(400, "invalid_request", "user_id is required");
+  }
+  if (typeof deviceHashRaw !== "string" || deviceHashRaw.trim().length === 0) {
+    throw new HttpError(400, "invalid_request", "device_hash is required");
+  }
+
+  const userId = userIdRaw.trim();
+  const deviceHash = deviceHashRaw.trim();
+
+  const record = await getUserRecord(env, userId);
+  if (!record || isEntitled(record.status, record.current_period_end)) {
+    throw new HttpError(403, "trial_invalid", "Trial is unavailable");
+  }
+
+  const trial = normalizeTrialState(record.trial);
+  if (!trial.allowed || !trial.started) {
+    throw new HttpError(403, "trial_invalid", "Trial is not active");
+  }
+
+  if (!trial.device_hash || trial.device_hash !== deviceHash) {
+    throw new HttpError(403, "trial_invalid", "Trial device mismatch");
+  }
+
+  if (trial.remaining <= 0) {
+    throw new HttpError(409, "trial_exhausted", "Trial quota exhausted");
+  }
+
+  const token = await issueTrialToken(env, userId);
+  const updatedTrial = normalizeTrialState({
+    ...trial,
+    jti: token.jti,
+    exp: token.exp,
+    device_hash: deviceHash,
+    started: true,
+  });
+
+  const updatedRecord = mergeUserRecord(record, {
+    updated_at: Date.now(),
+    trial: updatedTrial,
+  });
+  await putUserRecord(env, userId, updatedRecord);
+
+  console.log(
+    `[${context.requestId}] Trial claim for ${userId} exp=${token.exp} remaining=${updatedTrial.remaining}`,
+  );
+
+  return jsonResponse(
+    { token: token.token, exp: token.exp, remaining: updatedTrial.remaining },
+    200,
+    corsHeaders,
+  );
+}
+
+async function handleTrialConsume(
+  env: Env,
+  request: Request,
+  corsHeaders: HeadersInit,
+  context: RequestContext
+): Promise<Response> {
+  const body = await request.json().catch(() => {
+    throw new HttpError(400, "invalid_request", "Body must be valid JSON");
+  });
+
+  if (typeof body !== "object" || body === null) {
+    throw new HttpError(400, "invalid_request", "Body must be an object");
+  }
+
+  const { user_id: userIdRaw, token, device_hash: deviceHashRaw } =
+    body as TrialConsumeRequestBody;
+
+  if (typeof userIdRaw !== "string" || userIdRaw.trim().length === 0) {
+    throw new HttpError(400, "invalid_request", "user_id is required");
+  }
+  if (typeof token !== "string" || token.trim().length === 0) {
+    throw new HttpError(400, "invalid_request", "token is required");
+  }
+  if (typeof deviceHashRaw !== "string" || deviceHashRaw.trim().length === 0) {
+    throw new HttpError(400, "invalid_request", "device_hash is required");
+  }
+
+  const userId = userIdRaw.trim();
+  const deviceHash = deviceHashRaw.trim();
+
+  const record = await getUserRecord(env, userId);
+  if (!record || isEntitled(record.status, record.current_period_end)) {
+    throw new HttpError(403, "trial_invalid", "Trial is unavailable");
+  }
+
+  const trial = normalizeTrialState(record.trial);
+
+  if (!trial.started || !trial.device_hash || trial.device_hash !== deviceHash) {
+    throw new HttpError(403, "trial_invalid", "Trial is not active");
+  }
+
+  if (!trial.jti || !trial.exp) {
+    throw new HttpError(403, "trial_invalid", "Trial token is not available");
+  }
+
+  const claims = await verifyTrialToken(env, token.trim());
+  if (claims.sub !== userId || claims.jti !== trial.jti) {
+    throw new HttpError(403, "trial_invalid", "Trial token mismatch");
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (trial.exp <= nowSeconds) {
+    throw new HttpError(403, "trial_invalid", "Trial token expired");
+  }
+
+  if (trial.remaining <= 0) {
+    throw new HttpError(403, "trial_invalid", "Trial quota exhausted");
+  }
+
+  const remaining = Math.max(0, trial.remaining - 1);
+  const updatedTrial = normalizeTrialState({
+    ...trial,
+    remaining,
+    used_at: Date.now(),
+    jti: null,
+    exp: null,
+    device_hash: deviceHash,
+  });
+
+  const updatedRecord = mergeUserRecord(record, {
+    updated_at: Date.now(),
+    trial: updatedTrial,
+  });
+  await putUserRecord(env, userId, updatedRecord);
+
+  console.log(
+    `[${context.requestId}] Trial consume for ${userId} remaining=${remaining}`,
+  );
+
+  return jsonResponse({ success: true, remaining }, 200, corsHeaders);
 }
 
 async function handleWebhook(
@@ -458,7 +764,7 @@ async function handleWebhook(
             (object.metadata as Record<string, string> | undefined)?.price_id ??
             existing?.plan_price_id ??
             env.PRICE_ID_MONTHLY;
-          await putUserRecord(env, userId, {
+          const updatedRecord = mergeUserRecord(existing, {
             email,
             stripe_customer_id: customerId,
             status,
@@ -469,6 +775,7 @@ async function handleWebhook(
             epoch: existing?.epoch ?? 0,
             device_hash: existing?.device_hash,
           });
+          await putUserRecord(env, userId, updatedRecord);
           console.log(
             `[${context.requestId}] Checkout complete for ${userId} (${customerId}) subscription=${subscriptionId}`
           );
@@ -511,7 +818,7 @@ async function handleWebhook(
           existingUser?.plan_price_id ??
           env.PRICE_ID_MONTHLY;
         const updatedAt = Date.now();
-        await putUserRecord(env, userId, {
+        const updatedRecord = mergeUserRecord(existingUser, {
           email: subscription.customer_email ?? existingUser?.email ?? "",
           stripe_customer_id: customerId,
           status,
@@ -522,6 +829,7 @@ async function handleWebhook(
           epoch: existingUser?.epoch ?? 0,
           device_hash: existingUser?.device_hash,
         });
+        await putUserRecord(env, userId, updatedRecord);
         console.log(
           `[${context.requestId}] Subscription ${subscription.id} -> ${status}`
         );
@@ -554,7 +862,7 @@ async function handleWebhook(
           subscription.items?.data?.[0]?.price?.id ??
           env.PRICE_ID_MONTHLY;
         const previousEpoch = existingUser?.epoch ?? 0;
-        await putUserRecord(env, userId, {
+        const updatedRecord = mergeUserRecord(existingUser, {
           email: existingUser?.email ?? subscription.customer_email ?? "",
           stripe_customer_id: customerId,
           status: "canceled",
@@ -565,6 +873,7 @@ async function handleWebhook(
           epoch: previousEpoch + 1,
           device_hash: existingUser?.device_hash,
         });
+        await putUserRecord(env, userId, updatedRecord);
         console.log(
           `[${context.requestId}] Subscription ${subscription.id} canceled`
         );
@@ -742,6 +1051,15 @@ export default {
           }
           if (apiPath === "/license/issue") {
             return await handleIssue(env, request, corsHeaders);
+          }
+          if (apiPath === "/trial/start") {
+            return await handleTrialStart(env, request, corsHeaders, context);
+          }
+          if (apiPath === "/trial/claim") {
+            return await handleTrialClaim(env, request, corsHeaders, context);
+          }
+          if (apiPath === "/trial/consume") {
+            return await handleTrialConsume(env, request, corsHeaders, context);
           }
           break;
         }


### PR DESCRIPTION
## Summary
- extend the licensing service with three-render trial state, new trial endpoints, and JWT handling
- wire the desktop renderer to surface trial controls, claim tokens, and consume them during pipeline runs
- expand access control, payments, and profile tests to cover local caching and trial UI scenarios

## Testing
- pytest *(fails: missing httpx module and libGL.so.1 in the container)*
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d69345c96c83239ec987d7afdc61c1