### PR TITLE
Refine desktop access snapshot handling

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -12,7 +12,6 @@ import Settings, { type SettingsHeaderAction } from './pages/Settings'
 import { createInitialPipelineSteps } from './data/pipeline'
 import useNavigationHistory from './hooks/useNavigationHistory'
 import type {
-  AccessCheckResult,
   AccountSummary,
   AuthPingSummary,
   HomePipelineState,
@@ -29,7 +28,7 @@ import {
   updateAccount as updateAccountApi,
   updateAccountPlatform
 } from './services/accountsApi'
-import { verifyDesktopAccess } from './services/accessControl'
+import { verifyDesktopAccess, type AccessSnapshot } from './services/accessControl'
 
 type PlatformPayload = {
   platform: SupportedPlatform
@@ -100,7 +99,7 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
   const [isLoadingAccounts, setIsLoadingAccounts] = useState(true)
   const [authStatus, setAuthStatus] = useState<AuthPingSummary | null>(null)
   const [authError, setAuthError] = useState<string | null>(null)
-  const [accessStatus, setAccessStatus] = useState<AccessCheckResult | null>(null)
+  const [accessStatus, setAccessStatus] = useState<AccessSnapshot | null>(null)
   const [accessCheckError, setAccessCheckError] = useState<string | null>(null)
   const [isCheckingAccess, setIsCheckingAccess] = useState(true)
   const [isDark, setIsDark] = useState(false)
@@ -172,7 +171,7 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
   const refreshAccessStatus = useCallback(async () => {
     setIsCheckingAccess(true)
     try {
-      const result = await verifyDesktopAccess()
+      const result = (await verifyDesktopAccess()) as AccessSnapshot
       setAccessStatus(result)
       setAccessCheckError(null)
     } catch (error) {
@@ -428,6 +427,21 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
   const isClipEditRoute = /^\/clip\/[^/]+\/edit$/.test(location.pathname)
   const isSettingsRoute = location.pathname.startsWith('/settings')
   const isProfileRoute = location.pathname.startsWith('/profile')
+  const showOverlay =
+    !isProfileRoute &&
+    (isCheckingAccess || accessStatus?.allowed === false || (!accessStatus && !!accessCheckError))
+  const overlayTitle = isCheckingAccess
+    ? 'Verifying access…'
+    : accessStatus?.allowed === false
+      ? accessStatus?.mode === 'subscription'
+        ? 'Subscription required'
+        : 'Trial unavailable'
+      : 'Unable to verify access'
+  const overlayMessage = isCheckingAccess
+    ? 'Hold tight while we confirm your access permissions.'
+    : accessStatus?.allowed === false
+      ? accessStatus?.reason ?? 'No active subscription. Open billing to continue.'
+      : accessCheckError ?? 'An unexpected error occurred while validating access.'
   const showBackButton = location.pathname.startsWith('/clip/')
 
   const accountSelectOptions = useMemo(() => {
@@ -467,27 +481,11 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
 
   return (
     <div className="flex min-h-full flex-col bg-[var(--bg)] text-[var(--fg)]">
-      {!isProfileRoute &&
-        (isCheckingAccess ||
-          (!isCheckingAccess && ((accessStatus && !accessStatus.allowed) || (!accessStatus && accessCheckError)))) && (
-          <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/75 backdrop-blur">
-            <div className="max-w-md rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--panel)_75%,transparent)] p-6 text-center shadow-[0_18px_40px_rgba(0,0,0,0.45)]">
-            <h2 className="text-xl font-semibold text-[var(--fg)]">
-              {isCheckingAccess
-                ? 'Verifying access…'
-                : accessStatus && !accessStatus.allowed
-                  ? 'Subscription required'
-                  : 'Unable to verify access'}
-            </h2>
-            <p className="mt-3 text-sm text-[var(--muted)]">
-              {isCheckingAccess
-                ? 'Hold tight while we confirm your access permissions.'
-                : accessStatus && !accessStatus.allowed
-                  ? accessStatus.reason
-                    ? accessStatus.reason
-                    : 'Your account does not have an active subscription. Update your billing details to continue using Atropos.'
-                  : accessCheckError ?? 'An unexpected error occurred while validating access.'}
-            </p>
+      {showOverlay && (
+        <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/75 backdrop-blur">
+          <div className="max-w-md rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--panel)_75%,transparent)] p-6 text-center shadow-[0_18px_40px_rgba(0,0,0,0.45)]">
+            <h2 className="text-xl font-semibold text-[var(--fg)]">{overlayTitle}</h2>
+            <p className="mt-3 text-sm text-[var(--muted)]">{overlayMessage}</p>
             <div className="mt-5 flex flex-wrap justify-center gap-3">
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- add a normalized access snapshot helper that reuses the billing subscription snapshot, handles trial priority, and retries license issuance with forced revalidation
- surface the normalized snapshot through verifyDesktopAccess so the access overlay can use consistent allowed/mode/reason messaging

## Testing
- pytest *(fails: missing httpx dependency and libGL runtime for cv2)*

------
https://chatgpt.com/codex/tasks/task_e_68d74428be3c8323bac279948af7b6e7