### PR TITLE
Align desktop overlay with shared access model

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -29,7 +29,7 @@ import {
   updateAccount as updateAccountApi,
   updateAccountPlatform
 } from './services/accountsApi'
-import { verifyDesktopAccess } from './services/accessControl'
+import { verifyDesktopAccess, type AccessStatusPayload } from './services/accessControl'
 
 type PlatformPayload = {
   platform: SupportedPlatform
@@ -100,7 +100,7 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
   const [isLoadingAccounts, setIsLoadingAccounts] = useState(true)
   const [authStatus, setAuthStatus] = useState<AuthPingSummary | null>(null)
   const [authError, setAuthError] = useState<string | null>(null)
-  const [accessStatus, setAccessStatus] = useState<AccessCheckResult | null>(null)
+  const [accessStatus, setAccessStatus] = useState<AccessStatusPayload | null>(null)
   const [accessCheckError, setAccessCheckError] = useState<string | null>(null)
   const [isCheckingAccess, setIsCheckingAccess] = useState(true)
   const [isDark, setIsDark] = useState(false)
@@ -465,29 +465,47 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
     navigate(-1)
   }, [navigate])
 
+  const normalizedAccessReason = accessStatus?.reason?.toLowerCase() ?? ''
+
+  const accessMode: AccessStatusPayload['mode'] | 'none' = accessStatus
+    ? accessStatus.mode ??
+      ((accessStatus.subscriptionStatus === 'trialing' && accessStatus.subscriptionPlan === 'trial') ||
+      normalizedAccessReason.startsWith('trial')
+        ? 'trial'
+        : 'subscription')
+    : 'none'
+
+  const showOverlay =
+    !isProfileRoute &&
+    (isCheckingAccess || accessStatus?.allowed === false || (!accessStatus && Boolean(accessCheckError)))
+
+  const overlayTitle = isCheckingAccess
+    ? 'Verifying access…'
+    : accessStatus?.allowed === false
+      ? accessMode === 'trial'
+        ? 'Trial unavailable'
+        : accessMode === 'subscription'
+          ? 'Subscription required'
+          : 'Unable to verify access'
+      : 'Unable to verify access'
+
+  const overlayMessage = isCheckingAccess
+    ? 'Hold tight while we confirm your access permissions.'
+    : accessStatus?.allowed === false
+      ? accessStatus.reason
+          ? accessStatus.reason
+          : accessMode === 'trial'
+            ? 'Trial access is currently unavailable for this installation.'
+            : 'Your account does not have an active subscription. Update your billing details to continue using Atropos.'
+      : accessCheckError ?? 'An unexpected error occurred while validating access.'
+
   return (
     <div className="flex min-h-full flex-col bg-[var(--bg)] text-[var(--fg)]">
-      {!isProfileRoute &&
-        (isCheckingAccess ||
-          (!isCheckingAccess && ((accessStatus && !accessStatus.allowed) || (!accessStatus && accessCheckError)))) && (
-          <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/75 backdrop-blur">
-            <div className="max-w-md rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--panel)_75%,transparent)] p-6 text-center shadow-[0_18px_40px_rgba(0,0,0,0.45)]">
-            <h2 className="text-xl font-semibold text-[var(--fg)]">
-              {isCheckingAccess
-                ? 'Verifying access…'
-                : accessStatus && !accessStatus.allowed
-                  ? 'Subscription required'
-                  : 'Unable to verify access'}
-            </h2>
-            <p className="mt-3 text-sm text-[var(--muted)]">
-              {isCheckingAccess
-                ? 'Hold tight while we confirm your access permissions.'
-                : accessStatus && !accessStatus.allowed
-                  ? accessStatus.reason
-                    ? accessStatus.reason
-                    : 'Your account does not have an active subscription. Update your billing details to continue using Atropos.'
-                  : accessCheckError ?? 'An unexpected error occurred while validating access.'}
-            </p>
+      {showOverlay && (
+        <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/75 backdrop-blur">
+          <div className="max-w-md rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--panel)_75%,transparent)] p-6 text-center shadow-[0_18px_40px_rgba(0,0,0,0.45)]">
+            <h2 className="text-xl font-semibold text-[var(--fg)]">{overlayTitle}</h2>
+            <p className="mt-3 text-sm text-[var(--muted)]">{overlayMessage}</p>
             <div className="mt-5 flex flex-wrap justify-center gap-3">
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- expose a shared access model payload and ensure verifyDesktopAccess delegates to it, including a fallback when the API URL is absent
- drive the desktop access overlay from the shared model so the title and messaging align with subscription and trial states

## Testing
- pytest *(fails: missing optional dependencies such as httpx and libGL for cv2)*
- npm test -- --run Tests/appAccessOverlay.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d749b6a5cc8323acc63b2d90b75f26