### PR TITLE
fix: credit original video in generated descriptions

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -727,9 +727,10 @@ def _build_description_text(
 
     full_video_link = youtube_timestamp_url(source_url, start_seconds)
     credited_channel = channel or "Unknown Channel"
+    credited_title = source_title or "Original video"
     description = (
         f"Full video: {full_video_link}\n\n"
-        f"Credit: {credited_channel}\n"
+        f"Credit: {credited_channel} — {credited_title}\n"
         "Made by Atropos\n"
     )
     description = maybe_append_website_link(description)

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -1062,9 +1062,11 @@ def process_video(
             )
             hashtags.extend(["#shorts", "#withatropos"])
             full_video_link = youtube_timestamp_url(yt_url, candidate.start)
+            credited_channel = video_info.get("uploader", "Unknown Channel")
+            credited_title = video_info.get("title") or "Original video"
             description = (
                 f"Full video: {full_video_link}\n\n"
-                f"Credit: {video_info.get('uploader', 'Unknown Channel')}\n"
+                f"Credit: {credited_channel} — {credited_title}\n"
                 "Made by Atropos\n"
             )
             description = maybe_append_website_link(description)


### PR DESCRIPTION
## Summary
- include the original video title when crediting channels in generated descriptions
- keep the pipeline and manual description rebuild paths aligned so credits include both channel and video

## Testing
- pytest *(fails: missing optional dependencies httpx and libGL)*

------
https://chatgpt.com/codex/tasks/task_e_68d967db28708323b93fbea8295b420c