### PR TITLE
Add billing checkout and portal endpoints to licensing worker

### DIFF
--- a/services/licensing/src/billing/checkout.ts
+++ b/services/licensing/src/billing/checkout.ts
@@ -1,0 +1,246 @@
+import type Stripe from "stripe";
+import { getStripeClient } from "./client";
+import {
+  BillingEnv,
+  BillingUrlResponse,
+  CheckoutRequestBody,
+  computeIdempotencyKey,
+  ensurePriceId,
+  ensureUrl,
+  ensureUserId,
+  isBillableStatus,
+  normalizeEmail,
+  buildCustomerQuery,
+} from "./types";
+
+const isDeletedCustomer = (
+  candidate: Stripe.Customer | Stripe.DeletedCustomer,
+): candidate is Stripe.DeletedCustomer => {
+  return "deleted" in candidate && candidate.deleted === true;
+};
+
+class RequestError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "RequestError";
+    this.status = status;
+  }
+}
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+};
+
+const validate = <T>(resolver: () => T): T => {
+  try {
+    return resolver();
+  } catch (error) {
+    if (error instanceof RequestError) {
+      throw error;
+    }
+
+    if (error instanceof Error) {
+      throw new RequestError(error.message, 400);
+    }
+
+    throw new RequestError("Invalid request", 400);
+  }
+};
+
+const parseRequestBody = async (request: Request): Promise<CheckoutRequestBody> => {
+  try {
+    const payload = (await request.json()) as CheckoutRequestBody;
+    return payload;
+  } catch (error) {
+    throw new RequestError("Invalid JSON body", 400);
+  }
+};
+
+export const findOrCreateCustomer = async (
+  stripe: Stripe,
+  userId: string,
+  email?: string,
+): Promise<Stripe.Customer> => {
+  const query = buildCustomerQuery(userId);
+  let customer: Stripe.Customer | null = null;
+
+  try {
+    const result = await stripe.customers.search({
+      query,
+      limit: 1,
+      expand: ["data.subscriptions"],
+    });
+    if (result.data.length > 0 && !isDeletedCustomer(result.data[0])) {
+      customer = result.data[0] as Stripe.Customer;
+    }
+  } catch (error) {
+    console.error("Stripe customer search failed", error);
+  }
+
+  if (!customer && email) {
+    const list = await stripe.customers.list({ email, limit: 5 });
+    for (const candidate of list.data) {
+      if (isDeletedCustomer(candidate)) {
+        continue;
+      }
+
+      if (candidate.metadata?.user_id && candidate.metadata.user_id !== userId) {
+        continue;
+      }
+
+      customer = candidate as Stripe.Customer;
+      break;
+    }
+  }
+
+  if (!customer) {
+    const params: Stripe.CustomerCreateParams = {
+      metadata: { user_id: userId },
+    };
+
+    if (email) {
+      params.email = email;
+    }
+
+    customer = await stripe.customers.create(params);
+    return customer;
+  }
+
+  const updates: Stripe.CustomerUpdateParams = {};
+  if (email && customer.email !== email) {
+    updates.email = email;
+  }
+  if (!customer.metadata?.user_id) {
+    updates.metadata = { ...customer.metadata, user_id: userId };
+  }
+
+  if (Object.keys(updates).length > 0) {
+    customer = await stripe.customers.update(customer.id, updates);
+  }
+
+  return customer;
+};
+
+const findBillableSubscription = async (
+  stripe: Stripe,
+  customerId: string,
+): Promise<Stripe.Subscription | null> => {
+  const subscriptions = await stripe.subscriptions.list({
+    customer: customerId,
+    status: "all",
+    limit: 20,
+  });
+
+  for (const subscription of subscriptions.data) {
+    if (isBillableStatus(subscription.status)) {
+      return subscription;
+    }
+  }
+
+  return null;
+};
+
+export const createPortalSession = async (
+  stripe: Stripe,
+  customerId: string,
+  returnUrl: string,
+  userId: string,
+): Promise<string> => {
+  const idempotencyKey = await computeIdempotencyKey("portal", [userId, returnUrl]);
+  const session = await stripe.billingPortal.sessions.create(
+    {
+      customer: customerId,
+      return_url: returnUrl,
+    },
+    { idempotencyKey },
+  );
+
+  if (!session.url) {
+    throw new Error("Portal session missing URL");
+  }
+
+  return session.url;
+};
+
+export const handleCheckoutRequest = async (
+  request: Request,
+  env: BillingEnv,
+): Promise<Response> => {
+  try {
+    const payload = await parseRequestBody(request);
+    const userId = validate(() => ensureUserId(payload.user_id));
+    const email = normalizeEmail(payload.email);
+    const priceId = validate(() =>
+      ensurePriceId(
+        payload.price_id,
+        typeof env.PRICE_ID_MONTHLY === "string" ? env.PRICE_ID_MONTHLY : undefined,
+      ),
+    );
+    const successUrl = validate(() => ensureUrl(payload.success_url, "success_url"));
+    const cancelUrl = validate(() => ensureUrl(payload.cancel_url, "cancel_url"));
+
+    const stripe = getStripeClient(env);
+    const customer = await findOrCreateCustomer(stripe, userId, email);
+    const billableSubscription = await findBillableSubscription(stripe, customer.id);
+
+    if (billableSubscription) {
+      const portalUrl = await createPortalSession(stripe, customer.id, successUrl, userId);
+      const responseBody: BillingUrlResponse = { url: portalUrl };
+      return jsonResponse(responseBody, { status: 200 });
+    }
+
+    const idempotencyKey = await computeIdempotencyKey("checkout", [
+      userId,
+      priceId,
+      successUrl,
+      cancelUrl,
+    ]);
+
+    const session = await stripe.checkout.sessions.create(
+      {
+        mode: "subscription",
+        customer: customer.id,
+        success_url: successUrl,
+        cancel_url: cancelUrl,
+        line_items: [
+          {
+            price: priceId,
+            quantity: 1,
+          },
+        ],
+        client_reference_id: userId,
+        metadata: {
+          user_id: userId,
+        },
+        subscription_data: {
+          metadata: {
+            user_id: userId,
+          },
+        },
+      },
+      { idempotencyKey },
+    );
+
+    if (!session.url) {
+      throw new Error("Checkout session missing URL");
+    }
+
+    const responseBody: BillingUrlResponse = { url: session.url };
+    return jsonResponse(responseBody, { status: 200 });
+  } catch (error) {
+    if (error instanceof RequestError) {
+      return jsonResponse({ error: error.message }, { status: error.status });
+    }
+
+    console.error("Checkout handler failure", error);
+    return jsonResponse({ error: "Internal server error" }, { status: 500 });
+  }
+};

--- a/services/licensing/src/billing/client.ts
+++ b/services/licensing/src/billing/client.ts
@@ -1,0 +1,25 @@
+import Stripe from "stripe";
+import type { BillingEnv, StripeClient } from "./types";
+
+const clients = new Map<string, StripeClient>();
+
+export const getStripeClient = (env: BillingEnv): StripeClient => {
+  const secretKey = typeof env.STRIPE_SECRET_KEY === "string" ? env.STRIPE_SECRET_KEY.trim() : "";
+
+  if (!secretKey) {
+    throw new Error("STRIPE_SECRET_KEY is not configured");
+  }
+
+  const existing = clients.get(secretKey);
+  if (existing) {
+    return existing;
+  }
+
+  const stripe = new Stripe(secretKey, {
+    apiVersion: "2023-10-16",
+    httpClient: Stripe.createFetchHttpClient(),
+  });
+
+  clients.set(secretKey, stripe);
+  return stripe;
+};

--- a/services/licensing/src/billing/portal.ts
+++ b/services/licensing/src/billing/portal.ts
@@ -1,0 +1,73 @@
+import { getStripeClient } from "./client";
+import { createPortalSession, findOrCreateCustomer } from "./checkout";
+import { BillingEnv, BillingUrlResponse, PortalRequestBody, ensureUrl, ensureUserId } from "./types";
+
+class RequestError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "RequestError";
+    this.status = status;
+  }
+}
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+};
+
+const validate = <T>(resolver: () => T): T => {
+  try {
+    return resolver();
+  } catch (error) {
+    if (error instanceof RequestError) {
+      throw error;
+    }
+
+    if (error instanceof Error) {
+      throw new RequestError(error.message, 400);
+    }
+
+    throw new RequestError("Invalid request", 400);
+  }
+};
+
+const parseRequestBody = async (request: Request): Promise<PortalRequestBody> => {
+  try {
+    const payload = (await request.json()) as PortalRequestBody;
+    return payload;
+  } catch (error) {
+    throw new RequestError("Invalid JSON body", 400);
+  }
+};
+
+export const handlePortalRequest = async (
+  request: Request,
+  env: BillingEnv,
+): Promise<Response> => {
+  try {
+    const payload = await parseRequestBody(request);
+    const userId = validate(() => ensureUserId(payload.user_id));
+    const returnUrl = validate(() => ensureUrl(payload.return_url, "return_url"));
+
+    const stripe = getStripeClient(env);
+    const customer = await findOrCreateCustomer(stripe, userId);
+    const portalUrl = await createPortalSession(stripe, customer.id, returnUrl, userId);
+
+    const responseBody: BillingUrlResponse = { url: portalUrl };
+    return jsonResponse(responseBody, { status: 200 });
+  } catch (error) {
+    if (error instanceof RequestError) {
+      return jsonResponse({ error: error.message }, { status: error.status });
+    }
+
+    console.error("Portal handler failure", error);
+    return jsonResponse({ error: "Internal server error" }, { status: 500 });
+  }
+};

--- a/services/licensing/src/billing/types.ts
+++ b/services/licensing/src/billing/types.ts
@@ -1,0 +1,97 @@
+import type Stripe from "stripe";
+
+export interface BillingEnv extends Record<string, unknown> {
+  STRIPE_SECRET_KEY?: string;
+  PRICE_ID_MONTHLY?: string;
+}
+
+export interface CheckoutRequestBody {
+  user_id: string;
+  email?: string;
+  price_id?: string;
+  success_url?: string;
+  cancel_url?: string;
+}
+
+export interface PortalRequestBody {
+  user_id: string;
+  return_url?: string;
+}
+
+export interface BillingUrlResponse {
+  url: string;
+}
+
+const BILLABLE_SUBSCRIPTION_STATUSES: ReadonlySet<string> = new Set([
+  "active",
+  "trialing",
+  "past_due",
+  "unpaid",
+  "paused",
+]);
+
+export const isBillableStatus = (status: string | null | undefined): boolean => {
+  if (!status) {
+    return false;
+  }
+
+  return BILLABLE_SUBSCRIPTION_STATUSES.has(status);
+};
+
+export const buildCustomerQuery = (userId: string): string => {
+  const escaped = userId.replace(/['\\]/g, "\\$&");
+  return `metadata['user_id']:'${escaped}'`;
+};
+
+export const ensureUrl = (value: string | undefined | null, field: string): string => {
+  if (!value || typeof value !== "string") {
+    throw new Error(`${field} is required`);
+  }
+
+  try {
+    return new URL(value).toString();
+  } catch (error) {
+    throw new Error(`${field} must be a valid URL`);
+  }
+};
+
+export const ensureUserId = (value: unknown): string => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error("user_id is required");
+  }
+
+  return value.trim();
+};
+
+export const ensurePriceId = (value: string | undefined | null, fallback?: string): string => {
+  const candidate = value ?? fallback;
+  if (!candidate || typeof candidate !== "string") {
+    throw new Error("price_id is required");
+  }
+
+  return candidate;
+};
+
+export const normalizeEmail = (value: unknown): string | undefined => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return undefined;
+  }
+
+  return value.trim();
+};
+
+export const computeIdempotencyKey = async (
+  prefix: string,
+  parts: Array<string | undefined>,
+): Promise<string> => {
+  const encoder = new TextEncoder();
+  const digestInput = encoder.encode(parts.filter(Boolean).join("|"));
+  const hashBuffer = await crypto.subtle.digest("SHA-256", digestInput);
+  const hex = Array.from(new Uint8Array(hashBuffer))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+
+  return `${prefix}_${hex.slice(0, 48)}`;
+};
+
+export type StripeClient = Stripe;

--- a/services/licensing/src/index.ts
+++ b/services/licensing/src/index.ts
@@ -1,4 +1,6 @@
 import { handleSubscriptionRequest } from "./billing";
+import { handleCheckoutRequest } from "./billing/checkout";
+import { handlePortalRequest } from "./billing/portal";
 
 const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
   return new Response(JSON.stringify(body), {
@@ -17,6 +19,14 @@ export default {
 
     if (path === "/health") {
       return jsonResponse({ status: "ok" }, { status: 200 });
+    }
+
+    if (path === "/billing/checkout" && request.method === "POST") {
+      return handleCheckoutRequest(request, env);
+    }
+
+    if (path === "/billing/portal" && request.method === "POST") {
+      return handlePortalRequest(request, env);
     }
 
     if (path === "/billing/subscription" && request.method === "GET") {


### PR DESCRIPTION
## Summary
- implement a Stripe client wrapper and billing helpers for the licensing worker
- add checkout and portal handlers that reuse customers, handle idempotency, and return Stripe URLs
- expose POST /billing/checkout and /billing/portal worker routes

## Testing
- pytest *(fails: missing httpx package and libGL.so.1 for cv2)*

------
https://chatgpt.com/codex/tasks/task_e_68db03b3e67c83238ee5d86c19be4e68