### PR TITLE
feat: add Stripe checkout and portal handlers to licensing service

### DIFF
--- a/services/licensing/src/billing/checkout.ts
+++ b/services/licensing/src/billing/checkout.ts
@@ -1,0 +1,192 @@
+import Stripe from "stripe";
+import { ensureCustomer, getStripeClient } from "./client";
+import { createPortalSession } from "./portal";
+import { BillingEnv, CheckoutRequestBody, CheckoutResponseBody } from "./types";
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+};
+
+const isNonEmptyString = (value: unknown): value is string => {
+  return typeof value === "string" && value.trim().length > 0;
+};
+
+const buildIdempotencyKey = (request: Request, userId: string): string => {
+  return request.headers.get("Idempotency-Key") ?? `checkout:${userId}:${crypto.randomUUID()}`;
+};
+
+const normalizeErrorDetails = (error: unknown): Record<string, string> => {
+  const details: Record<string, string> = {};
+
+  if (error && typeof error === "object" && "code" in error && typeof (error as { code?: unknown }).code === "string") {
+    details.code = (error as { code: string }).code;
+  }
+
+  details.name = error instanceof Error ? error.name : "unknown_error";
+
+  return details;
+};
+
+const BILLABLE_STATUSES = new Set(["active", "trialing", "past_due", "unpaid", "paused"]);
+
+const isBillableSubscription = (subscription: Stripe.Subscription): boolean => {
+  const status = subscription.status?.toLowerCase();
+
+  if (status && BILLABLE_STATUSES.has(status)) {
+    return true;
+  }
+
+  if (subscription.pause_collection) {
+    return true;
+  }
+
+  return false;
+};
+
+const customerHasBillableSubscription = async (
+  stripe: Stripe,
+  customerId: string,
+): Promise<boolean> => {
+  const subscriptions = await stripe.subscriptions.list({
+    customer: customerId,
+    status: "all",
+    limit: 10,
+  });
+
+  return subscriptions.data.some((subscription) => isBillableSubscription(subscription));
+};
+
+const resolveSuccessUrl = (env: BillingEnv, payload: CheckoutRequestBody): string | null => {
+  if (isNonEmptyString(payload.success_url)) {
+    return payload.success_url;
+  }
+
+  if (isNonEmptyString(env.BILLING_SUCCESS_URL)) {
+    return env.BILLING_SUCCESS_URL;
+  }
+
+  return null;
+};
+
+const resolveCancelUrl = (env: BillingEnv, payload: CheckoutRequestBody, fallback: string): string => {
+  if (isNonEmptyString(payload.cancel_url)) {
+    return payload.cancel_url;
+  }
+
+  if (isNonEmptyString(env.BILLING_CANCEL_URL)) {
+    return env.BILLING_CANCEL_URL;
+  }
+
+  return fallback;
+};
+
+const resolvePriceId = (env: BillingEnv, payload: CheckoutRequestBody): string | null => {
+  if (isNonEmptyString(payload.price_id)) {
+    return payload.price_id;
+  }
+
+  if (isNonEmptyString(env.PRICE_ID_MONTHLY)) {
+    return env.PRICE_ID_MONTHLY;
+  }
+
+  return null;
+};
+
+export const handleCheckoutRequest = async (
+  request: Request,
+  env: BillingEnv,
+): Promise<Response> => {
+  let payload: CheckoutRequestBody;
+
+  try {
+    payload = (await request.json()) as CheckoutRequestBody;
+  } catch {
+    return jsonResponse({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const userId = isNonEmptyString(payload.user_id) ? payload.user_id.trim() : null;
+
+  if (!userId) {
+    return jsonResponse({ error: "user_id_required" }, { status: 400 });
+  }
+
+  const successUrl = resolveSuccessUrl(env, payload);
+  if (!successUrl) {
+    return jsonResponse({ error: "success_url_required" }, { status: 400 });
+  }
+
+  const priceId = resolvePriceId(env, payload);
+  if (!priceId) {
+    return jsonResponse({ error: "price_id_required" }, { status: 400 });
+  }
+
+  const cancelUrl = resolveCancelUrl(env, payload, successUrl);
+  const email = isNonEmptyString(payload.email) ? payload.email : undefined;
+
+  try {
+    const stripe = getStripeClient(env);
+    const customer = await ensureCustomer(stripe, userId, email);
+
+    const hasBillable = await customerHasBillableSubscription(stripe, customer.id);
+
+    if (hasBillable) {
+      const portalSession = await createPortalSession(stripe, {
+        customerId: customer.id,
+        returnUrl: successUrl,
+        idempotencyKey: buildIdempotencyKey(request, userId).replace("checkout:", "portal:"),
+      });
+
+      const responseBody: CheckoutResponseBody = {
+        url: portalSession.url,
+        type: "portal",
+      };
+
+      return jsonResponse(responseBody, { status: 200 });
+    }
+
+    const session = await stripe.checkout.sessions.create(
+      {
+        mode: "subscription",
+        customer: customer.id,
+        line_items: [
+          {
+            price: priceId,
+            quantity: 1,
+          },
+        ],
+        allow_promotion_codes: true,
+        success_url: successUrl,
+        cancel_url: cancelUrl,
+        subscription_data: {
+          metadata: {
+            user_id: userId,
+          },
+        },
+        metadata: {
+          user_id: userId,
+        },
+      },
+      { idempotencyKey: buildIdempotencyKey(request, userId) },
+    );
+
+    if (!session.url) {
+      return jsonResponse({ error: "session_url_missing" }, { status: 502 });
+    }
+
+    const responseBody: CheckoutResponseBody = {
+      url: session.url,
+      type: "checkout",
+    };
+
+    return jsonResponse(responseBody, { status: 200 });
+  } catch (error) {
+    console.error("billing_checkout_error", normalizeErrorDetails(error));
+    return jsonResponse({ error: "internal_error" }, { status: 500 });
+  }
+};

--- a/services/licensing/src/billing/client.ts
+++ b/services/licensing/src/billing/client.ts
@@ -1,0 +1,90 @@
+import Stripe from "stripe";
+import { BillingEnv } from "./types";
+
+const STRIPE_API_VERSION: Stripe.LatestApiVersion = "2023-10-16";
+
+let cachedStripe: Stripe | null = null;
+let cachedSecretKey: string | null = null;
+
+const escapeSearchValue = (value: string): string => {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+};
+
+export const getStripeClient = (env: BillingEnv): Stripe => {
+  const secretKey = env.STRIPE_SECRET_KEY;
+
+  if (!secretKey || typeof secretKey !== "string") {
+    throw new Error("STRIPE_SECRET_KEY is not configured");
+  }
+
+  if (!cachedStripe || cachedSecretKey !== secretKey) {
+    cachedStripe = new Stripe(secretKey, {
+      apiVersion: STRIPE_API_VERSION,
+      httpClient: Stripe.createFetchHttpClient(),
+      maxNetworkRetries: 2,
+    });
+    cachedSecretKey = secretKey;
+  }
+
+  return cachedStripe;
+};
+
+export const findCustomerByUserId = async (
+  stripe: Stripe,
+  userId: string,
+): Promise<Stripe.Customer | null> => {
+  const query = `metadata['user_id']:'${escapeSearchValue(userId)}'`;
+  const result = await stripe.customers.search({ query, limit: 1 });
+
+  if (!result.data.length) {
+    return null;
+  }
+
+  const customer = result.data[0];
+
+  if ((customer as Stripe.DeletedCustomer).deleted) {
+    return null;
+  }
+
+  return customer as Stripe.Customer;
+};
+
+export const ensureCustomer = async (
+  stripe: Stripe,
+  userId: string,
+  email?: string,
+): Promise<Stripe.Customer> => {
+  const existing = await findCustomerByUserId(stripe, userId);
+
+  if (existing) {
+    if (email && typeof email === "string" && email.length > 0 && existing.email !== email) {
+      const updated = await stripe.customers.update(existing.id, {
+        email,
+        metadata: {
+          ...existing.metadata,
+          user_id: userId,
+        },
+      });
+
+      return updated as Stripe.Customer;
+    }
+
+    if (!existing.metadata?.user_id) {
+      await stripe.customers.update(existing.id, {
+        metadata: {
+          ...existing.metadata,
+          user_id: userId,
+        },
+      });
+    }
+
+    return existing;
+  }
+
+  const created = await stripe.customers.create({
+    email: email && typeof email === "string" && email.length > 0 ? email : undefined,
+    metadata: { user_id: userId },
+  });
+
+  return created;
+};

--- a/services/licensing/src/billing/portal.ts
+++ b/services/licensing/src/billing/portal.ts
@@ -1,0 +1,93 @@
+import Stripe from "stripe";
+import { ensureCustomer, getStripeClient } from "./client";
+import { BillingEnv, PortalRequestBody, PortalResponseBody } from "./types";
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+};
+
+const isNonEmptyString = (value: unknown): value is string => {
+  return typeof value === "string" && value.trim().length > 0;
+};
+
+const buildIdempotencyKey = (request: Request, userId: string): string => {
+  return request.headers.get("Idempotency-Key") ?? `portal:${userId}:${crypto.randomUUID()}`;
+};
+
+const normalizeErrorDetails = (error: unknown): Record<string, string> => {
+  const details: Record<string, string> = {};
+
+  if (error && typeof error === "object" && "code" in error && typeof (error as { code?: unknown }).code === "string") {
+    details.code = (error as { code: string }).code;
+  }
+
+  details.name = error instanceof Error ? error.name : "unknown_error";
+
+  return details;
+};
+
+export const createPortalSession = async (
+  stripe: Stripe,
+  params: { customerId: string; returnUrl?: string; idempotencyKey: string },
+): Promise<Stripe.BillingPortal.Session> => {
+  const session = await stripe.billingPortal.sessions.create(
+    {
+      customer: params.customerId,
+      return_url: params.returnUrl,
+    },
+    { idempotencyKey: params.idempotencyKey },
+  );
+
+  return session;
+};
+
+export const handlePortalRequest = async (
+  request: Request,
+  env: BillingEnv,
+): Promise<Response> => {
+  let payload: PortalRequestBody;
+
+  try {
+    payload = (await request.json()) as PortalRequestBody;
+  } catch {
+    return jsonResponse({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const userId = isNonEmptyString(payload.user_id) ? payload.user_id.trim() : null;
+
+  if (!userId) {
+    return jsonResponse({ error: "user_id_required" }, { status: 400 });
+  }
+
+  try {
+    const stripe = getStripeClient(env);
+    const customer = await ensureCustomer(stripe, userId);
+    const returnUrl = isNonEmptyString(payload.return_url) ? payload.return_url : undefined;
+    const idempotencyKey = buildIdempotencyKey(request, userId);
+
+    const session = await createPortalSession(stripe, {
+      customerId: customer.id,
+      returnUrl,
+      idempotencyKey,
+    });
+
+    if (!session.url) {
+      return jsonResponse({ error: "session_url_missing" }, { status: 502 });
+    }
+
+    const responseBody: PortalResponseBody = {
+      url: session.url,
+    };
+
+    return jsonResponse(responseBody, { status: 200 });
+  } catch (error) {
+    console.error("billing_portal_error", normalizeErrorDetails(error));
+    return jsonResponse({ error: "internal_error" }, { status: 500 });
+  }
+};

--- a/services/licensing/src/billing/types.ts
+++ b/services/licensing/src/billing/types.ts
@@ -1,0 +1,28 @@
+export interface BillingEnv {
+  STRIPE_SECRET_KEY?: string;
+  PRICE_ID_MONTHLY?: string;
+  BILLING_SUCCESS_URL?: string;
+  BILLING_CANCEL_URL?: string;
+}
+
+export interface CheckoutRequestBody {
+  user_id?: unknown;
+  email?: unknown;
+  price_id?: unknown;
+  success_url?: unknown;
+  cancel_url?: unknown;
+}
+
+export interface CheckoutResponseBody {
+  url: string;
+  type: "portal" | "checkout";
+}
+
+export interface PortalRequestBody {
+  user_id?: unknown;
+  return_url?: unknown;
+}
+
+export interface PortalResponseBody {
+  url: string;
+}

--- a/services/licensing/src/index.ts
+++ b/services/licensing/src/index.ts
@@ -1,4 +1,6 @@
 import { handleSubscriptionRequest } from "./billing";
+import { handleCheckoutRequest } from "./billing/checkout";
+import { handlePortalRequest } from "./billing/portal";
 
 const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
   return new Response(JSON.stringify(body), {
@@ -21,6 +23,14 @@ export default {
 
     if (path === "/billing/subscription" && request.method === "GET") {
       return handleSubscriptionRequest(request, env);
+    }
+
+    if (path === "/billing/checkout" && request.method === "POST") {
+      return handleCheckoutRequest(request, env);
+    }
+
+    if (path === "/billing/portal" && request.method === "POST") {
+      return handlePortalRequest(request, env);
     }
 
     // TODO: route other endpoints


### PR DESCRIPTION
## Summary
- add dedicated Stripe client utilities and billing types for the licensing worker
- implement subscription-aware checkout flow and billing portal session creation
- expose new POST /billing/checkout and /billing/portal routes from the worker

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db06b2fed483239976fb3740b9ec73