### PR TITLE
feat(licensing): add license issuance endpoints

### DIFF
--- a/services/licensing/src/index.ts
+++ b/services/licensing/src/index.ts
@@ -2,6 +2,9 @@ import { handleSubscriptionRequest } from "./billing";
 import { handleCheckoutRequest } from "./billing/checkout";
 import { handlePortalRequest } from "./billing/portal";
 import { handleWebhookRequest } from "./billing/webhook";
+import { handleIssueRequest } from "./license/issue";
+import { handleValidateRequest } from "./license/validate";
+import { handlePublicKeyRequest } from "./license/keys";
 
 const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
   return new Response(JSON.stringify(body), {
@@ -38,10 +41,17 @@ export default {
       return handleWebhookRequest(request, env);
     }
 
-    // TODO: route other endpoints
-    // e.g. if path.startsWith("/license") → license handler
-    // else if path.startsWith("/trial") → trial handler
-    // else return 404
+    if (path === "/license/issue" && request.method === "POST") {
+      return handleIssueRequest(request, env);
+    }
+
+    if (path === "/license/validate" && request.method === "GET") {
+      return handleValidateRequest(request, env);
+    }
+
+    if (path === "/license/public-key" && request.method === "GET") {
+      return handlePublicKeyRequest(request, env);
+    }
 
     return jsonResponse({ error: "Not found" }, { status: 404 });
   },

--- a/services/licensing/src/lib/jwt.ts
+++ b/services/licensing/src/lib/jwt.ts
@@ -1,0 +1,187 @@
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const base64UrlEncode = (input: Uint8Array | ArrayBuffer | string): string => {
+  let bytes: Uint8Array;
+
+  if (typeof input === "string") {
+    bytes = textEncoder.encode(input);
+  } else if (input instanceof ArrayBuffer) {
+    bytes = new Uint8Array(input);
+  } else {
+    bytes = input;
+  }
+
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
+};
+
+const base64UrlDecode = (input: string): Uint8Array => {
+  const sanitized = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = sanitized.length % 4 === 0 ? 0 : 4 - (sanitized.length % 4);
+  const base64 = sanitized + "=".repeat(padding);
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  return bytes;
+};
+
+const parsePrivateKey = (value: string): JsonWebKey => {
+  let parsed: JsonWebKey;
+
+  try {
+    parsed = JSON.parse(value) as JsonWebKey;
+  } catch (error) {
+    throw new Error("JWT_PRIVATE_KEY must be a JSON Web Key string");
+  }
+
+  if (parsed.kty !== "OKP" || parsed.crv !== "Ed25519") {
+    throw new Error("JWT_PRIVATE_KEY must be an Ed25519 OKP JWK");
+  }
+
+  if (typeof parsed.d !== "string" || typeof parsed.x !== "string") {
+    throw new Error("JWT_PRIVATE_KEY must include both private (d) and public (x) components");
+  }
+
+  return parsed;
+};
+
+export interface SigningMaterial {
+  privateKey: CryptoKey;
+  publicKey: CryptoKey;
+  publicJwk: JsonWebKey;
+}
+
+let cachedKey: string | null = null;
+let cachedMaterial: SigningMaterial | null = null;
+
+export const getSigningMaterial = async (
+  env: { JWT_PRIVATE_KEY?: string } & Record<string, unknown>,
+): Promise<SigningMaterial> => {
+  const rawKey = env.JWT_PRIVATE_KEY;
+
+  if (typeof rawKey !== "string" || rawKey.trim().length === 0) {
+    throw new Error("JWT_PRIVATE_KEY is not configured");
+  }
+
+  if (cachedMaterial && cachedKey === rawKey) {
+    return cachedMaterial;
+  }
+
+  const jwk = parsePrivateKey(rawKey);
+  const privateKey = await crypto.subtle.importKey("jwk", jwk, { name: "Ed25519" }, false, ["sign"]);
+
+  const publicJwk: JsonWebKey = {
+    kty: "OKP",
+    crv: "Ed25519",
+    x: jwk.x,
+  };
+
+  if (jwk.kid) {
+    publicJwk.kid = jwk.kid;
+  }
+
+  const publicKey = await crypto.subtle.importKey("jwk", publicJwk, { name: "Ed25519" }, false, ["verify"]);
+
+  cachedKey = rawKey;
+  cachedMaterial = { privateKey, publicKey, publicJwk };
+
+  return cachedMaterial;
+};
+
+export const signJwt = async (
+  payload: Record<string, unknown>,
+  material: SigningMaterial,
+): Promise<string> => {
+  const header = { alg: "EdDSA", typ: "JWT" };
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  const signature = await crypto.subtle.sign("Ed25519", material.privateKey, textEncoder.encode(signingInput));
+  const encodedSignature = base64UrlEncode(signature);
+
+  return `${signingInput}.${encodedSignature}`;
+};
+
+export interface JwtVerificationResult {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+}
+
+const decodeSegment = (segment: string): Record<string, unknown> => {
+  const decoded = base64UrlDecode(segment);
+  const json = textDecoder.decode(decoded);
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(json);
+  } catch (error) {
+    throw new Error("Invalid JWT segment encoding");
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Invalid JWT segment payload");
+  }
+
+  return parsed as Record<string, unknown>;
+};
+
+export const verifyJwt = async (
+  token: string,
+  material: SigningMaterial,
+): Promise<JwtVerificationResult> => {
+  const parts = token.split(".");
+
+  if (parts.length !== 3) {
+    throw new Error("Invalid token format");
+  }
+
+  const [encodedHeader, encodedPayload, encodedSignature] = parts;
+  const header = decodeSegment(encodedHeader);
+  const payload = decodeSegment(encodedPayload);
+
+  if (header.alg && header.alg !== "EdDSA") {
+    throw new Error("Unsupported JWT algorithm");
+  }
+
+  const signature = base64UrlDecode(encodedSignature);
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  const isValid = await crypto.subtle.verify(
+    "Ed25519",
+    material.publicKey,
+    signature,
+    textEncoder.encode(signingInput),
+  );
+
+  if (!isValid) {
+    throw new Error("Invalid token signature");
+  }
+
+  return { header, payload };
+};
+
+export const getPublicKeyResponse = async (
+  env: { JWT_PRIVATE_KEY?: string } & Record<string, unknown>,
+): Promise<Record<string, unknown>> => {
+  const material = await getSigningMaterial(env);
+  const { publicJwk } = material;
+
+  return {
+    alg: "EdDSA",
+    kty: publicJwk.kty,
+    crv: publicJwk.crv,
+    x: publicJwk.x,
+    ...(publicJwk.kid ? { kid: publicJwk.kid } : {}),
+  };
+};

--- a/services/licensing/src/license/issue.ts
+++ b/services/licensing/src/license/issue.ts
@@ -1,0 +1,131 @@
+import { getUserRecord, isEntitled, KVNamespace, UserRecord } from "../kv";
+import { mutateUserRecord } from "../kv/user";
+import { getSigningMaterial, signJwt } from "../lib/jwt";
+
+interface LicensingEnv extends Record<string, unknown> {
+  LICENSING_KV: KVNamespace;
+  JWT_PRIVATE_KEY?: string;
+}
+
+interface IssueRequestBody {
+  user_id?: unknown;
+  device_hash?: unknown;
+}
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+};
+
+const determineTier = (record: UserRecord): string => {
+  if (record.plan_price_id) {
+    return record.plan_price_id;
+  }
+
+  const status = (record.status ?? "").toLowerCase();
+
+  if (status === "trialing") {
+    return "trial";
+  }
+
+  if (status === "active") {
+    return "paid";
+  }
+
+  return "free";
+};
+
+export const handleIssueRequest = async (
+  request: Request,
+  env: LicensingEnv,
+): Promise<Response> => {
+  let body: IssueRequestBody;
+
+  try {
+    body = (await request.json()) as IssueRequestBody;
+  } catch (error) {
+    return jsonResponse({ error: "invalid_request", detail: "Body must be valid JSON" }, { status: 400 });
+  }
+
+  const userId = typeof body.user_id === "string" ? body.user_id.trim() : "";
+  const deviceHash = typeof body.device_hash === "string" ? body.device_hash.trim() : "";
+
+  if (!userId || !deviceHash) {
+    return jsonResponse({ error: "invalid_request", detail: "user_id and device_hash are required" }, { status: 400 });
+  }
+
+  if (!(await getUserRecord(env.LICENSING_KV, userId))) {
+    return jsonResponse({ error: "user_not_found" }, { status: 404 });
+  }
+
+  let deviceMismatch = false;
+
+  const record = await mutateUserRecord(env.LICENSING_KV, userId, ({ current }) => {
+    if (current.device_hash && current.device_hash !== deviceHash) {
+      deviceMismatch = true;
+      return null;
+    }
+
+    if (!current.device_hash) {
+      return { device_hash: deviceHash };
+    }
+
+    return null;
+  });
+
+  if (deviceMismatch) {
+    return jsonResponse({ error: "device_conflict", detail: "license already bound to another device" }, { status: 409 });
+  }
+
+  if (!isEntitled(record.status, record.current_period_end)) {
+    return jsonResponse({ error: "not_entitled" }, { status: 403 });
+  }
+
+  if (!record.device_hash) {
+    return jsonResponse({ error: "device_binding_failed" }, { status: 500 });
+  }
+
+  let material: Awaited<ReturnType<typeof getSigningMaterial>>;
+
+  try {
+    material = await getSigningMaterial(env);
+  } catch (error) {
+    return jsonResponse({ error: "signing_unavailable" }, { status: 500 });
+  }
+
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const expiresAt = issuedAt + 15 * 60;
+  const payload = {
+    sub: userId,
+    email: record.email,
+    tier: determineTier(record),
+    device_hash: record.device_hash,
+    epoch: record.epoch ?? 0,
+    iat: issuedAt,
+    exp: expiresAt,
+  };
+
+  let token: string;
+
+  try {
+    token = await signJwt(payload, material);
+  } catch (error) {
+    return jsonResponse({ error: "signing_failed" }, { status: 500 });
+  }
+
+  return jsonResponse(
+    {
+      token,
+      issued_at: issuedAt,
+      expires_at: expiresAt,
+      epoch: payload.epoch,
+      device_hash: payload.device_hash,
+    },
+    { status: 200 },
+  );
+};

--- a/services/licensing/src/license/keys.ts
+++ b/services/licensing/src/license/keys.ts
@@ -1,0 +1,29 @@
+import type { KVNamespace } from "../kv";
+import { getPublicKeyResponse } from "../lib/jwt";
+
+interface LicensingEnv extends Record<string, unknown> {
+  LICENSING_KV: KVNamespace;
+  JWT_PRIVATE_KEY?: string;
+}
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+};
+
+export const handlePublicKeyRequest = async (
+  _request: Request,
+  env: LicensingEnv,
+): Promise<Response> => {
+  try {
+    const body = await getPublicKeyResponse(env);
+    return jsonResponse(body, { status: 200 });
+  } catch (error) {
+    return jsonResponse({ error: "signing_unavailable" }, { status: 500 });
+  }
+};

--- a/services/licensing/src/license/validate.ts
+++ b/services/licensing/src/license/validate.ts
@@ -1,0 +1,139 @@
+import { getUserRecord, isEntitled, KVNamespace, UserRecord } from "../kv";
+import { getSigningMaterial, verifyJwt } from "../lib/jwt";
+
+interface LicensingEnv extends Record<string, unknown> {
+  LICENSING_KV: KVNamespace;
+  JWT_PRIVATE_KEY?: string;
+}
+
+interface LicenseClaims extends Record<string, unknown> {
+  sub?: string;
+  email?: string | null;
+  tier?: string | null;
+  device_hash?: string | null;
+  epoch?: number;
+  iat?: number;
+  exp?: number;
+}
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+};
+
+const determineTier = (record: UserRecord): string => {
+  if (record.plan_price_id) {
+    return record.plan_price_id;
+  }
+
+  const status = (record.status ?? "").toLowerCase();
+
+  if (status === "trialing") {
+    return "trial";
+  }
+
+  if (status === "active") {
+    return "paid";
+  }
+
+  return "free";
+};
+
+const extractBearerToken = (request: Request): string | null => {
+  const header = request.headers.get("authorization");
+
+  if (header) {
+    const [scheme, ...rest] = header.split(" ");
+
+    if (scheme && scheme.toLowerCase() === "bearer") {
+      const token = rest.join(" ").trim();
+
+      if (token.length > 0) {
+        return token;
+      }
+    }
+  }
+
+  const url = new URL(request.url);
+  const tokenParam = url.searchParams.get("token");
+
+  if (tokenParam && tokenParam.trim().length > 0) {
+    return tokenParam.trim();
+  }
+
+  return null;
+};
+
+export const handleValidateRequest = async (
+  request: Request,
+  env: LicensingEnv,
+): Promise<Response> => {
+  const token = extractBearerToken(request);
+
+  if (!token) {
+    return jsonResponse({ valid: false, error: "missing_token" }, { status: 400 });
+  }
+
+  let claims: LicenseClaims;
+
+  try {
+    const material = await getSigningMaterial(env);
+    const verification = await verifyJwt(token, material);
+    claims = verification.payload as LicenseClaims;
+  } catch (error) {
+    return jsonResponse({ valid: false, error: "invalid_token" }, { status: 401 });
+  }
+
+  if (!claims || typeof claims !== "object") {
+    return jsonResponse({ valid: false, error: "invalid_token" }, { status: 401 });
+  }
+
+  if (typeof claims.sub !== "string" || claims.sub.trim().length === 0) {
+    return jsonResponse({ valid: false, error: "invalid_subject" }, { status: 400 });
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  if (typeof claims.exp !== "number" || Number.isNaN(claims.exp) || claims.exp <= now) {
+    return jsonResponse({ valid: false, error: "token_expired" }, { status: 401 });
+  }
+
+  const record = await getUserRecord(env.LICENSING_KV, claims.sub);
+
+  if (!record) {
+    return jsonResponse({ valid: false, error: "user_not_found" }, { status: 404 });
+  }
+
+  if (!isEntitled(record.status, record.current_period_end)) {
+    return jsonResponse({ valid: false, error: "not_entitled" }, { status: 403 });
+  }
+
+  if (record.device_hash && record.device_hash !== claims.device_hash) {
+    return jsonResponse({ valid: false, error: "device_mismatch" }, { status: 409 });
+  }
+
+  if (typeof record.epoch === "number" && typeof claims.epoch === "number" && record.epoch !== claims.epoch) {
+    return jsonResponse({ valid: false, error: "stale_epoch" }, { status: 409 });
+  }
+
+  return jsonResponse(
+    {
+      valid: true,
+      license: {
+        sub: claims.sub,
+        email: claims.email ?? record.email,
+        tier: claims.tier ?? determineTier(record),
+        device_hash: claims.device_hash ?? record.device_hash,
+        epoch: claims.epoch ?? record.epoch,
+        iat: claims.iat,
+        exp: claims.exp,
+      },
+    },
+    { status: 200 },
+  );
+};


### PR DESCRIPTION
## Summary
- add an Ed25519 JWT helper for signing, verification, and public key exposure
- implement /license/issue and /license/validate endpoints that bind devices and enforce entitlement checks
- expose /license/public-key and wire the new handlers into the worker entrypoint

## Testing
- pytest *(fails: missing httpx package and libGL.so.1 shared library in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db0d25aa648323a92dbc77b980eec4