### PR TITLE
Add centralized CORS handling for licensing worker

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,6 +48,7 @@ Atropos is composed of three cooperating runtimes:
 - `VITE_LICENSE_API_BASE_URL` → Desktop → Cloudflare Worker host (dev: `https://licensing.dev.atropos.workers.dev`, prod: `https://licensing.atropos.app`).
 - `SERVER_ENV` / `ENVIRONMENT` → Python services → selects credentials in `server/config.py` and toggles webhook hosts.
 - `LICENSING_ENV` → Worker → selects Stripe keys and KV namespace bindings.
+- `CORS_ALLOW_ORIGINS` → Worker → comma-separated origins allowed for CORS responses (defaults to `*`).
 
 ### Cloudflare worker environments
 

--- a/services/licensing/README.md
+++ b/services/licensing/README.md
@@ -20,6 +20,7 @@ Configure secrets via `wrangler secret` or environment variables in CI:
 - `ED25519_PRIVATE_KEY` (base64-encoded seed used for signing entitlements)
 - `KV_LICENSE_NAMESPACE` (Workers KV binding name)
 - `TRIAL_MAX_PER_DEVICE` (default `3`)
+- `CORS_ALLOW_ORIGINS` (comma-separated list of allowed origins for CORS responses; defaults to `*`)
 
 ## Development vs production
 

--- a/services/licensing/src/http/cors.ts
+++ b/services/licensing/src/http/cors.ts
@@ -1,0 +1,92 @@
+const DEFAULT_ALLOW_ORIGINS = ["*"];
+const DEFAULT_ALLOW_METHODS = ["GET", "POST", "OPTIONS"];
+const DEFAULT_ALLOW_HEADERS = ["Content-Type", "Authorization"];
+
+const parseCsv = (value: string): string[] => {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+};
+
+export const parseAllowedOrigins = (
+  env: Record<string, unknown>,
+): string[] => {
+  const raw = typeof env?.CORS_ALLOW_ORIGINS === "string" ? env.CORS_ALLOW_ORIGINS : "";
+  const parsed = parseCsv(raw);
+
+  if (parsed.length === 0) {
+    return [...DEFAULT_ALLOW_ORIGINS];
+  }
+
+  return Array.from(new Set(parsed));
+};
+
+const resolveAllowedOrigin = (request: Request, allowedOrigins: string[]): string => {
+  if (allowedOrigins.includes("*")) {
+    return "*";
+  }
+
+  const origin = request.headers.get("Origin");
+
+  if (origin && allowedOrigins.includes(origin)) {
+    return origin;
+  }
+
+  return allowedOrigins[0] ?? "*";
+};
+
+const ensureVaryIncludesOrigin = (headers: Headers, allowOrigin: string): void => {
+  if (allowOrigin === "*") {
+    return;
+  }
+
+  const varyHeader = headers.get("Vary");
+
+  if (!varyHeader) {
+    headers.set("Vary", "Origin");
+    return;
+  }
+
+  const varyValues = varyHeader
+    .split(",")
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0);
+
+  if (!varyValues.includes("origin")) {
+    headers.set("Vary", `${varyHeader}, Origin`);
+  }
+};
+
+export const applyCorsHeaders = (
+  request: Request,
+  response: Response,
+  allowedOrigins: string[],
+): Response => {
+  const headers = response.headers;
+  const allowOrigin = resolveAllowedOrigin(request, allowedOrigins);
+  const requestedHeaders = request.headers.get("Access-Control-Request-Headers");
+
+  headers.set("Access-Control-Allow-Origin", allowOrigin);
+  headers.set("Access-Control-Allow-Methods", DEFAULT_ALLOW_METHODS.join(","));
+
+  if (requestedHeaders) {
+    headers.set("Access-Control-Allow-Headers", requestedHeaders);
+  } else if (!headers.has("Access-Control-Allow-Headers")) {
+    headers.set("Access-Control-Allow-Headers", DEFAULT_ALLOW_HEADERS.join(","));
+  }
+
+  ensureVaryIncludesOrigin(headers, allowOrigin);
+
+  return response;
+};
+
+export const createPreflightResponse = (
+  request: Request,
+  allowedOrigins: string[],
+): Response => {
+  const response = new Response(null, { status: 204 });
+  response.headers.set("Access-Control-Max-Age", "86400");
+  return applyCorsHeaders(request, response, allowedOrigins);
+};
+

--- a/services/licensing/src/http/router.ts
+++ b/services/licensing/src/http/router.ts
@@ -1,0 +1,85 @@
+import { applyCorsHeaders, createPreflightResponse, parseAllowedOrigins } from "./cors";
+
+type RouteHandler = (
+  request: Request,
+  env: Record<string, unknown>,
+  ctx: ExecutionContext,
+) => Promise<Response> | Response;
+
+interface RouteDefinition {
+  method: string;
+  path: string;
+  handler: RouteHandler;
+}
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+};
+
+export class Router {
+  private readonly routes: RouteDefinition[] = [];
+
+  get(path: string, handler: RouteHandler): this {
+    return this.add("GET", path, handler);
+  }
+
+  post(path: string, handler: RouteHandler): this {
+    return this.add("POST", path, handler);
+  }
+
+  private add(method: string, path: string, handler: RouteHandler): this {
+    this.routes.push({ method: method.toUpperCase(), path, handler });
+    return this;
+  }
+
+  async handle(request: Request, env: Record<string, unknown>, ctx: ExecutionContext): Promise<Response> {
+    const allowedOrigins = parseAllowedOrigins(env);
+    const method = request.method.toUpperCase();
+
+    if (method === "OPTIONS") {
+      const requestedMethod = request.headers.get("Access-Control-Request-Method")?.toUpperCase();
+
+      if (!requestedMethod || requestedMethod === "GET" || requestedMethod === "POST") {
+        return createPreflightResponse(request, allowedOrigins);
+      }
+
+      const methodNotAllowed = new Response(null, { status: 405 });
+      methodNotAllowed.headers.set("Allow", "GET, POST, OPTIONS");
+      return applyCorsHeaders(request, methodNotAllowed, allowedOrigins);
+    }
+
+    const url = new URL(request.url);
+    const path = url.pathname;
+    const route = this.routes.find((entry) => entry.method === method && entry.path === path);
+
+    let response: Response;
+
+    if (!route) {
+      response = jsonResponse({ error: "Not found" }, { status: 404 });
+    } else {
+      try {
+        const result = await route.handler(request, env, ctx);
+
+        if (result instanceof Response) {
+          response = result;
+        } else {
+          response = jsonResponse({ error: "internal_error" }, { status: 500 });
+        }
+      } catch (error) {
+        console.error("Unhandled error while processing request", error);
+        response = jsonResponse({ error: "internal_error" }, { status: 500 });
+      }
+    }
+
+    return applyCorsHeaders(request, response, allowedOrigins);
+  }
+}
+
+export const createRouter = (): Router => new Router();
+


### PR DESCRIPTION
## Summary
- add HTTP CORS utilities that read CORS_ALLOW_ORIGINS and build shared headers
- route licensing requests through a centralized router that serves GET/POST preflight responses and wraps every response with CORS headers
- document the CORS_ALLOW_ORIGINS environment variable for the worker

## Testing
- pytest *(fails: missing httpx and libGL system dependency in test environment)*
- npx --yes cspell --config cspell.json "**/*.md"

------
https://chatgpt.com/codex/tasks/task_e_68db11a460f08323b536aae3243d8e42