### PR TITLE
Add paid license transfer workflow to licensing worker

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,6 +49,10 @@ Atropos is composed of three cooperating runtimes:
 - `SERVER_ENV` / `ENVIRONMENT` → Python services → selects credentials in `server/config.py` and toggles webhook hosts.
 - `LICENSING_ENV` → Worker → selects Stripe keys and KV namespace bindings.
 - `CORS_ALLOW_ORIGINS` → Worker → comma-separated origins allowed for CORS responses (defaults to `*`).
+- `RESEND_API_KEY` → Worker → Resend credential used when emailing license transfer approvals.
+- `APP_DOWNLOAD_URL` → Worker → Download page shown in license transfer flows (defaults to the production marketing URL).
+- `DEEPLINK_SCHEME` → Worker → Desktop deep link scheme used for transfer acceptance (defaults to `atropos`).
+- `TRANSFER_LINK_TTL_SECONDS` → Worker → Expiration window for transfer approval tokens (defaults to 900 seconds).
 
 ### Cloudflare worker environments
 

--- a/services/licensing/README.md
+++ b/services/licensing/README.md
@@ -7,6 +7,10 @@ The licensing service is a Cloudflare Worker that verifies device entitlements, 
 | Path | Method | Description |
 | --- | --- | --- |
 | `/license/verify` | `POST` | Validates a device + license token, returning a signed entitlement JWT. |
+| `/license/issue` | `POST` | Issues a short-lived license token bound to a device fingerprint. |
+| `/transfer/initiate` | `POST` | Starts a paid license transfer by emailing a one-time approval link. |
+| `/transfer/accept` | `GET` | HTML shim that launches the desktop deep link for approving a transfer. |
+| `/transfer/accept` | `POST` | Completes an approved transfer, rebinding the license to a new device. |
 | `/trial/consume` | `POST` | Consumes one trial credit for a device and returns remaining quota. |
 | `/billing/webhook` | `POST` | Stripe webhook endpoint that updates subscription status and KV state. |
 | `/billing/portal` | `GET` | Generates a Stripe customer portal link for account management. |
@@ -21,6 +25,10 @@ Configure secrets via `wrangler secret` or environment variables in CI:
 - `KV_LICENSE_NAMESPACE` (Workers KV binding name)
 - `TRIAL_MAX_PER_DEVICE` (default `3`)
 - `CORS_ALLOW_ORIGINS` (comma-separated list of allowed origins for CORS responses; defaults to `*`)
+- `RESEND_API_KEY` (Resend email API token used for transfer notifications)
+- `APP_DOWNLOAD_URL` (desktop download URL surfaced in transfer shims and emails)
+- `DEEPLINK_SCHEME` (custom deep link scheme for launching the desktop client; defaults to `atropos`)
+- `TRANSFER_LINK_TTL_SECONDS` (lifetime for transfer approval links; defaults to 900 seconds)
 
 ## Development vs production
 

--- a/services/licensing/src/email/sender.ts
+++ b/services/licensing/src/email/sender.ts
@@ -1,0 +1,88 @@
+export interface EmailSenderEnv extends Record<string, unknown> {
+  RESEND_API_KEY?: string;
+}
+
+export interface SendEmailPayload {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+  from?: string;
+  replyTo?: string;
+}
+
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+const DEFAULT_FROM_ADDRESS = "Atropos <no-reply@atropos.app>";
+
+interface ResendSuccessResponse {
+  id: string;
+}
+
+interface ResendErrorResponse {
+  name?: string;
+  message?: string;
+}
+
+export class EmailDeliveryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EmailDeliveryError";
+  }
+}
+
+const parseApiKey = (env: EmailSenderEnv): string => {
+  const apiKey = env.RESEND_API_KEY;
+
+  if (typeof apiKey !== "string" || apiKey.trim().length === 0) {
+    throw new EmailDeliveryError("RESEND_API_KEY is not configured");
+  }
+
+  return apiKey.trim();
+};
+
+export const sendEmail = async (
+  env: EmailSenderEnv,
+  payload: SendEmailPayload,
+): Promise<ResendSuccessResponse> => {
+  const apiKey = parseApiKey(env);
+
+  const body: Record<string, unknown> = {
+    from: payload.from ?? DEFAULT_FROM_ADDRESS,
+    to: [payload.to],
+    subject: payload.subject,
+    html: payload.html,
+  };
+
+  if (payload.text) {
+    body.text = payload.text;
+  }
+
+  if (payload.replyTo) {
+    body.reply_to = payload.replyTo;
+  }
+
+  const response = await fetch(RESEND_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (response.ok) {
+    const data = (await response.json()) as ResendSuccessResponse;
+    return data;
+  }
+
+  let detail = await response.text();
+
+  try {
+    const parsed = JSON.parse(detail) as ResendErrorResponse;
+    detail = parsed.message ?? JSON.stringify(parsed);
+  } catch (error) {
+    // ignore parse error and use raw text
+  }
+
+  throw new EmailDeliveryError(`Resend API error (${response.status}): ${detail}`);
+};

--- a/services/licensing/src/email/templates.ts
+++ b/services/licensing/src/email/templates.ts
@@ -1,0 +1,114 @@
+interface TransferEmailTemplateOptions {
+  acceptUrl: string;
+  deepLinkUrl: string;
+  downloadUrl: string;
+  expiresInMinutes: number;
+}
+
+interface EmailTemplateResult {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+const escapeHtml = (value: string): string => {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+};
+
+export const createTransferEmailTemplate = (
+  options: TransferEmailTemplateOptions,
+): EmailTemplateResult => {
+  const expiresLabel = options.expiresInMinutes === 1 ? "1 minute" : `${options.expiresInMinutes} minutes`;
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Confirm your Atropos license transfer</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+        background-color: #f7f7f8;
+        color: #111827;
+        padding: 0;
+        margin: 0;
+      }
+      .container {
+        max-width: 560px;
+        margin: 0 auto;
+        padding: 32px 24px;
+        background-color: #ffffff;
+      }
+      h1 {
+        font-size: 20px;
+        margin-bottom: 16px;
+      }
+      p {
+        line-height: 1.5;
+        margin: 12px 0;
+      }
+      a.button {
+        display: inline-block;
+        padding: 12px 20px;
+        margin: 20px 0;
+        background-color: #111827;
+        color: #ffffff !important;
+        text-decoration: none;
+        border-radius: 6px;
+        font-weight: 600;
+      }
+      .note {
+        font-size: 14px;
+        color: #4b5563;
+      }
+      .code {
+        font-family: "SFMono-Regular", ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        word-break: break-all;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Confirm your license transfer</h1>
+      <p>We received a request to move your Atropos license to a new device. Approve the transfer to continue using the app.</p>
+      <p>
+        <a href="${escapeHtml(options.acceptUrl)}" class="button">Open Atropos to approve transfer</a>
+      </p>
+      <p class="note">If the button doesn't open the desktop app, try the direct link:</p>
+      <p class="code">
+        <a href="${escapeHtml(options.deepLinkUrl)}">${escapeHtml(options.deepLinkUrl)}</a>
+      </p>
+      <p class="note">You can also copy and paste this URL into a browser if you're on the same computer:</p>
+      <p class="code">
+        <a href="${escapeHtml(options.acceptUrl)}">${escapeHtml(options.acceptUrl)}</a>
+      </p>
+      <p>This approval link expires in ${expiresLabel}.</p>
+      <p class="note">
+        Need the app on this device? <a href="${escapeHtml(options.downloadUrl)}">Download Atropos</a> and sign in with your account.
+      </p>
+      <p class="note">If you didn't request this, you can safely ignore the email.</p>
+    </div>
+  </body>
+</html>`;
+
+  const text = [
+    "We received a request to move your Atropos license to a new device.",
+    `Approve the transfer: ${options.acceptUrl}`,
+    `Direct deep link: ${options.deepLinkUrl}`,
+    `Download Atropos: ${options.downloadUrl}`,
+    `This link expires in ${expiresLabel}.`,
+    "If you didn't request this, ignore this email.",
+  ].join("\n\n");
+
+  return {
+    subject: "Confirm your Atropos license transfer",
+    html,
+    text,
+  };
+};

--- a/services/licensing/src/index.ts
+++ b/services/licensing/src/index.ts
@@ -8,6 +8,9 @@ import { handlePublicKeyRequest } from "./license/keys";
 import { handleTrialStartRequest } from "./trial/start";
 import { handleTrialClaimRequest } from "./trial/claim";
 import { handleTrialConsumeRequest } from "./trial/consume";
+import { handleTransferInitiateRequest } from "./transfer/initiate";
+import { handleTransferAcceptView } from "./transfer/accept";
+import { handleTransferCompleteRequest } from "./transfer/complete";
 import { createRouter } from "./http/router";
 
 const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
@@ -33,6 +36,9 @@ router.get("/license/public-key", handlePublicKeyRequest);
 router.post("/trial/start", handleTrialStartRequest);
 router.post("/trial/claim", handleTrialClaimRequest);
 router.post("/trial/consume", handleTrialConsumeRequest);
+router.post("/transfer/initiate", handleTransferInitiateRequest);
+router.get("/transfer/accept", handleTransferAcceptView);
+router.post("/transfer/accept", handleTransferCompleteRequest);
 
 export default {
   async fetch(request: Request, env: Record<string, unknown>, ctx: ExecutionContext) {

--- a/services/licensing/src/transfer/accept.ts
+++ b/services/licensing/src/transfer/accept.ts
@@ -1,0 +1,113 @@
+import { resolveDeepLinkScheme, resolveDownloadUrl, TransferEnvConfig } from "./common";
+
+interface TransferAcceptEnv extends TransferEnvConfig {}
+
+const htmlResponse = (content: string, status = 200): Response => {
+  return new Response(content, {
+    status,
+    headers: {
+      "Content-Type": "text/html; charset=UTF-8",
+    },
+  });
+};
+
+export const handleTransferAcceptView = (
+  request: Request,
+  env: TransferAcceptEnv,
+): Response => {
+  const url = new URL(request.url);
+  const userId = url.searchParams.get("user_id")?.trim();
+  const token = url.searchParams.get("token")?.trim();
+
+  if (!userId || !token) {
+    return htmlResponse("<h1>Missing transfer parameters</h1>", 400);
+  }
+
+  const scheme = resolveDeepLinkScheme(env);
+  const deepLink = `${scheme}://accept-transfer?user_id=${encodeURIComponent(userId)}&token=${encodeURIComponent(token)}`;
+  const downloadUrl = resolveDownloadUrl(env);
+
+  const escapeHtml = (value: string): string =>
+    value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+
+  const escapedDeepLink = escapeHtml(deepLink);
+  const escapedDownloadUrl = escapeHtml(downloadUrl);
+
+  const body = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Open Atropos</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+        color: #111827;
+        margin: 0;
+        padding: 40px 16px;
+        background-color: #f7f7f8;
+      }
+      .container {
+        max-width: 520px;
+        margin: 0 auto;
+        background: #ffffff;
+        padding: 32px 24px;
+        border-radius: 12px;
+        box-shadow: 0 12px 30px rgba(17, 24, 39, 0.08);
+        text-align: center;
+      }
+      h1 {
+        font-size: 22px;
+        margin-bottom: 16px;
+      }
+      p {
+        font-size: 16px;
+        line-height: 1.6;
+        margin: 12px 0;
+      }
+      a.button {
+        display: inline-block;
+        margin: 24px 0;
+        padding: 12px 20px;
+        background-color: #111827;
+        color: #ffffff;
+        text-decoration: none;
+        border-radius: 6px;
+        font-weight: 600;
+      }
+      .muted {
+        color: #6b7280;
+        font-size: 14px;
+      }
+    </style>
+    <script>
+      window.addEventListener('load', function () {
+        const target = ${JSON.stringify(deepLink)};
+        window.location.href = target;
+        setTimeout(function () {
+          document.getElementById('manual-link').style.display = 'inline-block';
+        }, 1500);
+      });
+    </script>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Open Atropos to finish your transfer</h1>
+      <p>We're opening the Atropos desktop app so you can approve this license transfer.</p>
+      <p>
+        <a id="manual-link" class="button" href="${escapedDeepLink}" style="display:none">Open Atropos</a>
+      </p>
+      <p class="muted">If nothing happens, click the button above or copy and paste this link into your browser:</p>
+      <p class="muted"><code>${escapedDeepLink}</code></p>
+      <p class="muted">Need the app on this device? <a href="${escapedDownloadUrl}">Download Atropos</a>.</p>
+    </div>
+  </body>
+</html>`;
+
+  return htmlResponse(body);
+};

--- a/services/licensing/src/transfer/common.ts
+++ b/services/licensing/src/transfer/common.ts
@@ -1,0 +1,57 @@
+import { TransferState } from "../kv";
+
+export interface TransferEnvConfig extends Record<string, unknown> {
+  TRANSFER_LINK_TTL_SECONDS?: number | string;
+  DEEPLINK_SCHEME?: string;
+  APP_DOWNLOAD_URL?: string;
+}
+
+const DEFAULT_TRANSFER_TTL_SECONDS = 15 * 60;
+const DEFAULT_DEEPLINK_SCHEME = "atropos";
+const DEFAULT_DOWNLOAD_URL = "https://atropos-video.com/download";
+
+export const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+};
+
+export const resolveTransferTtlSeconds = (env: TransferEnvConfig): number => {
+  const raw = env.TRANSFER_LINK_TTL_SECONDS;
+
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return Math.max(60, Math.floor(raw));
+  }
+
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    const parsed = Number.parseInt(raw, 10);
+
+    if (Number.isFinite(parsed)) {
+      return Math.max(60, parsed);
+    }
+  }
+
+  return DEFAULT_TRANSFER_TTL_SECONDS;
+};
+
+export const resolveDeepLinkScheme = (env: TransferEnvConfig): string => {
+  const raw = typeof env.DEEPLINK_SCHEME === "string" ? env.DEEPLINK_SCHEME.trim() : "";
+  return raw.length > 0 ? raw : DEFAULT_DEEPLINK_SCHEME;
+};
+
+export const resolveDownloadUrl = (env: TransferEnvConfig): string => {
+  const raw = typeof env.APP_DOWNLOAD_URL === "string" ? env.APP_DOWNLOAD_URL.trim() : "";
+  return raw.length > 0 ? raw : DEFAULT_DOWNLOAD_URL;
+};
+
+export const clearedTransferState = (): TransferState => ({
+  pending: false,
+  jti: null,
+  exp: null,
+  email: null,
+  initiated_at: null,
+});

--- a/services/licensing/src/transfer/complete.ts
+++ b/services/licensing/src/transfer/complete.ts
@@ -1,0 +1,141 @@
+import { isEntitled, KVNamespace, UserRecord } from "../kv";
+import { mutateUserRecord } from "../kv/user";
+import { getSigningMaterial, signJwt } from "../lib/jwt";
+import { clearedTransferState, jsonResponse, TransferEnvConfig } from "./common";
+
+interface TransferCompleteEnv extends TransferEnvConfig {
+  LICENSING_KV: KVNamespace;
+  JWT_PRIVATE_KEY?: string;
+}
+
+interface TransferCompleteRequestBody {
+  user_id?: unknown;
+  token?: unknown;
+  device_hash?: unknown;
+}
+
+const determineTier = (record: UserRecord): string => {
+  if (record.plan_price_id) {
+    return record.plan_price_id;
+  }
+
+  const status = (record.status ?? "").toLowerCase();
+
+  if (status === "trialing") {
+    return "trial";
+  }
+
+  if (status === "active") {
+    return "paid";
+  }
+
+  return "free";
+};
+
+export const handleTransferCompleteRequest = async (
+  request: Request,
+  env: TransferCompleteEnv,
+): Promise<Response> => {
+  let body: TransferCompleteRequestBody;
+
+  try {
+    body = (await request.json()) as TransferCompleteRequestBody;
+  } catch (error) {
+    return jsonResponse({ error: "invalid_request", detail: "Body must be valid JSON" }, { status: 400 });
+  }
+
+  const userId = typeof body.user_id === "string" ? body.user_id.trim() : "";
+  const token = typeof body.token === "string" ? body.token.trim() : "";
+  const deviceHash = typeof body.device_hash === "string" ? body.device_hash.trim() : "";
+
+  if (!userId || !token || !deviceHash) {
+    return jsonResponse(
+      { error: "invalid_request", detail: "user_id, token, and device_hash are required" },
+      { status: 400 },
+    );
+  }
+
+  let nextEpoch: number | null = null;
+  let errorResponse: Response | null = null;
+
+  const record = await mutateUserRecord(env.LICENSING_KV, userId, ({ current, now }) => {
+    const transfer = current.transfer;
+
+    if (!transfer?.pending) {
+      errorResponse = jsonResponse({ error: "transfer_not_pending" }, { status: 404 });
+      return null;
+    }
+
+    if (!transfer.jti || transfer.jti !== token) {
+      errorResponse = jsonResponse({ error: "transfer_token_invalid" }, { status: 403 });
+      return null;
+    }
+
+    if (typeof transfer.exp !== "number" || transfer.exp <= now) {
+      errorResponse = jsonResponse({ error: "transfer_token_expired" }, { status: 410 });
+      return { transfer: clearedTransferState() };
+    }
+
+    if (!isEntitled(current.status, current.current_period_end)) {
+      errorResponse = jsonResponse({ error: "not_entitled" }, { status: 403 });
+      return { transfer: clearedTransferState() };
+    }
+
+    nextEpoch = (current.epoch ?? 0) + 1;
+
+    return {
+      device_hash: deviceHash,
+      epoch: nextEpoch,
+      transfer: clearedTransferState(),
+    };
+  });
+
+  if (errorResponse) {
+    return errorResponse;
+  }
+
+  if (!record || !record.device_hash || nextEpoch === null) {
+    return jsonResponse({ error: "transfer_completion_failed" }, { status: 500 });
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const issuedAt = now;
+  const expiresAt = issuedAt + 15 * 60;
+
+  let material: Awaited<ReturnType<typeof getSigningMaterial>>;
+
+  try {
+    material = await getSigningMaterial(env);
+  } catch (error) {
+    return jsonResponse({ error: "signing_unavailable" }, { status: 500 });
+  }
+
+  const payload = {
+    sub: userId,
+    email: record.email,
+    tier: determineTier(record),
+    device_hash: record.device_hash,
+    epoch: record.epoch ?? nextEpoch,
+    iat: issuedAt,
+    exp: expiresAt,
+  };
+
+  let signedToken: string;
+
+  try {
+    signedToken = await signJwt(payload, material);
+  } catch (error) {
+    return jsonResponse({ error: "signing_failed" }, { status: 500 });
+  }
+
+  return jsonResponse(
+    {
+      token: signedToken,
+      issued_at: issuedAt,
+      expires_at: expiresAt,
+      epoch: payload.epoch,
+      device_hash: payload.device_hash,
+    },
+    { status: 200 },
+  );
+};

--- a/services/licensing/src/transfer/initiate.ts
+++ b/services/licensing/src/transfer/initiate.ts
@@ -1,0 +1,213 @@
+import { getUserRecord, isEntitled, KVNamespace, TransferState, UserRecord } from "../kv";
+import { mutateUserRecord } from "../kv/user";
+import { getSigningMaterial, verifyJwt } from "../lib/jwt";
+import { EmailDeliveryError, sendEmail } from "../email/sender";
+import { createTransferEmailTemplate } from "../email/templates";
+import {
+  clearedTransferState,
+  jsonResponse,
+  resolveDeepLinkScheme,
+  resolveDownloadUrl,
+  resolveTransferTtlSeconds,
+  TransferEnvConfig,
+} from "./common";
+
+interface TransferInitiateEnv extends TransferEnvConfig {
+  LICENSING_KV: KVNamespace;
+  JWT_PRIVATE_KEY?: string;
+  RESEND_API_KEY?: string;
+}
+
+interface LicenseClaims extends Record<string, unknown> {
+  sub?: string;
+  device_hash?: string | null;
+  epoch?: number;
+  exp?: number;
+  tier?: string | null;
+}
+
+const extractBearerToken = (request: Request): string | null => {
+  const header = request.headers.get("authorization");
+
+  if (header) {
+    const [scheme, ...rest] = header.split(" ");
+
+    if (scheme && scheme.toLowerCase() === "bearer") {
+      const token = rest.join(" ").trim();
+
+      if (token.length > 0) {
+        return token;
+      }
+    }
+  }
+
+  const url = new URL(request.url);
+  const tokenParam = url.searchParams.get("token");
+
+  if (tokenParam && tokenParam.trim().length > 0) {
+    return tokenParam.trim();
+  }
+
+  return null;
+};
+
+const isPaidSubscription = (record: UserRecord): boolean => {
+  const status = (record.status ?? "").toLowerCase();
+  if (status === "active") {
+    return true;
+  }
+
+  if (record.plan_price_id) {
+    return true;
+  }
+
+  return false;
+};
+
+export const handleTransferInitiateRequest = async (
+  request: Request,
+  env: TransferInitiateEnv,
+): Promise<Response> => {
+  const token = extractBearerToken(request);
+
+  if (!token) {
+    return jsonResponse({ error: "missing_token" }, { status: 401 });
+  }
+
+  let claims: LicenseClaims;
+
+  try {
+    const material = await getSigningMaterial(env);
+    const verification = await verifyJwt(token, material);
+    claims = verification.payload as LicenseClaims;
+  } catch (error) {
+    return jsonResponse({ error: "invalid_token" }, { status: 401 });
+  }
+
+  if (!claims || typeof claims !== "object") {
+    return jsonResponse({ error: "invalid_token" }, { status: 401 });
+  }
+
+  if (typeof claims.sub !== "string" || claims.sub.trim().length === 0) {
+    return jsonResponse({ error: "invalid_subject" }, { status: 400 });
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  if (typeof claims.exp !== "number" || Number.isNaN(claims.exp) || claims.exp <= now) {
+    return jsonResponse({ error: "token_expired" }, { status: 401 });
+  }
+
+  const userId = claims.sub;
+  const record = await getUserRecord(env.LICENSING_KV, userId);
+
+  if (!record) {
+    return jsonResponse({ error: "user_not_found" }, { status: 404 });
+  }
+
+  let jti: string | null = null;
+  let expiresAt: number | null = null;
+  let recipientEmail: string | null = null;
+  let errorResponse: Response | null = null;
+
+  const ttlSeconds = resolveTransferTtlSeconds(env);
+
+  await mutateUserRecord(env.LICENSING_KV, userId, ({ current, now: mutationNow }) => {
+    if (!isEntitled(current.status, current.current_period_end)) {
+      errorResponse = jsonResponse({ error: "not_entitled" }, { status: 403 });
+      return null;
+    }
+
+    if (!isPaidSubscription(current)) {
+      errorResponse = jsonResponse({ error: "subscription_required" }, { status: 403 });
+      return null;
+    }
+
+    if (!current.device_hash || current.device_hash !== claims.device_hash) {
+      errorResponse = jsonResponse({ error: "device_mismatch" }, { status: 409 });
+      return null;
+    }
+
+    if (
+      typeof current.epoch === "number" &&
+      typeof claims.epoch === "number" &&
+      current.epoch !== claims.epoch
+    ) {
+      errorResponse = jsonResponse({ error: "stale_epoch" }, { status: 409 });
+      return null;
+    }
+
+    if (!current.email) {
+      errorResponse = jsonResponse({ error: "email_not_found" }, { status: 400 });
+      return null;
+    }
+
+    const existingTransfer = current.transfer;
+    if (existingTransfer?.pending && typeof existingTransfer.exp === "number" && existingTransfer.exp > mutationNow) {
+      errorResponse = jsonResponse({ error: "transfer_already_pending" }, { status: 409 });
+      return null;
+    }
+
+    jti = crypto.randomUUID();
+    expiresAt = mutationNow + ttlSeconds;
+    recipientEmail = current.email;
+
+    const transferState: TransferState = {
+      pending: true,
+      jti,
+      exp: expiresAt,
+      email: current.email,
+      initiated_at: mutationNow,
+    };
+
+    return { transfer: transferState };
+  });
+
+  if (errorResponse) {
+    return errorResponse;
+  }
+
+  if (!jti || !expiresAt || !recipientEmail) {
+    return jsonResponse({ error: "transfer_initialization_failed" }, { status: 500 });
+  }
+
+  const origin = new URL(request.url).origin;
+  const acceptUrl = `${origin}/transfer/accept?user_id=${encodeURIComponent(userId)}&token=${encodeURIComponent(jti)}`;
+  const deepLinkScheme = resolveDeepLinkScheme(env);
+  const deepLinkUrl = `${deepLinkScheme}://accept-transfer?user_id=${encodeURIComponent(userId)}&token=${encodeURIComponent(
+    jti,
+  )}`;
+  const downloadUrl = resolveDownloadUrl(env);
+  const { subject, html, text } = createTransferEmailTemplate({
+    acceptUrl,
+    deepLinkUrl,
+    downloadUrl,
+    expiresInMinutes: Math.max(1, Math.round(ttlSeconds / 60)),
+  });
+
+  try {
+    await sendEmail(env, {
+      to: recipientEmail,
+      subject,
+      html,
+      text,
+    });
+  } catch (error) {
+    console.error("Failed to send transfer email", error);
+    await mutateUserRecord(env.LICENSING_KV, userId, () => ({ transfer: clearedTransferState() }));
+
+    const status = error instanceof EmailDeliveryError ? 502 : 500;
+    const detail = error instanceof EmailDeliveryError ? error.message : "email_failed";
+    return jsonResponse({ error: "transfer_email_failed", detail }, { status });
+  }
+
+  return jsonResponse(
+    {
+      transfer: {
+        status: "pending",
+        expires_at: expiresAt,
+      },
+    },
+    { status: 200 },
+  );
+};


### PR DESCRIPTION
## Summary
- add a Resend-backed email sender and transfer email template for license handoffs
- implement transfer initiate, accept, and completion handlers with shared helpers and routing
- document the new endpoints and environment variables required for the transfer flow

## Testing
- pytest *(fails: missing httpx package and libGL runtime in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe7cba8688323b2bba2ec3f2aa558