### PR TITLE
Add licensing API client and deep link handling

### DIFF
--- a/desktop/src/lib/accessStore.ts
+++ b/desktop/src/lib/accessStore.ts
@@ -1,0 +1,514 @@
+import { ApiClient, ApiError, getDefaultApiClient, type Logger } from './apiClient'
+
+export type AccessStatus = 'idle' | 'loading' | 'entitled' | 'not_entitled' | 'error'
+
+export interface AccessIdentity {
+  userId: string
+  deviceHash: string
+}
+
+export interface TrialSnapshot {
+  allowed: number
+  startedAt: number | null
+  total: number
+  remaining: number
+  usedAt: number | null
+  deviceHash: string | null
+  tokenId: string | null
+  expiresAt: number | null
+}
+
+export interface SubscriptionSnapshot {
+  status: string | null
+  entitled: boolean
+  currentPeriodEnd: number | null
+  cancelAtPeriodEnd: boolean
+  trial: TrialSnapshot | null
+  fetchedAt: number
+}
+
+export interface LicenseTokenSnapshot {
+  token: string
+  issuedAt: number
+  expiresAt: number
+  epoch: number
+  deviceHash: string
+}
+
+export interface AccessSnapshot {
+  status: AccessStatus
+  subscription: SubscriptionSnapshot | null
+  license: LicenseTokenSnapshot | null
+  identity: AccessIdentity | null
+  lastError: string | null
+  lastCheckedAt: number | null
+  isRefreshing: boolean
+}
+
+export interface AccessStoreListener {
+  (snapshot: AccessSnapshot): void
+}
+
+export interface AccessStoreOptions {
+  identity?: AccessIdentity | null
+  client?: ApiClient
+  logger?: Logger
+  autoStart?: boolean
+  now?: () => number
+}
+
+interface SubscriptionResponseBody {
+  status?: string | null
+  entitled?: boolean
+  current_period_end?: number | null
+  cancel_at_period_end?: boolean
+  trial?: TrialResponseBody | null
+}
+
+interface TrialResponseBody {
+  allowed?: number
+  started?: number | null
+  total?: number
+  remaining?: number
+  used_at?: number | null
+  device_hash?: string | null
+  jti?: string | null
+  exp?: number | null
+}
+
+interface LicenseIssueResponseBody {
+  token: string
+  issued_at: number
+  expires_at: number
+  epoch: number
+  device_hash: string
+}
+
+const DEFAULT_SNAPSHOT: AccessSnapshot = {
+  status: 'idle',
+  subscription: null,
+  license: null,
+  identity: null,
+  lastError: null,
+  lastCheckedAt: null,
+  isRefreshing: false
+}
+
+const IDENTITY_USER_KEYS = ['ATROPOS_USER_ID', 'VITE_USER_ID', 'USER_ID']
+const IDENTITY_DEVICE_KEYS = ['ATROPOS_DEVICE_HASH', 'VITE_DEVICE_HASH', 'DEVICE_HASH']
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0
+
+const readImportMetaEnv = (key: string): string | undefined => {
+  if (typeof import.meta === 'undefined') {
+    return undefined
+  }
+  try {
+    const meta = import.meta as unknown as { env?: Record<string, unknown> }
+    const candidate = meta?.env?.[key]
+    return isNonEmptyString(candidate) ? candidate : undefined
+  } catch (error) {
+    return undefined
+  }
+}
+
+const readEnv = (key: string): string | undefined => {
+  if (typeof process !== 'undefined' && process.env && isNonEmptyString(process.env[key])) {
+    return process.env[key]
+  }
+  return readImportMetaEnv(key)
+}
+
+const resolveIdentityFromEnvironment = (): AccessIdentity | null => {
+  const userIdCandidate = IDENTITY_USER_KEYS.map(readEnv).find(isNonEmptyString)
+  const deviceHashCandidate = IDENTITY_DEVICE_KEYS.map(readEnv).find(isNonEmptyString)
+  if (!userIdCandidate || !deviceHashCandidate) {
+    return null
+  }
+  return {
+    userId: userIdCandidate.trim(),
+    deviceHash: deviceHashCandidate.trim()
+  }
+}
+
+const cloneIdentity = (identity: AccessIdentity | null): AccessIdentity | null => {
+  if (!identity) {
+    return null
+  }
+  return { ...identity }
+}
+
+const cloneTrial = (trial: TrialSnapshot | null): TrialSnapshot | null => {
+  if (!trial) {
+    return null
+  }
+  return { ...trial }
+}
+
+const cloneLicense = (license: LicenseTokenSnapshot | null): LicenseTokenSnapshot | null => {
+  if (!license) {
+    return null
+  }
+  return { ...license }
+}
+
+const mapTrial = (trial: TrialResponseBody | null | undefined): TrialSnapshot | null => {
+  if (!trial) {
+    return null
+  }
+  return {
+    allowed: Math.max(0, trial.allowed ?? 0),
+    startedAt: trial.started ?? null,
+    total: Math.max(trial.total ?? trial.allowed ?? 0, trial.allowed ?? 0),
+    remaining: Math.max(0, trial.remaining ?? trial.total ?? trial.allowed ?? 0),
+    usedAt: trial.used_at ?? null,
+    deviceHash: trial.device_hash ?? null,
+    tokenId: trial.jti ?? null,
+    expiresAt: trial.exp ?? null
+  }
+}
+
+const describeError = (error: unknown, fallback: string): string => {
+  if (error instanceof ApiError) {
+    const detail =
+      error.body && typeof error.body === 'object' && error.body !== null
+        ? (error.body as { detail?: unknown }).detail
+        : undefined
+    if (isNonEmptyString(detail)) {
+      return detail
+    }
+    return `Request failed with status ${error.status}`
+  }
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  return fallback
+}
+
+const nowSeconds = (now: () => number): number => Math.floor(now() / 1000)
+
+export class AccessStore {
+  private snapshot: AccessSnapshot
+
+  private readonly listeners = new Set<AccessStoreListener>()
+
+  private readonly client: ApiClient
+
+  private identity: AccessIdentity | null
+
+  private readonly logger: Logger
+
+  private refreshPromise: Promise<void> | null = null
+
+  private issuePromise: Promise<string | null> | null = null
+
+  private readonly now: () => number
+
+  constructor(options?: AccessStoreOptions) {
+    this.client = options?.client ?? getDefaultApiClient()
+    this.identity = cloneIdentity(options?.identity ?? resolveIdentityFromEnvironment())
+    this.logger = options?.logger ?? console
+    this.now = options?.now ?? Date.now
+    this.snapshot = {
+      ...DEFAULT_SNAPSHOT,
+      identity: cloneIdentity(this.identity),
+      status: this.identity ? 'idle' : 'error',
+      lastError: this.identity ? null : 'Licensing identity is not configured.'
+    }
+    if (options?.autoStart ?? true) {
+      void this.refresh()
+    }
+  }
+
+  getSnapshot(): AccessSnapshot {
+    return {
+      ...this.snapshot,
+      identity: cloneIdentity(this.snapshot.identity),
+      subscription: this.snapshot.subscription ? { ...this.snapshot.subscription, trial: cloneTrial(this.snapshot.subscription.trial) } : null,
+      license: cloneLicense(this.snapshot.license)
+    }
+  }
+
+  subscribe(listener: AccessStoreListener): () => void {
+    this.listeners.add(listener)
+    try {
+      listener(this.getSnapshot())
+    } catch (error) {
+      this.logger.error?.('Access store listener threw during initial emit', error)
+    }
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  setIdentity(identity: AccessIdentity | null, options?: { refresh?: boolean; invalidateLicense?: boolean }): void {
+    this.identity = cloneIdentity(identity)
+    const hasIdentity = Boolean(this.identity)
+    this.updateSnapshot({
+      identity: cloneIdentity(this.identity),
+      status: hasIdentity ? (this.snapshot.status === 'error' ? 'idle' : this.snapshot.status) : 'error',
+      lastError: hasIdentity ? null : 'Licensing identity is not configured.'
+    })
+    if (!hasIdentity && (options?.invalidateLicense ?? true)) {
+      this.clearLicenseToken()
+    }
+    if (hasIdentity && options?.refresh !== false) {
+      void this.refresh()
+    }
+  }
+
+  async refresh(options?: { force?: boolean }): Promise<void> {
+    if (this.refreshPromise) {
+      return this.refreshPromise
+    }
+    if (!this.identity) {
+      this.updateSnapshot({
+        status: 'error',
+        lastError: 'Licensing identity is not configured.',
+        isRefreshing: false,
+        identity: null
+      })
+      return
+    }
+    this.updateSnapshot({
+      isRefreshing: true,
+      status: this.snapshot.status === 'idle' ? 'loading' : this.snapshot.status,
+      lastError: null,
+      identity: cloneIdentity(this.identity)
+    })
+
+    const performRefresh = async (): Promise<void> => {
+      try {
+        const response = await this.client.get<SubscriptionResponseBody>('/billing/subscription', {
+          query: {
+            user_id: this.identity?.userId ?? '',
+            force: options?.force ? 'true' : undefined
+          }
+        })
+        const subscription = this.mapSubscription(response)
+        this.updateSnapshot({
+          subscription,
+          lastCheckedAt: subscription?.fetchedAt ?? this.now(),
+          status: subscription?.entitled ? 'entitled' : 'not_entitled',
+          lastError: null,
+          isRefreshing: false
+        })
+        if (!subscription?.entitled) {
+          this.clearLicenseToken()
+          return
+        }
+        await this.issueLicenseToken({ reason: 'subscription_refresh' })
+      } catch (error) {
+        this.handleSubscriptionError(error, options)
+      } finally {
+        this.refreshPromise = null
+        this.updateSnapshot({ isRefreshing: false })
+      }
+    }
+
+    const promise = performRefresh()
+    this.refreshPromise = promise
+    return promise
+  }
+
+  async ensureLicenseToken(): Promise<string | null> {
+    if (this.refreshPromise) {
+      try {
+        await this.refreshPromise
+      } catch (error) {
+        // ignore refresh errors; we'll attempt issuance regardless
+      }
+    }
+
+    if (!this.identity) {
+      this.logger.warn?.('Cannot issue license token without identity.')
+      return null
+    }
+
+    const subscription = this.snapshot.subscription
+    if (!subscription || !subscription.entitled) {
+      return null
+    }
+
+    const license = this.snapshot.license
+    const now = nowSeconds(this.now)
+    if (license && license.expiresAt > now) {
+      return license.token
+    }
+
+    if (license && license.expiresAt <= now) {
+      this.logger.info?.('License token expired; requesting a new token.')
+      this.clearLicenseToken()
+    }
+
+    return this.issueLicenseToken({ reason: 'ensure_token' })
+  }
+
+  reportUnauthorized(): void {
+    if (!this.snapshot.subscription || !this.snapshot.subscription.entitled) {
+      return
+    }
+    this.logger.warn?.('License token rejected by the API. Attempting to refresh.')
+    this.clearLicenseToken()
+    void this.issueLicenseToken({ reason: 'unauthorized' })
+  }
+
+  private updateSnapshot(partial: Partial<AccessSnapshot>): void {
+    this.snapshot = {
+      ...this.snapshot,
+      ...partial,
+      identity: partial.identity !== undefined ? cloneIdentity(partial.identity) : cloneIdentity(this.snapshot.identity),
+      subscription:
+        partial.subscription !== undefined
+          ? partial.subscription
+            ? { ...partial.subscription, trial: cloneTrial(partial.subscription.trial) }
+            : null
+          : this.snapshot.subscription
+          ? { ...this.snapshot.subscription, trial: cloneTrial(this.snapshot.subscription.trial) }
+          : null,
+      license: partial.license !== undefined ? cloneLicense(partial.license) : cloneLicense(this.snapshot.license)
+    }
+    for (const listener of this.listeners) {
+      try {
+        listener(this.getSnapshot())
+      } catch (error) {
+        this.logger.error?.('Access store listener threw during update', error)
+      }
+    }
+  }
+
+  private clearLicenseToken(): void {
+    if (!this.snapshot.license) {
+      return
+    }
+    this.updateSnapshot({ license: null })
+  }
+
+  private mapSubscription(body: SubscriptionResponseBody | null | undefined): SubscriptionSnapshot | null {
+    if (!body) {
+      return null
+    }
+    const fetchedAt = this.now()
+    return {
+      status: body.status ?? null,
+      entitled: Boolean(body.entitled),
+      currentPeriodEnd: typeof body.current_period_end === 'number' ? body.current_period_end : null,
+      cancelAtPeriodEnd: Boolean(body.cancel_at_period_end),
+      trial: mapTrial(body.trial),
+      fetchedAt
+    }
+  }
+
+  private async issueLicenseToken(options?: { reason?: string }): Promise<string | null> {
+    if (!this.identity) {
+      this.logger.warn?.('Cannot issue license token without identity.')
+      return null
+    }
+    if (this.issuePromise) {
+      return this.issuePromise
+    }
+    const subscription = this.snapshot.subscription
+    if (!subscription || !subscription.entitled) {
+      return null
+    }
+
+    const promise = (async (): Promise<string | null> => {
+      try {
+        const response = await this.client.post<LicenseIssueResponseBody>('/license/issue', {
+          user_id: this.identity?.userId ?? '',
+          device_hash: this.identity?.deviceHash ?? ''
+        })
+        const license: LicenseTokenSnapshot = {
+          token: response.token,
+          issuedAt: response.issued_at,
+          expiresAt: response.expires_at,
+          epoch: response.epoch,
+          deviceHash: response.device_hash
+        }
+        this.updateSnapshot({ license, status: 'entitled', lastError: null })
+        return license.token
+      } catch (error) {
+        this.handleLicenseError(error, options)
+        return null
+      } finally {
+        this.issuePromise = null
+      }
+    })()
+
+    this.issuePromise = promise
+    return promise
+  }
+
+  private handleSubscriptionError(error: unknown, options?: { force?: boolean }): void {
+    if (error instanceof ApiError && error.status === 404) {
+      this.logger.info?.('No active subscription found for the current user.')
+      this.clearLicenseToken()
+      this.updateSnapshot({
+        subscription: null,
+        status: 'not_entitled',
+        lastError: null
+      })
+      return
+    }
+    if (error instanceof ApiError && error.status === 403 && options?.force) {
+      const message = describeError(error, 'Force refresh is not permitted in this environment.')
+      this.updateSnapshot({
+        lastError: message
+      })
+      return
+    }
+    const message = describeError(error, 'Unable to load subscription details.')
+    this.logger.error?.('Failed to refresh subscription', error)
+    this.updateSnapshot({
+      lastError: message,
+      status: this.snapshot.status === 'idle' ? 'error' : this.snapshot.status
+    })
+  }
+
+  private handleLicenseError(error: unknown, options?: { reason?: string }): void {
+    if (error instanceof ApiError) {
+      if (error.status === 403 || error.status === 404) {
+        const message = describeError(error, 'Device is not entitled to receive a license token.')
+        this.logger.warn?.('License issuance rejected: %s', message)
+        this.clearLicenseToken()
+        this.updateSnapshot({
+          status: 'not_entitled',
+          lastError: message
+        })
+        return
+      }
+      if (error.status === 409) {
+        const message = describeError(error, 'License is already bound to another device.')
+        this.logger.error?.('License issuance failed due to device conflict: %s', message)
+        this.clearLicenseToken()
+        this.updateSnapshot({
+          status: 'error',
+          lastError: message
+        })
+        return
+      }
+    }
+    const message = describeError(error, 'Failed to issue license token.')
+    this.logger.error?.('Unexpected error while issuing license token%s', options?.reason ? ` (${options.reason})` : '', error)
+    this.clearLicenseToken()
+    this.updateSnapshot({
+      status: 'error',
+      lastError: message
+    })
+  }
+}
+
+let defaultStore: AccessStore | null = null
+
+export const getAccessStore = (): AccessStore => {
+  if (!defaultStore) {
+    defaultStore = new AccessStore()
+  }
+  return defaultStore
+}
+
+export const accessStore = getAccessStore()

--- a/desktop/src/lib/apiClient.ts
+++ b/desktop/src/lib/apiClient.ts
@@ -1,0 +1,331 @@
+const DEFAULT_BASE_URLS = {
+  dev: 'https://dev.api.atropos-video.com',
+  prod: 'https://api.atropos-video.com'
+} as const
+
+export type ApiEnvironment = keyof typeof DEFAULT_BASE_URLS
+
+export interface Logger {
+  debug?: (...args: unknown[]) => void
+  info?: (...args: unknown[]) => void
+  warn?: (...args: unknown[]) => void
+  error?: (...args: unknown[]) => void
+}
+
+export interface ApiClientOptions {
+  baseUrl?: string
+  fetchImpl?: typeof fetch
+  logger?: Logger
+}
+
+export interface ApiRequestOptions extends Omit<RequestInit, 'body'> {
+  query?: Record<string, string | number | boolean | null | undefined>
+  body?: unknown
+}
+
+const ENVIRONMENT_KEYS = ['ATROPOS_ENV', 'ENVIRONMENT', 'NODE_ENV', 'VITE_RELEASE_CHANNEL', 'RELEASE_CHANNEL', 'MODE']
+const BASE_OVERRIDE_KEYS = [
+  'ATROPOS_API_BASE_URL',
+  'ATROPOS_LICENSE_API_BASE_URL',
+  'LICENSE_API_BASE_URL',
+  'VITE_LICENSE_API_BASE_URL',
+  'VITE_ATROPOS_API_BASE_URL'
+]
+const FLAG_CANDIDATES = ['--api-base', '--license-api-base', '--atropos-api-base']
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0
+
+const readImportMetaEnv = (key: string): string | undefined => {
+  if (typeof import.meta === 'undefined') {
+    return undefined
+  }
+  try {
+    const meta = import.meta as unknown as { env?: Record<string, unknown> }
+    const candidate = meta?.env?.[key]
+    return isNonEmptyString(candidate) ? candidate : undefined
+  } catch (error) {
+    return undefined
+  }
+}
+
+const readEnv = (key: string): string | undefined => {
+  if (typeof process !== 'undefined' && process.env && isNonEmptyString(process.env[key])) {
+    return process.env[key]
+  }
+  return readImportMetaEnv(key)
+}
+
+const takeFirstEnvValue = (keys: string[]): string | null => {
+  for (const key of keys) {
+    const value = readEnv(key)
+    if (isNonEmptyString(value)) {
+      return value.trim()
+    }
+  }
+  return null
+}
+
+const parseEnvironment = (value: string | null | undefined): ApiEnvironment | null => {
+  if (!value) {
+    return null
+  }
+  const normalized = value.trim().toLowerCase()
+  if (!normalized) {
+    return null
+  }
+  if (['prod', 'production', 'release', 'stable', 'beta', 'live'].includes(normalized)) {
+    return 'prod'
+  }
+  if (['dev', 'development', 'local', 'test', 'ci', 'staging', 'preview'].includes(normalized)) {
+    return 'dev'
+  }
+  return null
+}
+
+const normaliseBaseUrl = (value: string | null | undefined): string | null => {
+  if (!value) {
+    return null
+  }
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
+  try {
+    const url = new URL(withProtocol)
+    url.hash = ''
+    url.search = ''
+    return url.toString().replace(/\/$/, '')
+  } catch (error) {
+    return null
+  }
+}
+
+const inferEnvironmentFromUrl = (baseUrl: string | null | undefined): ApiEnvironment | null => {
+  const normalised = normaliseBaseUrl(baseUrl)
+  if (!normalised) {
+    return null
+  }
+  try {
+    const host = new URL(normalised).hostname.toLowerCase()
+    if (host.includes('dev.')) {
+      return 'dev'
+    }
+    if (host.includes('localhost') || host.startsWith('127.')) {
+      return 'dev'
+    }
+  } catch (error) {
+    return null
+  }
+  return null
+}
+
+const extractFlagValue = (flag: string, argv: string[]): string | null => {
+  const flagWithEquals = `${flag}=`
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index]
+    if (token === flag && index + 1 < argv.length) {
+      const next = argv[index + 1]
+      if (isNonEmptyString(next)) {
+        return next.trim()
+      }
+    }
+    if (token.startsWith(flagWithEquals)) {
+      const candidate = token.slice(flagWithEquals.length)
+      if (isNonEmptyString(candidate)) {
+        return candidate.trim()
+      }
+    }
+  }
+  return null
+}
+
+const readFlagOverride = (): string | null => {
+  if (typeof process === 'undefined' || !Array.isArray(process.argv)) {
+    return null
+  }
+  for (const flag of FLAG_CANDIDATES) {
+    const value = extractFlagValue(flag, process.argv)
+    if (value) {
+      return value
+    }
+  }
+  return null
+}
+
+const resolveEnvironment = (): ApiEnvironment => {
+  const envValue = parseEnvironment(takeFirstEnvValue(ENVIRONMENT_KEYS))
+  if (envValue) {
+    return envValue
+  }
+  return 'dev'
+}
+
+const resolveBaseConfiguration = (): { baseUrl: string; environment: ApiEnvironment } => {
+  const override = normaliseBaseUrl(takeFirstEnvValue(BASE_OVERRIDE_KEYS) ?? readFlagOverride())
+  if (override) {
+    return {
+      baseUrl: override,
+      environment: inferEnvironmentFromUrl(override) ?? resolveEnvironment()
+    }
+  }
+  const environment = resolveEnvironment()
+  return {
+    baseUrl: DEFAULT_BASE_URLS[environment],
+    environment
+  }
+}
+
+const ensureFetch = (fetchImpl?: typeof fetch): typeof fetch => {
+  if (fetchImpl) {
+    return fetchImpl
+  }
+  if (typeof fetch === 'function') {
+    return fetch.bind(globalThis)
+  }
+  throw new Error('Global fetch implementation is unavailable in this runtime.')
+}
+
+const parseResponseBody = async (response: Response): Promise<unknown> => {
+  if (response.status === 204 || response.status === 205) {
+    return null
+  }
+  const text = await response.text()
+  if (!text) {
+    return null
+  }
+  try {
+    return JSON.parse(text)
+  } catch (error) {
+    return text
+  }
+}
+
+export class ApiError extends Error {
+  readonly status: number
+
+  readonly response: Response
+
+  readonly body: unknown
+
+  constructor(response: Response, body: unknown) {
+    super(`Request failed with status ${response.status}`)
+    this.name = 'ApiError'
+    this.status = response.status
+    this.response = response
+    this.body = body
+  }
+}
+
+export class ApiClient {
+  private baseUrl: string
+
+  private readonly fetchImpl: typeof fetch
+
+  private readonly logger: Logger
+
+  private environment: ApiEnvironment
+
+  constructor(options?: ApiClientOptions) {
+    const configuration = resolveBaseConfiguration()
+    const providedBase = normaliseBaseUrl(options?.baseUrl)
+    this.baseUrl = providedBase ?? configuration.baseUrl
+    this.environment = inferEnvironmentFromUrl(this.baseUrl) ?? configuration.environment
+    this.fetchImpl = ensureFetch(options?.fetchImpl)
+    this.logger = options?.logger ?? console
+  }
+
+  getBaseUrl(): string {
+    return this.baseUrl
+  }
+
+  getEnvironment(): ApiEnvironment {
+    return this.environment
+  }
+
+  setBaseUrl(nextBaseUrl: string): void {
+    const normalised = normaliseBaseUrl(nextBaseUrl)
+    if (!normalised) {
+      this.logger.warn?.('Ignoring invalid API base override: %s', nextBaseUrl)
+      return
+    }
+    this.baseUrl = normalised
+    this.environment = inferEnvironmentFromUrl(normalised) ?? this.environment
+  }
+
+  private buildUrl(path: string, query?: ApiRequestOptions['query']): string {
+    const trimmedPath = path.startsWith('/') ? path : `/${path}`
+    const url = new URL(trimmedPath, this.baseUrl)
+    if (query) {
+      Object.entries(query).forEach(([key, value]) => {
+        if (value === undefined || value === null) {
+          return
+        }
+        url.searchParams.set(key, String(value))
+      })
+    }
+    return url.toString()
+  }
+
+  async request<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
+    const method = (options.method ?? 'GET').toUpperCase()
+    const url = this.buildUrl(path, options.query)
+    const headers = new Headers(options.headers ?? {})
+    if (!headers.has('Accept')) {
+      headers.set('Accept', 'application/json')
+    }
+
+    let body: BodyInit | undefined
+    if (options.body !== undefined && options.body !== null) {
+      if (
+        typeof options.body === 'string' ||
+        options.body instanceof ArrayBuffer ||
+        ArrayBuffer.isView(options.body) ||
+        options.body instanceof Blob ||
+        options.body instanceof FormData ||
+        options.body instanceof URLSearchParams
+      ) {
+        body = options.body as BodyInit
+      } else {
+        body = JSON.stringify(options.body)
+        if (!headers.has('Content-Type')) {
+          headers.set('Content-Type', 'application/json')
+        }
+      }
+    }
+
+    const requestInit: RequestInit = {
+      ...options,
+      method,
+      headers,
+      body
+    }
+
+    const response = await this.fetchImpl(url, requestInit)
+    const parsedBody = await parseResponseBody(response)
+    if (!response.ok) {
+      throw new ApiError(response, parsedBody)
+    }
+    return parsedBody as T
+  }
+
+  get<T>(path: string, options?: ApiRequestOptions): Promise<T> {
+    return this.request<T>(path, { ...options, method: 'GET' })
+  }
+
+  post<T>(path: string, body?: unknown, options?: ApiRequestOptions): Promise<T> {
+    return this.request<T>(path, { ...options, method: 'POST', body })
+  }
+}
+
+let defaultClient: ApiClient | null = null
+
+export const getDefaultApiClient = (): ApiClient => {
+  if (!defaultClient) {
+    defaultClient = new ApiClient()
+  }
+  return defaultClient
+}
+
+export const resolveApiBaseUrl = (): string => getDefaultApiClient().getBaseUrl()

--- a/desktop/src/main/deeplink.ts
+++ b/desktop/src/main/deeplink.ts
@@ -1,0 +1,145 @@
+import { app } from 'electron'
+import { accessStore } from '../lib/accessStore'
+import { ApiError, getDefaultApiClient, type Logger } from '../lib/apiClient'
+
+const DEEP_LINK_SCHEME = 'atropos'
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0
+
+const extractDeepLink = (argv: string[]): string | null => {
+  for (const token of argv) {
+    if (typeof token === 'string' && token.startsWith(`${DEEP_LINK_SCHEME}://`)) {
+      return token
+    }
+  }
+  return null
+}
+
+const sanitiseUrlForLog = (rawUrl: string): string => {
+  try {
+    const url = new URL(rawUrl)
+    url.searchParams.delete('token')
+    return url.toString()
+  } catch (error) {
+    return rawUrl
+  }
+}
+
+const extractDetail = (body: unknown): string | null => {
+  if (!body || typeof body !== 'object') {
+    return null
+  }
+  const detail = (body as { detail?: unknown }).detail
+  return isNonEmptyString(detail) ? detail : null
+}
+
+const handleAcceptTransfer = async (
+  rawUrl: string,
+  logger: Logger,
+  client = getDefaultApiClient()
+): Promise<void> => {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch (error) {
+    logger.warn?.('Received malformed deep link URL: %s', rawUrl)
+    return
+  }
+
+  const userId = url.searchParams.get('user_id')?.trim() ?? ''
+  const token = url.searchParams.get('token')?.trim() ?? ''
+
+  if (!userId || !token) {
+    logger.warn?.('Ignoring accept-transfer deep link missing required parameters: %s', sanitiseUrlForLog(rawUrl))
+    return
+  }
+
+  const identity = accessStore.getSnapshot().identity
+  const deviceHash = identity?.deviceHash?.trim() ?? ''
+
+  if (!deviceHash) {
+    logger.error?.('Cannot accept transfer because the local device hash is unavailable.')
+    return
+  }
+
+  try {
+    await client.post('/transfer/accept', {
+      user_id: userId,
+      token,
+      device_hash: deviceHash
+    })
+    logger.info?.('Accepted license transfer for user %s.', userId)
+    try {
+      await accessStore.refresh({ force: true })
+    } catch (error) {
+      logger.debug?.('Force refresh of subscription failed after transfer acceptance.', error)
+      await accessStore.refresh()
+    }
+  } catch (error) {
+    if (error instanceof ApiError) {
+      const detail = extractDetail(error.body)
+      logger.error?.(
+        'Transfer acceptance failed with status %d: %s',
+        error.status,
+        detail ?? 'Unexpected response from licensing service.'
+      )
+      return
+    }
+    logger.error?.('Unexpected error while accepting transfer.', error)
+  }
+}
+
+const handleDeepLink = async (url: string, logger: Logger): Promise<void> => {
+  if (!isNonEmptyString(url)) {
+    return
+  }
+
+  const sanitised = sanitiseUrlForLog(url)
+  logger.info?.('Processing deep link: %s', sanitised)
+
+  if (url.startsWith(`${DEEP_LINK_SCHEME}://accept-transfer`)) {
+    await handleAcceptTransfer(url, logger)
+    return
+  }
+
+  try {
+    const parsed = new URL(url)
+    const path = parsed.pathname.replace(/^\/+/, '')
+    if (parsed.host === 'accept-transfer' || path === 'accept-transfer') {
+      await handleAcceptTransfer(url, logger)
+      return
+    }
+  } catch (error) {
+    logger.warn?.('Unable to parse deep link URL: %s', sanitised)
+  }
+
+  logger.warn?.('Unhandled deep link: %s', sanitised)
+}
+
+export const registerDeepLinks = (logger: Logger = console): void => {
+  try {
+    if (process.platform === 'win32') {
+      app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME)
+    } else {
+      app.removeAsDefaultProtocolClient(DEEP_LINK_SCHEME)
+      app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME)
+    }
+  } catch (error) {
+    logger.warn?.('Failed to register deep link protocol handler.', error)
+  }
+
+  app.on('open-url', (event, url) => {
+    event.preventDefault()
+    void handleDeepLink(url, logger)
+  })
+
+  const initialLink = typeof process !== 'undefined' && Array.isArray(process.argv)
+    ? extractDeepLink(process.argv)
+    : null
+  if (initialLink) {
+    setImmediate(() => {
+      void handleDeepLink(initialLink, logger)
+    })
+  }
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { listAccountClips, resolveAccountClipsDirectory } from './clipLibrary'
+import { registerDeepLinks } from './deeplink'
 
 type NavigationCommand = 'back' | 'forward'
 
@@ -144,6 +145,8 @@ app.whenReady().then(() => {
   })
 
   createWindow()
+
+  registerDeepLinks()
 
   app.on('activate', function () {
     // On macOS it's common to re-create a window in the app when the


### PR DESCRIPTION
## Summary
- add a shared API client that resolves the licensing worker base URL with environment and flag overrides
- introduce a singleton access store that fetches subscription status, issues short-lived license tokens, and refreshes on expiry or 401 responses
- register the `atropos://accept-transfer` deep link in the main process to call the worker and refresh local state after acceptance

## Testing
- npm run typecheck *(fails: existing Electron/Vite config and typing issues unrelated to this change)*
- pytest *(fails: missing optional dependencies httpx and OpenCV in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbeafa4f2083238dff4129d3fddb23