### PR TITLE
Connect desktop licensing flow with worker-issued tokens

### DIFF
--- a/desktop/src/renderer/src/services/http.ts
+++ b/desktop/src/renderer/src/services/http.ts
@@ -1,7 +1,73 @@
+import { accessStore } from '../../../lib/accessStore'
 import { advanceApiBaseUrl } from '../config/backend'
 
 type ErrorBody = {
   detail?: string
+}
+
+export class LicenseTokenUnavailableError extends Error {}
+
+const DEVICE_HASH_HEADER = 'X-Atropos-Device-Hash'
+
+const cloneRequestInit = (init?: RequestInit): RequestInit => {
+  if (!init) {
+    return { headers: new Headers() }
+  }
+  const { headers, body, ...rest } = init
+  const clone: RequestInit = { ...rest }
+  clone.headers = new Headers(headers ?? {})
+  if (body !== undefined) {
+    clone.body = body as BodyInit | null
+  }
+  return clone
+}
+
+const requireIdentity = () => {
+  const snapshot = accessStore.getSnapshot()
+  const identity = snapshot.identity
+  if (!identity || !identity.deviceHash) {
+    throw new LicenseTokenUnavailableError('Licensing identity is not configured.')
+  }
+  return identity
+}
+
+const requireLicenseToken = async (): Promise<{ token: string; deviceHash: string }> => {
+  const identity = requireIdentity()
+  const token = await accessStore.ensureLicenseToken()
+  if (!token) {
+    throw new LicenseTokenUnavailableError('An active Atropos subscription is required to use the pipeline.')
+  }
+  return { token, deviceHash: identity.deviceHash }
+}
+
+export const authorizedFetch = async (url: string, init?: RequestInit): Promise<Response> => {
+  let response: Response | null = null
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const { token, deviceHash } = await requireLicenseToken()
+    const requestInit = cloneRequestInit(init)
+    const headers = requestInit.headers instanceof Headers ? requestInit.headers : new Headers(requestInit.headers)
+    headers.set('Authorization', `Bearer ${token}`)
+    headers.set(DEVICE_HASH_HEADER, deviceHash)
+    requestInit.headers = headers
+
+    response = await fetch(url, requestInit)
+    if (response.status !== 401) {
+      return response
+    }
+
+    if (attempt === 0) {
+      accessStore.reportUnauthorized()
+      continue
+    }
+
+    return response
+  }
+
+  if (response) {
+    return response
+  }
+
+  throw new Error('Unable to complete licensed request.')
 }
 
 export const requestWithFallback = async (
@@ -14,8 +80,11 @@ export const requestWithFallback = async (
     const url = buildUrl()
     lastUrl = url
     try {
-      return await fetch(url, init)
+      return await authorizedFetch(url, init)
     } catch (error) {
+      if (error instanceof LicenseTokenUnavailableError) {
+        throw error
+      }
       const fallback = advanceApiBaseUrl()
       if (fallback) {
         continue

--- a/server/README.md
+++ b/server/README.md
@@ -33,6 +33,8 @@ Key settings reside in `server/config.py`:
 - `DELETE_UPLOADED_CLIPS` – auto-delete rendered clips after successful uploads.
 - Legacy LLM options (`MAX_LLM_CHARS`, etc.) remain for backward compatibility and are deprecated.
 
+Licensing middleware reads the Worker public key from either the `WORKER_JWT_PUBLIC_KEY` environment variable (containing the Ed25519 JWK) or by fetching `https://api.atropos-video.com/license/public-key`. Override the host with `LICENSE_API_BASE_URL`, `ATROPOS_LICENSE_API_BASE_URL`, or `VITE_LICENSE_API_BASE_URL` when pointing to non-production workers.
+
 ## Running the FastAPI service
 
 ```bash
@@ -57,7 +59,8 @@ Multiple account support expects the structure `out/<account>/<project>`. Tokens
 ## Desktop integration
 
 - `server/app.py` exposes REST and websocket endpoints for job management.
-- Real-time progress updates stream over `ws://<host>/ws/jobs/<job_id>`.
+- Requests to `/api/jobs*` must include the Worker-signed JWT (`Authorization: Bearer <token>`) and the matching device hash header (`X-Atropos-Device-Hash`). The middleware rejects invalid signatures, expired tokens, or device mismatches.
+- Real-time progress updates stream over `ws://<host>/ws/jobs/<job_id>?token=<jwt>&device_hash=<hash>`.
 - Jobs can also be polled via `GET /api/jobs/<job_id>` for completion status.
 
 ## Extending services

--- a/server/middleware/worker_token.py
+++ b/server/middleware/worker_token.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
 import threading
 import time
+from dataclasses import dataclass
 from typing import Iterable
+from urllib.parse import urljoin, urlparse, urlunparse
 
+import requests
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
@@ -14,6 +19,106 @@ from starlette.status import HTTP_401_UNAUTHORIZED
 
 from common.security import JwtVerificationError, load_ed25519_public_key, verify_ed25519_jwt
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LICENSE_BASE_URLS = {
+    "dev": "https://dev.api.atropos-video.com",
+    "prod": "https://api.atropos-video.com",
+}
+
+_LICENSE_BASE_ENV_KEYS = (
+    "LICENSE_API_BASE_URL",
+    "ATROPOS_LICENSE_API_BASE_URL",
+    "VITE_LICENSE_API_BASE_URL",
+    "ATROPOS_API_BASE_URL",
+)
+
+_ENVIRONMENT_KEYS = (
+    "ATROPOS_ENV",
+    "ENVIRONMENT",
+    "NODE_ENV",
+    "RELEASE_CHANNEL",
+    "VITE_RELEASE_CHANNEL",
+    "SERVER_ENV",
+)
+
+_DEVICE_HEADER = "x-atropos-device-hash"
+
+
+def _normalise_base_url(value: str | None) -> str | None:
+    if not value:
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    if not candidate.lower().startswith(("http://", "https://")):
+        candidate = f"https://{candidate}"
+    try:
+        url = urlparse(candidate)
+    except ValueError:
+        return None
+    if not url.scheme or not url.netloc:
+        return None
+    path = url.path.rstrip("/")
+    return urlunparse((url.scheme, url.netloc, path, "", "", ""))
+
+
+def _parse_environment(value: str | None) -> str:
+    if not value:
+        return "dev"
+    token = value.strip().lower()
+    if token in {"prod", "production", "release", "stable", "live"}:
+        return "prod"
+    return "dev"
+
+
+def _resolve_license_base_url() -> str:
+    for key in _LICENSE_BASE_ENV_KEYS:
+        normalised = _normalise_base_url(os.getenv(key))
+        if normalised:
+            return normalised
+
+    env_candidate = None
+    for key in _ENVIRONMENT_KEYS:
+        value = os.getenv(key)
+        if value:
+            env_candidate = value
+            break
+
+    environment = _parse_environment(env_candidate)
+    return _DEFAULT_LICENSE_BASE_URLS.get(environment, _DEFAULT_LICENSE_BASE_URLS["dev"])
+
+
+def _fetch_public_key_from_worker(url: str) -> dict | None:
+    try:
+        response = requests.get(url, timeout=5)
+    except requests.RequestException as exc:  # pragma: no cover - network failure path
+        logger.warning("Failed to fetch worker public key: %s", exc)
+        return None
+
+    if response.status_code != 200:
+        logger.warning("Worker public key endpoint returned status %s", response.status_code)
+        return None
+
+    try:
+        body = response.json()
+    except ValueError:
+        logger.warning("Worker public key endpoint returned invalid JSON")
+        return None
+
+    if not isinstance(body, dict):
+        logger.warning("Worker public key response is not an object")
+        return None
+
+    return body
+
+
+@dataclass(slots=True)
+class _CachedKey:
+    public_key: Ed25519PublicKey
+    fetched_at: float
 
 
 class WorkerTokenMiddleware(BaseHTTPMiddleware):
@@ -25,29 +130,48 @@ class WorkerTokenMiddleware(BaseHTTPMiddleware):
         *,
         protected_paths: Iterable[str] | None = None,
         env_var: str = "WORKER_JWT_PUBLIC_KEY",
+        cache_ttl_seconds: int = 300,
     ) -> None:
         super().__init__(app)
         self._protected_paths = tuple(protected_paths or ("/api/jobs",))
         self._env_var = env_var
+        self._cache_ttl = max(60, cache_ttl_seconds)
         self._lock = threading.Lock()
-        self._public_key: Ed25519PublicKey | None = None
-        self._cached_raw: str | None = None
+        self._public_key: _CachedKey | None = None
 
-    def _load_public_key(self) -> Ed25519PublicKey | None:
+    async def _load_public_key(self) -> Ed25519PublicKey | None:
         raw = os.getenv(self._env_var, "").strip()
-        if not raw:
-            return None
+        if raw:
+            try:
+                return load_ed25519_public_key(raw)
+            except ValueError:
+                logger.warning("Invalid Ed25519 public key configured in %s", self._env_var)
 
         with self._lock:
-            if self._public_key is not None and raw == self._cached_raw:
-                return self._public_key
-            try:
-                public_key = load_ed25519_public_key(raw)
-            except ValueError:
-                return None
-            self._public_key = public_key
-            self._cached_raw = raw
-            return public_key
+            cached = self._public_key
+
+        now = time.time()
+        if cached and now - cached.fetched_at < self._cache_ttl:
+            return cached.public_key
+
+        base_url = _resolve_license_base_url()
+        public_key_url = urljoin(f"{base_url}/", "license/public-key")
+
+        loop = asyncio.get_running_loop()
+        payload = await loop.run_in_executor(None, _fetch_public_key_from_worker, public_key_url)
+        if not payload:
+            return cached.public_key if cached else None
+
+        try:
+            public_key = load_ed25519_public_key(payload)
+        except ValueError:
+            logger.warning("Worker public key payload is not a valid Ed25519 JWK")
+            return cached.public_key if cached else None
+
+        with self._lock:
+            self._public_key = _CachedKey(public_key=public_key, fetched_at=now)
+
+        return public_key
 
     @staticmethod
     def _extract_token(request: Request) -> str | None:
@@ -75,12 +199,21 @@ class WorkerTokenMiddleware(BaseHTTPMiddleware):
             return False
         return exp > time.time()
 
+    def _extract_device_hash(self, request: Request) -> str | None:
+        header_value = request.headers.get(_DEVICE_HEADER)
+        if header_value and header_value.strip():
+            return header_value.strip()
+        query_value = request.query_params.get("device_hash")
+        if query_value and query_value.strip():
+            return query_value.strip()
+        return None
+
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
         path = request.url.path
         if not self._is_protected(path) or request.method.upper() == "OPTIONS":
             return await call_next(request)
 
-        public_key = self._load_public_key()
+        public_key = await self._load_public_key()
         if public_key is None:
             return JSONResponse(
                 {"detail": "Worker token verification is not configured"},
@@ -108,7 +241,28 @@ class WorkerTokenMiddleware(BaseHTTPMiddleware):
                 status_code=HTTP_401_UNAUTHORIZED,
             )
 
+        claim_device_hash = segments.payload.get("device_hash")
+        if not isinstance(claim_device_hash, str) or not claim_device_hash:
+            return JSONResponse(
+                {"detail": "Worker token is missing device binding"},
+                status_code=HTTP_401_UNAUTHORIZED,
+            )
+
+        request_device_hash = self._extract_device_hash(request)
+        if request_device_hash is None:
+            return JSONResponse(
+                {"detail": "Device hash header is required"},
+                status_code=HTTP_401_UNAUTHORIZED,
+            )
+
+        if request_device_hash != claim_device_hash:
+            return JSONResponse(
+                {"detail": "Device hash does not match the active license"},
+                status_code=HTTP_401_UNAUTHORIZED,
+            )
+
         request.state.worker_claims = segments.payload
+        request.state.worker_device_hash = claim_device_hash
         return await call_next(request)
 
 

--- a/services/licensing/scripts/get-billing-subscription.sh
+++ b/services/licensing/scripts/get-billing-subscription.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+USER_ID=${USER_ID:-user_123}
+
+curl -sS -X GET "${BASE_URL}/billing/subscription" \
+  -H 'Accept: application/json' \
+  --get \
+  --data-urlencode "user_id=${USER_ID}"

--- a/services/licensing/scripts/get-health.sh
+++ b/services/licensing/scripts/get-health.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+
+curl -sS -X GET "${BASE_URL}/health" \
+  -H 'Accept: application/json'

--- a/services/licensing/scripts/get-license-public-key.sh
+++ b/services/licensing/scripts/get-license-public-key.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+
+curl -sS -X GET "${BASE_URL}/license/public-key" \
+  -H 'Accept: application/json'

--- a/services/licensing/scripts/get-license-validate.sh
+++ b/services/licensing/scripts/get-license-validate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+TOKEN=${TOKEN:-replace-with-license-token}
+
+curl -sS -X GET "${BASE_URL}/license/validate" \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer ${TOKEN}"

--- a/services/licensing/scripts/get-transfer-accept.sh
+++ b/services/licensing/scripts/get-transfer-accept.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+USER_ID=${USER_ID:-user_123}
+TOKEN=${TOKEN:-replace-with-transfer-token}
+
+curl -sS -X GET "${BASE_URL}/transfer/accept" \
+  -H 'Accept: text/html' \
+  --get \
+  --data-urlencode "user_id=${USER_ID}" \
+  --data-urlencode "token=${TOKEN}"

--- a/services/licensing/scripts/post-billing-checkout.sh
+++ b/services/licensing/scripts/post-billing-checkout.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+USER_ID=${USER_ID:-user_123}
+EMAIL=${EMAIL:-user@example.com}
+PRICE_ID=${PRICE_ID:-price_dev_monthly}
+SUCCESS_URL=${SUCCESS_URL:-https://app.atropos.dev/billing/success}
+CANCEL_URL=${CANCEL_URL:-https://app.atropos.dev/billing/cancel}
+
+curl -sS -X POST "${BASE_URL}/billing/checkout" \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d "{\
+    \"user_id\": \"${USER_ID}\",\
+    \"email\": \"${EMAIL}\",\
+    \"price_id\": \"${PRICE_ID}\",\
+    \"success_url\": \"${SUCCESS_URL}\",\
+    \"cancel_url\": \"${CANCEL_URL}\"\
+  }"

--- a/services/licensing/scripts/post-billing-portal.sh
+++ b/services/licensing/scripts/post-billing-portal.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+USER_ID=${USER_ID:-user_123}
+RETURN_URL=${RETURN_URL:-https://app.atropos.dev/settings}
+
+curl -sS -X POST "${BASE_URL}/billing/portal" \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d "{\
+    \"user_id\": \"${USER_ID}\",\
+    \"return_url\": \"${RETURN_URL}\"\
+  }"

--- a/services/licensing/scripts/post-billing-webhook.sh
+++ b/services/licensing/scripts/post-billing-webhook.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+SIGNATURE=${SIGNATURE:-t=0,v1=replace-with-test-signature}
+EVENT_PAYLOAD=${EVENT_PAYLOAD:-./fixtures/checkout.session.completed.json}
+
+if [[ ! -f "${EVENT_PAYLOAD}" ]]; then
+  echo "Event payload file '${EVENT_PAYLOAD}' not found." >&2
+  exit 1
+fi
+
+curl -sS -X POST "${BASE_URL}/billing/webhook" \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -H "Stripe-Signature: ${SIGNATURE}" \
+  --data @"${EVENT_PAYLOAD}"

--- a/services/licensing/scripts/post-license-issue.sh
+++ b/services/licensing/scripts/post-license-issue.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+USER_ID=${USER_ID:-user_123}
+DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
+
+curl -sS -X POST "${BASE_URL}/license/issue" \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d "{\
+    \"user_id\": \"${USER_ID}\",\
+    \"device_hash\": \"${DEVICE_HASH}\"\
+  }"

--- a/services/licensing/scripts/post-transfer-accept.sh
+++ b/services/licensing/scripts/post-transfer-accept.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+USER_ID=${USER_ID:-user_123}
+TOKEN=${TOKEN:-replace-with-transfer-token}
+DEVICE_HASH=${DEVICE_HASH:-new_device_hash_example}
+
+curl -sS -X POST "${BASE_URL}/transfer/accept" \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d "{\
+    \"user_id\": \"${USER_ID}\",\
+    \"token\": \"${TOKEN}\",\
+    \"device_hash\": \"${DEVICE_HASH}\"\
+  }"

--- a/services/licensing/scripts/post-transfer-initiate.sh
+++ b/services/licensing/scripts/post-transfer-initiate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+USER_ID=${USER_ID:-user_123}
+TOKEN=${TOKEN:-replace-with-paid-license-token}
+DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
+
+curl -sS -X POST "${BASE_URL}/transfer/initiate" \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-Atropos-Device-Hash: ${DEVICE_HASH}" \
+  -d "{\
+    \"user_id\": \"${USER_ID}\"\
+  }"

--- a/services/licensing/scripts/post-trial-claim.sh
+++ b/services/licensing/scripts/post-trial-claim.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+USER_ID=${USER_ID:-user_123}
+
+curl -sS -X POST "${BASE_URL}/trial/claim" \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d "{\
+    \"user_id\": \"${USER_ID}\"\
+  }"

--- a/services/licensing/scripts/post-trial-consume.sh
+++ b/services/licensing/scripts/post-trial-consume.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+USER_ID=${USER_ID:-user_123}
+DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
+TOKEN=${TOKEN:-replace-with-trial-token}
+
+curl -sS -X POST "${BASE_URL}/trial/consume" \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d "{\
+    \"user_id\": \"${USER_ID}\",\
+    \"device_hash\": \"${DEVICE_HASH}\",\
+    \"token\": \"${TOKEN}\"\
+  }"

--- a/services/licensing/scripts/post-trial-start.sh
+++ b/services/licensing/scripts/post-trial-start.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
+USER_ID=${USER_ID:-user_123}
+DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
+
+curl -sS -X POST "${BASE_URL}/trial/start" \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d "{\
+    \"user_id\": \"${USER_ID}\",\
+    \"device_hash\": \"${DEVICE_HASH}\"\
+  }"

--- a/services/licensing/src/billing.ts
+++ b/services/licensing/src/billing.ts
@@ -6,6 +6,8 @@ interface BillingResponseBody {
   current_period_end: number | null;
   cancel_at_period_end: boolean;
   trial: TrialState | null;
+  epoch: number;
+  updated_at: number | null;
 }
 
 const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
@@ -63,6 +65,8 @@ export const handleSubscriptionRequest = async (
     current_period_end: record.current_period_end ?? null,
     cancel_at_period_end: Boolean(record.cancel_at_period_end),
     trial: record.trial,
+    epoch: record.epoch ?? 0,
+    updated_at: typeof record.updated_at === "number" ? record.updated_at : null,
   };
 
   return jsonResponse(responseBody, { status: 200 });


### PR DESCRIPTION
## Summary
- refresh the desktop access store to track subscription epoch/updated_at and invalidate cached licenses when billing changes
- require Worker-issued JWTs for every pipeline HTTP/WebSocket call via the shared authorized fetch helper and update tests accordingly
- expose epoch metadata from the licensing Worker, document the desktop integration flow, and add per-endpoint curl scripts
- teach the Python middleware to cache the Worker public key and reject requests when the device hash or signature is invalid

## Testing
- pytest *(fails: missing optional dependencies `httpx` and `libGL.so.1` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf3b48bc08323889ee04b35cddf84