### PR TITLE
feat: adopt device hash identity for licensing

### DIFF
--- a/desktop/src/lib/deviceId.ts
+++ b/desktop/src/lib/deviceId.ts
@@ -1,0 +1,196 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import type { App } from 'electron'
+
+import { createHash, randomUUID } from 'node:crypto'
+import { dirname, join } from 'node:path'
+
+type FileSystem = typeof import('node:fs')
+
+declare const require: NodeRequire
+
+const CHANNEL_IDENTITY = 'atropos:device-identity'
+const ID_FILE_NAME = 'device-id'
+
+let cachedDeviceId: string | null = null
+let cachedDeviceHash: string | null = null
+
+const isElectronRuntime = (): boolean =>
+  typeof process !== 'undefined' && Boolean(process.versions?.electron)
+
+const isRendererProcess = (): boolean =>
+  isElectronRuntime() && process.type === 'renderer'
+
+const getRequire = (): NodeRequire | null => {
+  try {
+    if (typeof require === 'function') {
+      return require
+    }
+  } catch (error) {
+    // ignore
+  }
+  try {
+    const globalRequire = (globalThis as { require?: NodeRequire }).require
+    if (typeof globalRequire === 'function') {
+      return globalRequire
+    }
+  } catch (error) {
+    // ignore
+  }
+  return null
+}
+
+const loadElectronApp = (): App | null => {
+  if (!isElectronRuntime()) {
+    return null
+  }
+  const req = getRequire()
+  if (!req) {
+    return null
+  }
+  try {
+    const electron = req('electron') as typeof import('electron')
+    if (electron?.app) {
+      return electron.app
+    }
+    if ((electron as { remote?: { app?: App } }).remote?.app) {
+      return (electron as { remote?: { app?: App } }).remote?.app ?? null
+    }
+  } catch (error) {
+    return null
+  }
+  return null
+}
+
+const loadFs = (): FileSystem | null => {
+  const req = getRequire()
+  if (!req) {
+    return null
+  }
+  try {
+    return req('node:fs') as FileSystem
+  } catch (error) {
+    return null
+  }
+}
+
+const ensureDirectory = (fs: FileSystem, filePath: string): void => {
+  const directory = dirname(filePath)
+  try {
+    fs.mkdirSync(directory, { recursive: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== 'EEXIST') {
+      throw error
+    }
+  }
+}
+
+const readDeviceIdFromDisk = (fs: FileSystem, filePath: string): string | null => {
+  try {
+    const contents = fs.readFileSync(filePath, 'utf8')
+    const trimmed = contents.trim()
+    if (trimmed) {
+      return trimmed
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      throw error
+    }
+  }
+  return null
+}
+
+const writeDeviceIdToDisk = (fs: FileSystem, filePath: string, value: string): void => {
+  ensureDirectory(fs, filePath)
+  fs.writeFileSync(filePath, `${value}\n`, 'utf8')
+}
+
+const computeHash = (value: string): string => {
+  const hash = createHash('sha256')
+  hash.update(value)
+  return hash.digest('hex')
+}
+
+const resolveIdentityFromMainProcess = (): { deviceId: string; deviceHash: string } | null => {
+  const app = loadElectronApp()
+  const fs = loadFs()
+
+  if (!app || !fs) {
+    return null
+  }
+
+  const userDataPath = app.getPath('userData')
+  const filePath = join(userDataPath, ID_FILE_NAME)
+
+  let deviceId = readDeviceIdFromDisk(fs, filePath)
+  if (!deviceId) {
+    deviceId = randomUUID()
+    writeDeviceIdToDisk(fs, filePath, deviceId)
+  }
+
+  const deviceHash = computeHash(deviceId)
+  return { deviceId, deviceHash }
+}
+
+const resolveIdentityFromRendererProcess = (): { deviceId: string; deviceHash: string } | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const electronApi = (window as typeof window & {
+    electron?: {
+      ipcRenderer?: { sendSync: (channel: string, ...args: unknown[]) => unknown }
+    }
+  }).electron
+
+  const payload = electronApi?.ipcRenderer?.sendSync(CHANNEL_IDENTITY)
+  if (!payload || typeof payload !== 'object') {
+    return null
+  }
+
+  const { deviceId, deviceHash } = payload as {
+    deviceId?: unknown
+    deviceHash?: unknown
+  }
+
+  if (typeof deviceId === 'string' && typeof deviceHash === 'string') {
+    return { deviceId, deviceHash }
+  }
+
+  return null
+}
+
+const resolveIdentity = (): { deviceId: string; deviceHash: string } => {
+  if (cachedDeviceId && cachedDeviceHash) {
+    return { deviceId: cachedDeviceId, deviceHash: cachedDeviceHash }
+  }
+
+  let identity: { deviceId: string; deviceHash: string } | null = null
+
+  if (isRendererProcess()) {
+    identity = resolveIdentityFromRendererProcess()
+  } else {
+    identity = resolveIdentityFromMainProcess()
+  }
+
+  if (!identity) {
+    const fallbackId = cachedDeviceId ?? randomUUID()
+    const fallbackHash = computeHash(fallbackId)
+    cachedDeviceId = fallbackId
+    cachedDeviceHash = fallbackHash
+    return { deviceId: fallbackId, deviceHash: fallbackHash }
+  }
+
+  cachedDeviceId = identity.deviceId
+  cachedDeviceHash = identity.deviceHash
+  return identity
+}
+
+export const getDeviceId = (): string => {
+  return resolveIdentity().deviceId
+}
+
+export const getDeviceHash = (): string => {
+  return resolveIdentity().deviceHash
+}
+
+export const getDeviceIdentityChannel = (): string => CHANNEL_IDENTITY

--- a/desktop/src/main/deeplink.ts
+++ b/desktop/src/main/deeplink.ts
@@ -47,10 +47,10 @@ const handleAcceptTransfer = async (
     return
   }
 
-  const userId = url.searchParams.get('user_id')?.trim() ?? ''
+  const deviceHashFromLink = url.searchParams.get('device_hash')?.trim() ?? ''
   const token = url.searchParams.get('token')?.trim() ?? ''
 
-  if (!userId || !token) {
+  if (!deviceHashFromLink || !token) {
     logger.warn?.('Ignoring accept-transfer deep link missing required parameters: %s', sanitiseUrlForLog(rawUrl))
     return
   }
@@ -63,13 +63,17 @@ const handleAcceptTransfer = async (
     return
   }
 
+  if (deviceHashFromLink && deviceHashFromLink !== deviceHash) {
+    logger.warn?.('Received transfer link for a different device hash. Ignoring request.')
+    return
+  }
+
   try {
     await client.post('/transfer/accept', {
-      user_id: userId,
       token,
       device_hash: deviceHash
     })
-    logger.info?.('Accepted license transfer for user %s.', userId)
+    logger.info?.('Accepted license transfer for device %s.', deviceHash)
     try {
       await accessStore.refresh({ force: true })
     } catch (error) {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -4,6 +4,7 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { listAccountClips, resolveAccountClipsDirectory } from './clipLibrary'
 import { registerDeepLinks } from './deeplink'
+import { getDeviceHash, getDeviceId, getDeviceIdentityChannel } from '../lib/deviceId'
 
 type NavigationCommand = 'back' | 'forward'
 
@@ -117,6 +118,19 @@ app.whenReady().then(() => {
   ipcMain.on('ping', () => console.log('pong'))
   ipcMain.on('navigation:state', (_event, state: NavigationState) => {
     navigationState = state
+  })
+  ipcMain.on(getDeviceIdentityChannel(), (event) => {
+    try {
+      const deviceId = getDeviceId()
+      const deviceHash = getDeviceHash()
+      event.returnValue = { deviceId, deviceHash }
+    } catch (error) {
+      console.error('Failed to resolve device identity', error)
+      event.returnValue = {
+        deviceId: '',
+        deviceHash: ''
+      }
+    }
   })
   ipcMain.handle('clips:list', async (_event, accountId: string | null) => {
     try {

--- a/desktop/src/renderer/src/tests/pipelineapi.test.ts
+++ b/desktop/src/renderer/src/tests/pipelineapi.test.ts
@@ -9,7 +9,7 @@ const reportUnauthorizedMock = vi.fn<[], void>()
 vi.mock('../../../lib/accessStore', () => ({
   accessStore: {
     getSnapshot: () => ({
-      identity: { userId: 'user-123', deviceHash: 'device-abc' },
+      identity: { deviceHash: 'device-abc' },
       subscription: { status: 'entitled', entitled: true, currentPeriodEnd: null, cancelAtPeriodEnd: false, trial: null, fetchedAt: Date.now(), epoch: 1, updatedAt: Date.now() },
       license: null,
       status: 'entitled',

--- a/services/licensing/scripts/get-billing-subscription.sh
+++ b/services/licensing/scripts/get-billing-subscription.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
-USER_ID=${USER_ID:-user_123}
+DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
 
 curl -sS -X GET "${BASE_URL}/billing/subscription" \
   -H 'Accept: application/json' \
   --get \
-  --data-urlencode "user_id=${USER_ID}"
+  --data-urlencode "device_hash=${DEVICE_HASH}"

--- a/services/licensing/scripts/get-transfer-accept.sh
+++ b/services/licensing/scripts/get-transfer-accept.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
-USER_ID=${USER_ID:-user_123}
+DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
 TOKEN=${TOKEN:-replace-with-transfer-token}
 
 curl -sS -X GET "${BASE_URL}/transfer/accept" \
   -H 'Accept: text/html' \
   --get \
-  --data-urlencode "user_id=${USER_ID}" \
+  --data-urlencode "device_hash=${DEVICE_HASH}" \
   --data-urlencode "token=${TOKEN}"

--- a/services/licensing/scripts/post-billing-checkout.sh
+++ b/services/licensing/scripts/post-billing-checkout.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
-USER_ID=${USER_ID:-user_123}
+DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
 EMAIL=${EMAIL:-user@example.com}
 PRICE_ID=${PRICE_ID:-price_dev_monthly}
 SUCCESS_URL=${SUCCESS_URL:-https://app.atropos.dev/billing/success}
@@ -12,7 +12,7 @@ curl -sS -X POST "${BASE_URL}/billing/checkout" \
   -H 'Accept: application/json' \
   -H 'Content-Type: application/json' \
   -d "{\
-    \"user_id\": \"${USER_ID}\",\
+    \"device_hash\": \"${DEVICE_HASH}\",\
     \"email\": \"${EMAIL}\",\
     \"price_id\": \"${PRICE_ID}\",\
     \"success_url\": \"${SUCCESS_URL}\",\

--- a/services/licensing/scripts/post-billing-portal.sh
+++ b/services/licensing/scripts/post-billing-portal.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
-USER_ID=${USER_ID:-user_123}
+DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
 RETURN_URL=${RETURN_URL:-https://app.atropos.dev/settings}
 
 curl -sS -X POST "${BASE_URL}/billing/portal" \
   -H 'Accept: application/json' \
   -H 'Content-Type: application/json' \
   -d "{\
-    \"user_id\": \"${USER_ID}\",\
+    \"device_hash\": \"${DEVICE_HASH}\",\
     \"return_url\": \"${RETURN_URL}\"\
   }"

--- a/services/licensing/scripts/post-license-issue.sh
+++ b/services/licensing/scripts/post-license-issue.sh
@@ -2,13 +2,11 @@
 set -euo pipefail
 
 BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
-USER_ID=${USER_ID:-user_123}
 DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
 
 curl -sS -X POST "${BASE_URL}/license/issue" \
   -H 'Accept: application/json' \
   -H 'Content-Type: application/json' \
   -d "{\
-    \"user_id\": \"${USER_ID}\",\
     \"device_hash\": \"${DEVICE_HASH}\"\
   }"

--- a/services/licensing/scripts/post-transfer-accept.sh
+++ b/services/licensing/scripts/post-transfer-accept.sh
@@ -2,15 +2,13 @@
 set -euo pipefail
 
 BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
-USER_ID=${USER_ID:-user_123}
-TOKEN=${TOKEN:-replace-with-transfer-token}
 DEVICE_HASH=${DEVICE_HASH:-new_device_hash_example}
+TOKEN=${TOKEN:-replace-with-transfer-token}
 
 curl -sS -X POST "${BASE_URL}/transfer/accept" \
   -H 'Accept: application/json' \
   -H 'Content-Type: application/json' \
   -d "{\
-    \"user_id\": \"${USER_ID}\",\
-    \"token\": \"${TOKEN}\",\
-    \"device_hash\": \"${DEVICE_HASH}\"\
+    \"device_hash\": \"${DEVICE_HASH}\",\
+    \"token\": \"${TOKEN}\"\
   }"

--- a/services/licensing/scripts/post-transfer-initiate.sh
+++ b/services/licensing/scripts/post-transfer-initiate.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
-USER_ID=${USER_ID:-user_123}
 TOKEN=${TOKEN:-replace-with-paid-license-token}
 DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
 
@@ -11,6 +10,4 @@ curl -sS -X POST "${BASE_URL}/transfer/initiate" \
   -H 'Content-Type: application/json' \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "X-Atropos-Device-Hash: ${DEVICE_HASH}" \
-  -d "{\
-    \"user_id\": \"${USER_ID}\"\
-  }"
+  -d '{}'

--- a/services/licensing/scripts/post-trial-claim.sh
+++ b/services/licensing/scripts/post-trial-claim.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
-USER_ID=${USER_ID:-user_123}
+DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
 
 curl -sS -X POST "${BASE_URL}/trial/claim" \
   -H 'Accept: application/json' \
   -H 'Content-Type: application/json' \
   -d "{\
-    \"user_id\": \"${USER_ID}\"\
+    \"device_hash\": \"${DEVICE_HASH}\"\
   }"

--- a/services/licensing/scripts/post-trial-consume.sh
+++ b/services/licensing/scripts/post-trial-consume.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
-USER_ID=${USER_ID:-user_123}
 DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
 TOKEN=${TOKEN:-replace-with-trial-token}
 
@@ -10,7 +9,6 @@ curl -sS -X POST "${BASE_URL}/trial/consume" \
   -H 'Accept: application/json' \
   -H 'Content-Type: application/json' \
   -d "{\
-    \"user_id\": \"${USER_ID}\",\
     \"device_hash\": \"${DEVICE_HASH}\",\
     \"token\": \"${TOKEN}\"\
   }"

--- a/services/licensing/scripts/post-trial-start.sh
+++ b/services/licensing/scripts/post-trial-start.sh
@@ -2,13 +2,11 @@
 set -euo pipefail
 
 BASE_URL=${BASE_URL:-https://dev.api.atropos-video.com}
-USER_ID=${USER_ID:-user_123}
 DEVICE_HASH=${DEVICE_HASH:-device_hash_example}
 
 curl -sS -X POST "${BASE_URL}/trial/start" \
   -H 'Accept: application/json' \
   -H 'Content-Type: application/json' \
   -d "{\
-    \"user_id\": \"${USER_ID}\",\
     \"device_hash\": \"${DEVICE_HASH}\"\
   }"

--- a/services/licensing/src/billing/types.ts
+++ b/services/licensing/src/billing/types.ts
@@ -6,6 +6,7 @@ export interface BillingEnv {
 }
 
 export interface CheckoutRequestBody {
+  device_hash?: unknown;
   user_id?: unknown;
   email?: unknown;
   price_id?: unknown;
@@ -19,6 +20,7 @@ export interface CheckoutResponseBody {
 }
 
 export interface PortalRequestBody {
+  device_hash?: unknown;
   user_id?: unknown;
   return_url?: unknown;
 }

--- a/services/licensing/src/lib/identity.ts
+++ b/services/licensing/src/lib/identity.ts
@@ -1,0 +1,67 @@
+import type { KVNamespace, UserRecord } from "../kv";
+import {
+  getDeviceRecord,
+  linkLegacyUserId,
+  resolveRecordByLegacyUserId,
+} from "../kv";
+
+const toNonEmptyString = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export interface IdentityResolutionInput {
+  deviceHash?: unknown;
+  legacyUserId?: unknown;
+}
+
+export interface IdentityResolutionResult {
+  deviceHash: string | null;
+  legacyUserId: string | null;
+  record: UserRecord | null;
+  mappedFromLegacy: boolean;
+}
+
+export const resolveIdentity = async (
+  kv: KVNamespace,
+  input: IdentityResolutionInput,
+): Promise<IdentityResolutionResult> => {
+  const requestedDeviceHash = toNonEmptyString(input.deviceHash);
+  const legacyUserId = toNonEmptyString(input.legacyUserId);
+
+  if (requestedDeviceHash) {
+    const record = await getDeviceRecord(kv, requestedDeviceHash);
+    if (legacyUserId && requestedDeviceHash) {
+      await linkLegacyUserId(kv, legacyUserId, requestedDeviceHash);
+    }
+    return {
+      deviceHash: requestedDeviceHash,
+      legacyUserId,
+      record,
+      mappedFromLegacy: false,
+    };
+  }
+
+  if (legacyUserId) {
+    const { deviceHash, record } = await resolveRecordByLegacyUserId(kv, legacyUserId);
+    if (deviceHash) {
+      await linkLegacyUserId(kv, legacyUserId, deviceHash);
+    }
+    return {
+      deviceHash: deviceHash ?? null,
+      legacyUserId,
+      record,
+      mappedFromLegacy: Boolean(deviceHash),
+    };
+  }
+
+  return {
+    deviceHash: null,
+    legacyUserId: null,
+    record: null,
+    mappedFromLegacy: false,
+  };
+};

--- a/services/licensing/src/transfer/accept.ts
+++ b/services/licensing/src/transfer/accept.ts
@@ -16,15 +16,15 @@ export const handleTransferAcceptView = (
   env: TransferAcceptEnv,
 ): Response => {
   const url = new URL(request.url);
-  const userId = url.searchParams.get("user_id")?.trim();
+  const deviceHash = url.searchParams.get("device_hash")?.trim();
   const token = url.searchParams.get("token")?.trim();
 
-  if (!userId || !token) {
+  if (!deviceHash || !token) {
     return htmlResponse("<h1>Missing transfer parameters</h1>", 400);
   }
 
   const scheme = resolveDeepLinkScheme(env);
-  const deepLink = `${scheme}://accept-transfer?user_id=${encodeURIComponent(userId)}&token=${encodeURIComponent(token)}`;
+  const deepLink = `${scheme}://accept-transfer?device_hash=${encodeURIComponent(deviceHash)}&token=${encodeURIComponent(token)}`;
   const downloadUrl = resolveDownloadUrl(env);
 
   const escapeHtml = (value: string): string =>

--- a/services/licensing/src/trial/consume.ts
+++ b/services/licensing/src/trial/consume.ts
@@ -1,5 +1,6 @@
 import { isEntitled, KVNamespace } from "../kv";
-import { mutateUserRecord } from "../kv/user";
+import { mutateDeviceRecord } from "../kv/user";
+import { resolveIdentity } from "../lib/identity";
 import { decodeTrialToken, TrialTokenPayload } from "./token";
 
 interface TrialConsumeRequestBody {
@@ -37,19 +38,22 @@ export const handleTrialConsumeRequest = async (
     );
   }
 
-  const userId = typeof body.user_id === "string" ? body.user_id.trim() : "";
-  const deviceHash = typeof body.device_hash === "string" ? body.device_hash.trim() : "";
   const token = typeof body.token === "string" ? body.token.trim() : "";
-
-  if (!userId || !deviceHash || !token) {
-    return jsonResponse(
-      { error: "invalid_request", detail: "user_id, device_hash, and token are required" },
-      { status: 400 },
-    );
-  }
 
   if (!env.LICENSING_KV) {
     return jsonResponse({ error: "kv_unavailable" }, { status: 500 });
+  }
+
+  const identity = await resolveIdentity(env.LICENSING_KV, {
+    deviceHash: body.device_hash,
+    legacyUserId: body.user_id,
+  });
+
+  if (!identity.deviceHash || !token) {
+    return jsonResponse(
+      { error: "invalid_request", detail: "device_hash and token are required" },
+      { status: 400 },
+    );
   }
 
   let payload: TrialTokenPayload;
@@ -67,56 +71,61 @@ export const handleTrialConsumeRequest = async (
 
   let errorResponse: Response | null = null;
 
-  const record = await mutateUserRecord(env.LICENSING_KV, userId, ({ current, now }) => {
-    if (isEntitled(current.status, current.current_period_end)) {
-      errorResponse = jsonResponse({ error: "already_entitled" }, { status: 409 });
-      return null;
-    }
+  const record = await mutateDeviceRecord(
+    env.LICENSING_KV,
+    identity.deviceHash,
+    ({ current, now }) => {
+      if (isEntitled(current.status, current.current_period_end)) {
+        errorResponse = jsonResponse({ error: "already_entitled" }, { status: 409 });
+        return null;
+      }
 
-    const trial = current.trial;
-    if (!trial) {
-      errorResponse = jsonResponse({ error: "trial_not_started" }, { status: 400 });
-      return null;
-    }
+      const trial = current.trial;
+      if (!trial) {
+        errorResponse = jsonResponse({ error: "trial_not_started" }, { status: 400 });
+        return null;
+      }
 
-    if (trial.device_hash && trial.device_hash !== deviceHash) {
-      errorResponse = jsonResponse({ error: "device_conflict" }, { status: 409 });
-      return null;
-    }
+      if (trial.device_hash && trial.device_hash !== identity.deviceHash) {
+        errorResponse = jsonResponse({ error: "device_conflict" }, { status: 409 });
+        return null;
+      }
 
-    if (!trial.jti || trial.jti !== payload.jti) {
-      errorResponse = jsonResponse({ error: "invalid_token" }, { status: 400 });
-      return null;
-    }
+      if (!trial.jti || trial.jti !== payload.jti) {
+        errorResponse = jsonResponse({ error: "invalid_token" }, { status: 400 });
+        return null;
+      }
 
-    if (!trial.exp || trial.exp !== payload.exp) {
-      errorResponse = jsonResponse({ error: "invalid_token" }, { status: 400 });
-      return null;
-    }
+      if (!trial.exp || trial.exp !== payload.exp) {
+        errorResponse = jsonResponse({ error: "invalid_token" }, { status: 400 });
+        return null;
+      }
 
-    if (trial.exp <= now) {
-      errorResponse = jsonResponse({ error: "token_expired" }, { status: 400 });
-      return null;
-    }
+      if (trial.exp <= now) {
+        errorResponse = jsonResponse({ error: "token_expired" }, { status: 400 });
+        return null;
+      }
 
-    if (trial.remaining <= 0) {
-      errorResponse = jsonResponse({ error: "trial_exhausted" }, { status: 403 });
-      return null;
-    }
+      if (trial.remaining <= 0) {
+        errorResponse = jsonResponse({ error: "trial_exhausted" }, { status: 403 });
+        return null;
+      }
 
-    const remaining = Math.max(0, trial.remaining - 1);
+      const remaining = Math.max(0, trial.remaining - 1);
 
-    return {
-      trial: {
-        ...trial,
-        device_hash: trial.device_hash ?? deviceHash,
-        remaining,
-        used_at: now,
-        jti: null,
-        exp: null,
-      },
-    };
-  });
+      return {
+        trial: {
+          ...trial,
+          device_hash: trial.device_hash ?? identity.deviceHash,
+          remaining,
+          used_at: now,
+          jti: null,
+          exp: null,
+        },
+      };
+    },
+    { legacyUserId: identity.legacyUserId ?? undefined },
+  );
 
   if (errorResponse) {
     return errorResponse;


### PR DESCRIPTION
## Summary
- generate and persist per-device UUIDs in the desktop app, expose hashed identity, and auto-select licensing base URLs
- migrate licensing worker storage and routes to treat device hashes as the canonical principal while preserving legacy user_id compatibility
- refresh docs and helper scripts for the new device-hash API shape and add a /health endpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc43c1e17c8323820423542792a03e