### PR TITLE
feat: improve pipeline progress tracking

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -11,7 +11,9 @@ import Library from './pages/Library'
 import Profile from './pages/Profile'
 import Settings, { type SettingsHeaderAction } from './pages/Settings'
 import { createInitialPipelineSteps } from './data/pipeline'
+import { BACKEND_MODE } from './config/backend'
 import useNavigationHistory from './hooks/useNavigationHistory'
+import usePipelineProgress from './state/usePipelineProgress'
 import { useTrialAccess } from './state/trialAccess'
 import type {
   AccountSummary,
@@ -103,7 +105,7 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
   const [settingsHeaderAction, setSettingsHeaderAction] = useState<SettingsHeaderAction | null>(null)
   const location = useLocation()
   const navigate = useNavigate()
-  const { state: trialState } = useTrialAccess()
+  const { state: trialState, consumeTrialRun } = useTrialAccess()
   const homeNavigationDisabled = !trialState.isTrialActive
 
   const preventDisabledNavigation = useCallback((event: MouseEvent<HTMLAnchorElement>) => {
@@ -129,6 +131,17 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
       ),
     [accounts]
   )
+
+  const isMockBackend = BACKEND_MODE === 'mock'
+
+  const { startPipeline, resumePipeline } = usePipelineProgress({
+    state: homeState,
+    setState: setHomeState,
+    availableAccounts,
+    consumeTrialRun,
+    isTrialActive: trialState.isTrialActive,
+    isMockBackend
+  })
 
   useEffect(() => {
     if (typeof document === 'undefined') {
@@ -569,6 +582,8 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
                 initialState={homeState}
                 onStateChange={setHomeState}
                 accounts={accounts}
+                onStartPipeline={startPipeline}
+                onResumePipeline={resumePipeline}
               />
             }
           />
@@ -622,6 +637,8 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
                 initialState={homeState}
                 onStateChange={setHomeState}
                 accounts={accounts}
+                onStartPipeline={startPipeline}
+                onResumePipeline={resumePipeline}
               />
             }
           />

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -15,6 +15,11 @@ import { BACKEND_MODE } from './config/backend'
 import useNavigationHistory from './hooks/useNavigationHistory'
 import usePipelineProgress from './state/usePipelineProgress'
 import { useTrialAccess } from './state/trialAccess'
+import {
+  clamp01,
+  summarisePipelineProgress,
+  type PipelineOverallStatus
+} from './lib/pipelineProgress'
 import type {
   AccountSummary,
   AuthPingSummary,
@@ -44,36 +49,98 @@ const THEME_STORAGE_KEY = 'atropos:theme'
 const sortAccounts = (items: AccountSummary[]): AccountSummary[] =>
   [...items].sort((a, b) => a.displayName.localeCompare(b.displayName))
 
+type NavItemBadgeVariant = 'accent' | 'info' | 'success' | 'error'
+
+type NavItemBadge = {
+  label: string
+  variant?: NavItemBadgeVariant
+}
+
+type NavItemProgress = {
+  fraction: number
+  status: PipelineOverallStatus
+  srLabel?: string
+}
+
 type NavItemLabelProps = {
   label: string
   isActive: boolean
-  badge?: string | null
+  badge?: NavItemBadge | null
+  progress?: NavItemProgress | null
 }
 
-const NavItemLabel: FC<NavItemLabelProps> = ({ label, isActive, badge }) => (
-  <span className="relative flex h-full items-center justify-center">
-    {badge ? (
-      <span
-        aria-hidden
-        className="pointer-events-none absolute -top-3 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full border border-[color:var(--edge-soft)] bg-[color:color-mix(in_srgb,var(--accent)_80%,transparent)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--accent-contrast)] shadow-[0_10px_18px_rgba(43,42,40,0.18)]"
-      >
-        {badge}
+const badgeVariantClasses: Record<NavItemBadgeVariant, string> = {
+  accent:
+    'border-[color:var(--edge-soft)] bg-[color:color-mix(in_srgb,var(--accent)_80%,transparent)] text-[color:var(--accent-contrast)]',
+  info:
+    'border-[color:color-mix(in_srgb,var(--info-strong)_55%,var(--edge-soft))] bg-[color:color-mix(in_srgb,var(--info-soft)_78%,transparent)] text-[color:color-mix(in_srgb,var(--info-strong)_88%,var(--accent-contrast))]',
+  success:
+    'border-[color:color-mix(in_srgb,var(--success-strong)_55%,var(--edge-soft))] bg-[color:color-mix(in_srgb,var(--success-soft)_80%,transparent)] text-[color:color-mix(in_srgb,var(--success-strong)_90%,var(--accent-contrast))]',
+  error:
+    'border-[color:color-mix(in_srgb,var(--error-strong)_55%,var(--edge-soft))] bg-[color:color-mix(in_srgb,var(--error-soft)_78%,transparent)] text-[color:color-mix(in_srgb,var(--error-strong)_90%,var(--accent-contrast))]'
+}
+
+const progressStatusClasses: Record<PipelineOverallStatus, string> = {
+  idle: 'bg-[color:var(--edge-soft)]',
+  active: 'bg-[color:var(--info-strong)]',
+  completed: 'bg-[color:var(--success-strong)]',
+  failed: 'bg-[color:var(--error-strong)]'
+}
+
+const NavItemLabel: FC<NavItemLabelProps> = ({ label, isActive, badge, progress }) => {
+  const resolvedBadge = badge ? { label: badge.label, variant: badge.variant ?? 'accent' } : null
+  const srProgressLabel = progress?.srLabel
+    ?? (progress
+        ? progress.status === 'completed'
+          ? `${label} pipeline complete`
+          : progress.status === 'failed'
+            ? `${label} pipeline failed`
+            : `${label} pipeline progress ${Math.round(clamp01(progress.fraction) * 100)}%`
+        : null)
+  const showProgress = progress && progress.status !== 'idle'
+  const percent = showProgress ? Math.round(clamp01(progress.fraction) * 100) : 0
+  const progressClass = progress ? progressStatusClasses[progress.status] : progressStatusClasses.idle
+
+  return (
+    <span className="relative flex h-full min-w-[72px] flex-col items-center justify-center px-2 text-center">
+      {resolvedBadge ? (
+        <span
+          aria-hidden
+          className={`pointer-events-none absolute -top-3 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] shadow-[0_10px_18px_rgba(43,42,40,0.18)] ${
+            badgeVariantClasses[resolvedBadge.variant]
+          }`}
+        >
+          {resolvedBadge.label}
+        </span>
+      ) : null}
+      <span className="leading-none">
+        {label}
+        {resolvedBadge ? <span className="sr-only"> ({resolvedBadge.label})</span> : null}
       </span>
-    ) : null}
-    <span className="leading-none">
-      {label}
-      {badge ? <span className="sr-only"> ({badge})</span> : null}
+      {srProgressLabel ? <span className="sr-only">{srProgressLabel}</span> : null}
+      {showProgress ? (
+        <span
+          aria-hidden
+          className="pointer-events-none mt-1 flex h-1 w-12 items-center overflow-hidden rounded-full bg-[color:var(--edge-soft)]"
+        >
+          <span
+            className={`block h-full ${progressClass} transition-all duration-300 ease-out`}
+            style={{ width: `${percent}%` }}
+          />
+        </span>
+      ) : (
+        <span
+          aria-hidden
+          className={`pointer-events-none mt-1 block h-0.5 w-8 rounded-full transition ${
+            isActive
+              ? 'bg-[color:var(--accent)] opacity-100'
+              : 'bg-[color:var(--edge-soft)] opacity-0 group-hover:opacity-60'
+          }`}
+        />
+      )}
     </span>
-    <span
-      aria-hidden
-      className={`pointer-events-none absolute left-1/2 bottom-1 h-0.5 w-8 -translate-x-1/2 rounded-full transition ${
-        isActive
-          ? 'bg-[color:var(--accent)] opacity-100'
-          : 'bg-[color:var(--edge-soft)] opacity-0 group-hover:opacity-60'
-      }`}
-    />
-  </span>
-)
+  )
+}
 
 type AppProps = {
   searchInputRef: RefObject<HTMLInputElement | null>
@@ -133,6 +200,43 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
   )
 
   const isMockBackend = BACKEND_MODE === 'mock'
+
+  const homeProgressSummary = useMemo(
+    () => summarisePipelineProgress(homeState.steps),
+    [homeState.steps]
+  )
+
+  const homeNavProgress = useMemo(() => {
+    if (homeProgressSummary.status === 'idle') {
+      return null
+    }
+    const fraction = homeProgressSummary.status === 'completed' ? 1 : clamp01(homeProgressSummary.fraction)
+    const percent = Math.round(fraction * 100)
+    const srLabel =
+      homeProgressSummary.status === 'completed'
+        ? 'Pipeline run complete'
+        : homeProgressSummary.status === 'failed'
+          ? `Pipeline run failed at ${percent}%`
+          : `Pipeline progress ${percent}%`
+    return {
+      fraction,
+      status: homeProgressSummary.status,
+      srLabel
+    }
+  }, [homeProgressSummary])
+
+  const homeNavBadge = useMemo(() => {
+    if (homeProgressSummary.status === 'completed') {
+      return { label: 'Done', variant: 'success' } satisfies NavItemBadge
+    }
+    if (homeProgressSummary.status === 'failed') {
+      return { label: 'Failed', variant: 'error' } satisfies NavItemBadge
+    }
+    if (homeState.awaitingReview) {
+      return { label: 'Needs review', variant: 'info' } satisfies NavItemBadge
+    }
+    return null
+  }, [homeProgressSummary.status, homeState.awaitingReview])
 
   const { startPipeline, resumePipeline } = usePipelineProgress({
     state: homeState,
@@ -494,7 +598,14 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
                   tabIndex={homeNavigationDisabled ? -1 : undefined}
                   onClick={homeNavigationDisabled ? preventDisabledNavigation : undefined}
                 >
-                  {({ isActive }) => <NavItemLabel label="Home" isActive={isActive} />}
+                  {({ isActive }) => (
+                    <NavItemLabel
+                      label="Home"
+                      isActive={isActive}
+                      badge={homeNavBadge}
+                      progress={homeNavProgress}
+                    />
+                  )}
                 </NavLink>
                 <NavLink
                   to="/library"
@@ -504,7 +615,11 @@ const App: FC<AppProps> = ({ searchInputRef }) => {
                     <NavItemLabel
                       label="Library"
                       isActive={isActive}
-                      badge={isClipEditRoute ? 'Edit mode' : null}
+                      badge={
+                        isClipEditRoute
+                          ? ({ label: 'Edit mode', variant: 'info' } satisfies NavItemBadge)
+                          : null
+                      }
                     />
                   )}
                 </NavLink>

--- a/desktop/src/renderer/src/lib/pipelineProgress.ts
+++ b/desktop/src/renderer/src/lib/pipelineProgress.ts
@@ -1,0 +1,124 @@
+import type { PipelineStep } from '../types'
+
+export type PipelineOverallStatus = 'idle' | 'active' | 'completed' | 'failed'
+
+export type PipelineProgressSummary = {
+  fraction: number
+  status: PipelineOverallStatus
+  hasSteps: boolean
+}
+
+export const clamp01 = (value: number): number => Math.min(1, Math.max(0, value))
+
+const computeClipStageAggregate = (step: PipelineStep): number => {
+  const totalClips = step.substeps.reduce(
+    (max, substep) => Math.max(max, substep.totalClips),
+    step.clipProgress?.total ?? 0
+  )
+  const substepCount = step.substeps.length
+
+  if (totalClips === 0 || substepCount === 0) {
+    if (step.clipProgress && step.clipProgress.total === 0) {
+      return 1
+    }
+    return clamp01(step.progress)
+  }
+
+  const totalUnits = totalClips * substepCount
+  let completedUnits = 0
+  let inFlightUnits = 0
+
+  step.substeps.forEach((substep) => {
+    const boundedCompleted = Math.min(totalClips, Math.max(0, substep.completedClips))
+    completedUnits += boundedCompleted
+    if (substep.status === 'running' && boundedCompleted < totalClips) {
+      inFlightUnits += clamp01(substep.progress)
+    } else if (substep.status === 'failed') {
+      inFlightUnits += clamp01(substep.progress)
+    }
+  })
+
+  if (totalUnits <= 0) {
+    return clamp01(step.progress)
+  }
+
+  return clamp01((completedUnits + inFlightUnits) / totalUnits)
+}
+
+export const computeStepProgressValue = (step: PipelineStep): number => {
+  if (step.status === 'completed' || step.status === 'failed') {
+    return 1
+  }
+
+  if (step.status === 'pending') {
+    return 0
+  }
+
+  if (step.id === 'produce-clips') {
+    return computeClipStageAggregate(step)
+  }
+
+  if (step.clipStage && step.clipProgress) {
+    const total = Math.max(0, step.clipProgress.total)
+    if (total > 0) {
+      const completed = Math.min(total, Math.max(0, step.clipProgress.completed)) / total
+      const inFlight = clamp01(step.progress) / total
+      return clamp01(completed + inFlight)
+    }
+  }
+
+  return clamp01(step.progress)
+}
+
+export const summarisePipelineProgress = (steps: PipelineStep[]): PipelineProgressSummary => {
+  if (!Array.isArray(steps) || steps.length === 0) {
+    return { fraction: 0, status: 'idle', hasSteps: false }
+  }
+
+  const stepDurations = steps.map((step) => Math.max(1, step.durationMs))
+  const totalDuration = stepDurations.reduce((sum, duration) => sum + duration, 0)
+
+  if (totalDuration <= 0) {
+    return { fraction: 0, status: 'idle', hasSteps: true }
+  }
+
+  const weights = stepDurations.map((duration) => duration / totalDuration)
+
+  let aggregate = 0
+  let hasActive = false
+  let hasFailure = false
+  let completed = 0
+
+  steps.forEach((step, index) => {
+    const weight = weights[index] ?? 0
+    aggregate += weight * computeStepProgressValue(step)
+
+    if (step.status === 'failed') {
+      hasFailure = true
+    }
+    if (step.status === 'completed') {
+      completed += 1
+    }
+    if (step.status === 'running') {
+      hasActive = true
+    } else if (step.status === 'pending' && step.progress > 0) {
+      hasActive = true
+    }
+  })
+
+  const fraction = clamp01(aggregate)
+
+  if (hasFailure) {
+    return { fraction, status: 'failed', hasSteps: true }
+  }
+
+  if (completed === steps.length) {
+    return { fraction: fraction > 0 ? fraction : 1, status: 'completed', hasSteps: true }
+  }
+
+  if (hasActive || fraction > 0) {
+    return { fraction, status: 'active', hasSteps: true }
+  }
+
+  return { fraction, status: 'idle', hasSteps: true }
+}

--- a/desktop/src/renderer/src/state/usePipelineProgress.ts
+++ b/desktop/src/renderer/src/state/usePipelineProgress.ts
@@ -1,0 +1,590 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+import { buildJobClipVideoUrl } from '../config/backend'
+import {
+  createInitialPipelineSteps,
+  PIPELINE_STEP_DEFINITIONS,
+  resolvePipelineLocation
+} from '../data/pipeline'
+import {
+  normaliseJobClip,
+  resumePipelineJob,
+  startPipelineJob,
+  subscribeToPipelineEvents,
+  type PipelineEventMessage
+} from '../services/pipelineApi'
+import type { AccountSummary, HomePipelineState } from '../types'
+
+type UsePipelineProgressOptions = {
+  state: HomePipelineState
+  setState: React.Dispatch<React.SetStateAction<HomePipelineState>>
+  availableAccounts: AccountSummary[]
+  consumeTrialRun: () => Promise<void>
+  isTrialActive: boolean
+  isMockBackend: boolean
+}
+
+type UsePipelineProgressResult = {
+  startPipeline: (url: string, accountId: string, reviewMode: boolean) => Promise<void>
+  resumePipeline: () => Promise<void>
+  cleanup: () => void
+}
+
+const clamp01 = (value: number): number => Math.min(1, Math.max(0, value))
+
+export const usePipelineProgress = ({
+  state,
+  setState,
+  availableAccounts,
+  consumeTrialRun,
+  isTrialActive,
+  isMockBackend
+}: UsePipelineProgressOptions): UsePipelineProgressResult => {
+  const connectionCleanupRef = useRef<(() => void) | null>(null)
+  const subscribedJobIdRef = useRef<string | null>(null)
+  const activeJobIdRef = useRef<string | null>(state.activeJobId ?? null)
+
+  useEffect(() => {
+    activeJobIdRef.current = state.activeJobId ?? null
+  }, [state.activeJobId])
+
+  const updateState = useCallback(
+    (updater: (prev: HomePipelineState) => HomePipelineState) => {
+      setState((prev) => {
+        const next = updater(prev)
+        return next
+      })
+    },
+    [setState]
+  )
+
+  const cleanupConnection = useCallback(() => {
+    const cleanup = connectionCleanupRef.current
+    if (cleanup) {
+      cleanup()
+      connectionCleanupRef.current = null
+      subscribedJobIdRef.current = null
+    }
+  }, [])
+
+  const handlePipelineEvent = useCallback(
+    (event: PipelineEventMessage) => {
+      if (event.type === 'pipeline_started') {
+        updateState((prev) => ({
+          ...prev,
+          steps: createInitialPipelineSteps(),
+          pipelineError: null,
+          isProcessing: true
+        }))
+        return
+      }
+
+      if (event.type === 'step_progress') {
+        const location = resolvePipelineLocation(event.step)
+        if (!location || typeof event.data?.progress !== 'number') {
+          return
+        }
+        const progressValue = clamp01(event.data.progress)
+        const completedValue =
+          typeof event.data.completed === 'number' ? Math.max(0, event.data.completed) : null
+        const totalValue = typeof event.data.total === 'number' ? Math.max(0, event.data.total) : null
+        const rawEta =
+          typeof event.data.eta_seconds === 'number'
+            ? event.data.eta_seconds
+            : typeof event.data.eta === 'number'
+              ? event.data.eta
+              : null
+        const etaValue = rawEta !== null && Number.isFinite(rawEta) && rawEta >= 0 ? rawEta : null
+
+        updateState((prev) => ({
+          ...prev,
+          steps: prev.steps.map((step) => {
+            if (location.kind === 'step') {
+              if (step.id !== location.stepId) {
+                return step
+              }
+
+              const nextClipProgress = step.clipStage
+                ? {
+                    completed:
+                      completedValue !== null
+                        ? completedValue
+                        : step.clipProgress?.completed ?? 0,
+                    total: totalValue !== null ? totalValue : step.clipProgress?.total ?? 0
+                  }
+                : step.clipProgress
+
+              if (step.status === 'completed') {
+                return { ...step, clipProgress: nextClipProgress, etaSeconds: null }
+              }
+
+              return {
+                ...step,
+                status: 'running',
+                progress: progressValue,
+                clipProgress: nextClipProgress,
+                etaSeconds: etaValue
+              }
+            }
+
+            if (step.id !== location.stepId) {
+              return step
+            }
+
+            return {
+              ...step,
+              status: step.status === 'pending' ? 'running' : step.status,
+              substeps: step.substeps.map((substep) => {
+                if (substep.id !== location.substepId) {
+                  return substep
+                }
+
+                const totalClips = totalValue !== null ? totalValue : substep.totalClips
+                const boundedTotal = Math.max(0, totalClips)
+
+                if (location.clipIndex !== null) {
+                  const clipPosition =
+                    boundedTotal > 0
+                      ? Math.min(boundedTotal, Math.max(1, location.clipIndex))
+                      : Math.max(1, location.clipIndex)
+                  const previousCompleted = substep.completedClips
+                  const rawCompleted =
+                    completedValue !== null ? Math.max(0, completedValue) : previousCompleted
+                  let boundedCompleted =
+                    boundedTotal > 0 ? Math.min(boundedTotal, rawCompleted) : rawCompleted
+                  if (progressValue >= 1) {
+                    boundedCompleted = Math.max(boundedCompleted, clipPosition)
+                  }
+                  const allDone =
+                    (boundedTotal === 0 && totalValue !== null) ||
+                    (boundedTotal > 0 && boundedCompleted >= boundedTotal)
+
+                  return {
+                    ...substep,
+                    status: allDone ? 'completed' : 'running',
+                    progress: progressValue,
+                    etaSeconds: etaValue,
+                    completedClips: boundedCompleted,
+                    totalClips: boundedTotal,
+                    activeClipIndex: allDone ? null : clipPosition
+                  }
+                }
+
+                const previousCompleted = substep.completedClips
+                const rawCompleted =
+                  completedValue !== null ? Math.max(0, completedValue) : previousCompleted
+                const boundedCompleted =
+                  boundedTotal > 0 ? Math.min(boundedTotal, rawCompleted) : rawCompleted
+                const progressed = boundedCompleted > previousCompleted
+                const allDone =
+                  (boundedTotal === 0 && totalValue !== null) ||
+                  (boundedTotal > 0 && boundedCompleted >= boundedTotal)
+
+                const nextStatus = allDone
+                  ? 'completed'
+                  : substep.status === 'pending' && !progressed && previousCompleted === 0
+                    ? substep.status
+                    : 'running'
+
+                const nextProgress = allDone ? 1 : progressed ? 0 : substep.progress
+
+                const nextActiveClipIndex = allDone
+                  ? null
+                  : totalValue !== null && boundedTotal > 0
+                    ? Math.min(boundedTotal, boundedCompleted + 1)
+                    : substep.activeClipIndex
+
+                return {
+                  ...substep,
+                  status: nextStatus,
+                  progress: nextProgress,
+                  etaSeconds: etaValue,
+                  completedClips: boundedCompleted,
+                  totalClips: boundedTotal,
+                  activeClipIndex: nextActiveClipIndex
+                }
+              })
+            }
+          })
+        }))
+        return
+      }
+
+      if (
+        event.type === 'step_started' ||
+        event.type === 'step_completed' ||
+        event.type === 'step_failed'
+      ) {
+        const location = resolvePipelineLocation(event.step)
+        if (!location) {
+          return
+        }
+        const targetIndex = PIPELINE_STEP_DEFINITIONS.findIndex(
+          (definition) => definition.id === location.stepId
+        )
+        if (targetIndex === -1) {
+          return
+        }
+
+        updateState((prev) => ({
+          ...prev,
+          steps: prev.steps.map((step, index) => {
+            const shouldForceCompleted = index < targetIndex && step.status !== 'completed'
+
+            if (location.kind === 'step') {
+              if (shouldForceCompleted) {
+                return { ...step, status: 'completed', progress: 1, etaSeconds: null }
+              }
+              if (step.id === location.stepId) {
+                if (event.type === 'step_started') {
+                  return { ...step, status: 'running', progress: 0, etaSeconds: null }
+                }
+                if (event.type === 'step_completed') {
+                  return { ...step, status: 'completed', progress: 1, etaSeconds: null }
+                }
+                return { ...step, status: 'failed', progress: 1, etaSeconds: null }
+              }
+              return step
+            }
+
+            if (shouldForceCompleted) {
+              return { ...step, status: 'completed', progress: 1, etaSeconds: null }
+            }
+
+            if (step.id !== location.stepId) {
+              return step
+            }
+
+            const clipPosition =
+              location.kind === 'substep' && location.clipIndex !== null
+                ? Math.max(1, location.clipIndex)
+                : null
+
+            const updatedSubsteps = step.substeps.map((substep) => {
+              if (substep.id === location.substepId) {
+                if (event.type === 'step_started') {
+                  const nextActiveClip =
+                    clipPosition ?? substep.activeClipIndex ?? Math.max(1, substep.completedClips + 1)
+                  return {
+                    ...substep,
+                    status: 'running',
+                    progress: 0,
+                    etaSeconds: null,
+                    activeClipIndex: nextActiveClip
+                  }
+                }
+                if (event.type === 'step_completed') {
+                  const targetClipIndex = clipPosition ?? location.clipIndex
+                  const boundedTotal = Math.max(0, substep.totalClips)
+                  const rawCompleted =
+                    targetClipIndex !== null
+                      ? Math.max(substep.completedClips, targetClipIndex)
+                      : substep.completedClips
+                  const completedClips =
+                    boundedTotal > 0 ? Math.min(boundedTotal, rawCompleted) : rawCompleted
+                  const allDone = boundedTotal > 0 && completedClips >= boundedTotal
+                  return {
+                    ...substep,
+                    status: allDone ? 'completed' : 'running',
+                    progress: 1,
+                    etaSeconds: null,
+                    completedClips,
+                    activeClipIndex: allDone ? null : clipPosition ?? substep.activeClipIndex
+                  }
+                }
+                return {
+                  ...substep,
+                  status: 'failed',
+                  etaSeconds: null,
+                  progress: 1,
+                  activeClipIndex: clipPosition ?? substep.activeClipIndex
+                }
+              }
+
+              if (event.type === 'step_started' && clipPosition !== null) {
+                const boundedTotal = Math.max(0, substep.totalClips)
+                const completedClips = Math.max(0, substep.completedClips)
+                const allDone = boundedTotal > 0 && completedClips >= boundedTotal
+                if (!allDone && completedClips < clipPosition) {
+                  const nextActiveClip =
+                    boundedTotal > 0 ? Math.min(boundedTotal, clipPosition) : clipPosition
+                  return {
+                    ...substep,
+                    status: 'pending',
+                    progress: 0,
+                    etaSeconds: null,
+                    activeClipIndex: nextActiveClip
+                  }
+                }
+              }
+
+              return substep
+            })
+
+            const allCompleted =
+              updatedSubsteps.length > 0 &&
+              updatedSubsteps.every((substep) => substep.status === 'completed')
+
+            if (event.type === 'step_failed') {
+              return {
+                ...step,
+                status: 'failed',
+                progress: 1,
+                etaSeconds: null,
+                substeps: updatedSubsteps
+              }
+            }
+
+            if (event.type === 'step_completed' && allCompleted) {
+              return {
+                ...step,
+                status: 'completed',
+                progress: 1,
+                etaSeconds: null,
+                substeps: updatedSubsteps
+              }
+            }
+
+            if (event.type === 'step_started' && step.status === 'pending') {
+              return {
+                ...step,
+                status: 'running',
+                substeps: updatedSubsteps
+              }
+            }
+
+            return { ...step, substeps: updatedSubsteps }
+          })
+        }))
+
+        if (event.type === 'step_failed') {
+          updateState((prev) => ({
+            ...prev,
+            pipelineError: event.message ?? 'Pipeline step failed.'
+          }))
+        }
+        return
+      }
+
+      if (event.type === 'log') {
+        const statusValue =
+          event.data && typeof event.data === 'object'
+            ? (event.data as Record<string, unknown>).status
+            : null
+        if (statusValue === 'waiting_for_review') {
+          updateState((prev) => ({ ...prev, awaitingReview: true }))
+        }
+        return
+      }
+
+      if (event.type === 'clip_ready') {
+        const jobId = activeJobIdRef.current
+        const data = event.data ?? {}
+        if (!jobId || typeof data !== 'object') {
+          return
+        }
+
+        const payload = data as Record<string, unknown>
+        const clipId = typeof payload.clip_id === 'string' ? payload.clip_id : null
+        const description = typeof payload.description === 'string' ? payload.description : null
+        const durationValue = typeof payload.duration_seconds === 'number' ? payload.duration_seconds : null
+        const createdAt = typeof payload.created_at === 'string' ? payload.created_at : null
+        const sourceUrl = typeof payload.source_url === 'string' ? payload.source_url : null
+        const sourceTitle = typeof payload.source_title === 'string' ? payload.source_title : null
+
+        if (!clipId || !description || !createdAt || durationValue === null || !sourceUrl || !sourceTitle) {
+          return
+        }
+
+        const playbackUrl = buildJobClipVideoUrl(jobId, clipId)
+        const manifestPayload: Record<string, unknown> = {
+          ...payload,
+          id: clipId,
+          playback_url: playbackUrl,
+          description,
+          duration_seconds: durationValue,
+          created_at: createdAt,
+          source_url: sourceUrl,
+          source_title: sourceTitle
+        }
+
+        const incomingClip = normaliseJobClip(manifestPayload)
+        if (!incomingClip) {
+          return
+        }
+
+        updateState((prev) => {
+          const existingIndex = prev.clips.findIndex((clip) => clip.id === incomingClip.id)
+          const mergedClips =
+            existingIndex === -1
+              ? [...prev.clips, incomingClip]
+              : prev.clips.map((clip, index) => (index === existingIndex ? incomingClip : clip))
+
+          mergedClips.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+
+          const hasSelection = mergedClips.some((clip) => clip.id === prev.selectedClipId)
+          return {
+            ...prev,
+            clips: mergedClips,
+            selectedClipId: hasSelection ? prev.selectedClipId : mergedClips[0]?.id ?? null
+          }
+        })
+
+        return
+      }
+
+      if (event.type === 'pipeline_completed') {
+        const successValue = event.data?.success
+        const success = typeof successValue === 'boolean' ? successValue : true
+        const errorValue = event.data?.error
+        const errorMessage =
+          typeof errorValue === 'string'
+            ? errorValue
+            : typeof event.message === 'string'
+              ? event.message
+              : null
+
+        updateState((prev) => ({
+          ...prev,
+          pipelineError: success ? null : errorMessage ?? 'Pipeline failed.',
+          isProcessing: false,
+          awaitingReview: false,
+          steps: prev.steps.map((step) => {
+            if (success) {
+              if (step.status === 'completed' || step.status === 'failed') {
+                return { ...step, etaSeconds: null }
+              }
+              return { ...step, status: 'completed', progress: 1, etaSeconds: null }
+            }
+            if (step.status === 'completed' || step.status === 'failed') {
+              return { ...step, etaSeconds: null }
+            }
+            return { ...step, status: 'failed', progress: 1, etaSeconds: null }
+          })
+        }))
+        cleanupConnection()
+      }
+    },
+    [cleanupConnection, updateState]
+  )
+
+  const subscribeToJob = useCallback(
+    (jobId: string) => {
+      if (!jobId || isMockBackend) {
+        return
+      }
+
+      if (subscribedJobIdRef.current === jobId && connectionCleanupRef.current) {
+        return
+      }
+
+      cleanupConnection()
+      let unsubscribe: (() => void) | null = null
+      const cleanup = () => {
+        if (unsubscribe) {
+          unsubscribe()
+          unsubscribe = null
+        }
+      }
+
+      connectionCleanupRef.current = cleanup
+      subscribedJobIdRef.current = jobId
+
+      unsubscribe = subscribeToPipelineEvents(jobId, {
+        onEvent: handlePipelineEvent,
+        onError: (error) => {
+          updateState((prev) => ({
+            ...prev,
+            pipelineError: error.message,
+            isProcessing: false
+          }))
+          cleanupConnection()
+        },
+        onClose: () => {
+          if (connectionCleanupRef.current === cleanup) {
+            connectionCleanupRef.current = null
+            subscribedJobIdRef.current = null
+          }
+        }
+      })
+    },
+    [cleanupConnection, handlePipelineEvent, isMockBackend, updateState]
+  )
+
+  useEffect(() => {
+    if (!state.activeJobId || isMockBackend) {
+      return undefined
+    }
+
+    subscribeToJob(state.activeJobId)
+
+    return () => {
+      cleanupConnection()
+    }
+  }, [cleanupConnection, isMockBackend, state.activeJobId, subscribeToJob])
+
+  const startPipeline = useCallback(
+    async (url: string, accountId: string, reviewMode: boolean) => {
+      if (isMockBackend) {
+        return
+      }
+
+      updateState((prev) => ({
+        ...prev,
+        isProcessing: true,
+        pipelineError: null,
+        awaitingReview: false
+      }))
+
+      cleanupConnection()
+
+      try {
+        const toneOverride = availableAccounts.find((account) => account.id === accountId)?.tone ?? null
+        const { jobId } = await startPipelineJob({
+          url,
+          account: accountId,
+          tone: toneOverride,
+          reviewMode
+        })
+        activeJobIdRef.current = jobId
+        updateState((prev) => ({ ...prev, activeJobId: jobId, awaitingReview: false }))
+        subscribeToJob(jobId)
+        if (isTrialActive) {
+          await consumeTrialRun()
+        }
+      } catch (error) {
+        updateState((prev) => ({
+          ...prev,
+          pipelineError: error instanceof Error ? error.message : 'Unable to start the pipeline.',
+          isProcessing: false
+        }))
+      }
+    },
+    [availableAccounts, cleanupConnection, consumeTrialRun, isMockBackend, isTrialActive, subscribeToJob, updateState]
+  )
+
+  const resumePipeline = useCallback(async () => {
+    const jobId = activeJobIdRef.current
+    if (!jobId || isMockBackend) {
+      return
+    }
+    try {
+      await resumePipelineJob(jobId)
+      updateState((prev) => ({ ...prev, awaitingReview: false }))
+    } catch (error) {
+      updateState((prev) => ({
+        ...prev,
+        pipelineError:
+          error instanceof Error ? error.message : 'Unable to resume the pipeline. Try again shortly.'
+      }))
+    }
+  }, [isMockBackend, updateState])
+
+  return {
+    startPipeline,
+    resumePipeline,
+    cleanup: cleanupConnection
+  }
+}
+
+export default usePipelineProgress

--- a/desktop/src/renderer/src/tests/home.test.tsx
+++ b/desktop/src/renderer/src/tests/home.test.tsx
@@ -103,7 +103,7 @@ const createInitialState = (overrides: Partial<HomePipelineState> = {}): HomePip
 const renderHome = (props: ComponentProps<typeof Home>) =>
   render(
     <MemoryRouter>
-      <Home {...props} />
+      <Home onStartPipeline={vi.fn()} onResumePipeline={vi.fn()} {...props} />
     </MemoryRouter>
   )
 
@@ -145,7 +145,9 @@ describe('Home account selection', () => {
     const baseProps = {
       registerSearch: () => {},
       onStateChange: () => {},
-      accounts: [AVAILABLE_ACCOUNT]
+      accounts: [AVAILABLE_ACCOUNT],
+      onStartPipeline: vi.fn(),
+      onResumePipeline: vi.fn()
     }
     const { rerender } = render(
       <MemoryRouter>
@@ -217,7 +219,9 @@ describe('Home pipeline events', () => {
     const baseProps = {
       registerSearch: () => {},
       onStateChange: () => {},
-      accounts: [AVAILABLE_ACCOUNT]
+      accounts: [AVAILABLE_ACCOUNT],
+      onStartPipeline: vi.fn(),
+      onResumePipeline: vi.fn()
     }
     const { rerender } = render(
       <MemoryRouter>
@@ -301,7 +305,9 @@ describe('Home pipeline events', () => {
     const baseProps = {
       registerSearch: () => {},
       onStateChange: () => {},
-      accounts: [AVAILABLE_ACCOUNT]
+      accounts: [AVAILABLE_ACCOUNT],
+      onStartPipeline: vi.fn(),
+      onResumePipeline: vi.fn()
     }
     const { rerender } = render(
       <MemoryRouter>

--- a/server/common/thread_pool.py
+++ b/server/common/thread_pool.py
@@ -14,6 +14,7 @@ def process_with_thread_pool(
     max_workers: int,
     timeout: int | float | None,
     on_error: Callable[[int, T, Exception], R],
+    on_progress: Callable[[int, int], None] | None = None,
 ) -> List[R]:
     """Process ``chunks`` in parallel with a thread pool.
 
@@ -35,6 +36,7 @@ def process_with_thread_pool(
     ex = ThreadPoolExecutor(max_workers=max_workers)
     futures = [ex.submit(func, i + 1, ch) for i, ch in enumerate(chunks)]
     try:
+        total = len(chunks)
         for i, fut in enumerate(futures, 1):
             try:
                 if timeout in (0, None):
@@ -46,6 +48,8 @@ def process_with_thread_pool(
             except Exception as e:  # pragma: no cover - passthrough to handler
                 res = on_error(i, chunks[i - 1], e)
             results.append(res)
+            if on_progress:
+                on_progress(i, total)
     except KeyboardInterrupt:  # pragma: no cover - user requested termination
         for f in futures:
             f.cancel()

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -694,13 +694,14 @@ def process_video(
                 f"{Fore.YELLOW}Skipping STEP 5: loaded segments from {segments_path}{Style.RESET_ALL}",
                 level="warning",
             )
+            refinement_progress(1.0, message="Transcript structure already available")
         else:
             segments = []
             emit_log(
                 f"{Fore.YELLOW}Skipping STEP 5: no existing segments at {segments_path}{Style.RESET_ALL}",
                 level="warning",
             )
-        refinement_progress(1.0, message="Transcript structure skipped")
+            refinement_progress(1.0, message="Transcript structure skipped")
     emit_log(f"[Pipeline] Loaded {len(segments)} segments")
 
     # ----------------------


### PR DESCRIPTION
## Summary
- add a reusable pipeline progress manager so websocket updates persist outside the Home page
- update the Home page and tests to rely on the shared manager for starting and resuming jobs
- stream step 5 detection/refinement progress with weighted ranges and expose progress callbacks in the backend

## Testing
- pytest *(fails: missing httpx and libGL dependencies in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5900633e0832391124405ce63ec91