### PR TITLE
fix: defer Home state change notifications

### DIFF
--- a/desktop/src/renderer/src/pages/Home.tsx
+++ b/desktop/src/renderer/src/pages/Home.tsx
@@ -60,17 +60,29 @@ const Home: FC<HomeProps> = ({
     setState(initialState)
   }, [initialState])
 
+  const pendingStateRef = useRef<HomePipelineState | null>(null)
+
   const updateState = useCallback(
     (updater: (prev: HomePipelineState) => HomePipelineState) =>
       setState((prev) => {
         const next = updater(prev)
         if (next !== prev) {
-          onStateChange(next)
+          pendingStateRef.current = next
         }
         return next
       }),
-    [onStateChange]
+    []
   )
+
+  useEffect(() => {
+    if (pendingStateRef.current === null) {
+      return
+    }
+    if (pendingStateRef.current === state) {
+      onStateChange(state)
+    }
+    pendingStateRef.current = null
+  }, [onStateChange, state])
 
   const {
     videoUrl,


### PR DESCRIPTION
## Summary
- defer Home onStateChange propagation until after render to avoid parent updates during render
- track pending state updates and flush them from an effect to preserve existing behaviour

## Testing
- `pytest` *(fails: missing httpx dependency and libGL shared library)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b59628e48323a23480c474165055